### PR TITLE
fix(sandbox): stop treating ls /root as sensitive while keeping rm -rf /root blocked

### DIFF
--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -46,7 +46,6 @@ _SENSITIVE_PREFIXES: tuple[str, ...] = (
     "/sys",
     "/proc",
     "/dev",
-    "/root",
     "/var/log",
     "/lib/systemd",
     "/usr/lib/systemd",

--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -427,6 +427,12 @@ def sensitive_target_in_command(
     for _kind, target in _extract_intents(command, base_dir=effective_workspace):
         if _is_root_target(target):
             return _ROOT_TARGET_MARKER
+        # /root is not a credential path on its own, but a recursive delete of
+        # the home directory is destructive — catch it on the destructive path
+        # only (sensitive_path_in_text for reads still correctly allows ls /root).
+        target = _expand_env_vars(str(target))
+        if target.rstrip("/") == "/root":
+            return "/root"
         marker = sensitive_path_marker(target, workspace=effective_workspace)
         if marker is not None:
             return marker

--- a/tests/test_sandbox/test_sensitive_paths.py
+++ b/tests/test_sandbox/test_sensitive_paths.py
@@ -130,14 +130,23 @@ def test_every_rm_in_a_compound_command_is_checked() -> None:
 def test_sensitive_reads_in_a_later_segment_are_blocked_at_the_tool_boundary() -> None:
     """Issue #676: the delete-intent scan only sees ``rm`` targets, so a
     non-destructive second segment (``cat /root/.bash_history``) is caught by
-    the text scan ``exec_command`` runs alongside it, not by this one."""
+    the text scan ``exec_command`` runs alongside it, not by this one.
+
+    Unlike the env-var test (test_ordinary_text_with_a_dollar_sign_is_untouched),
+    ls /root is a benign read and is not a sensitive path.  rm -rf /root IS
+    caught as a destructive target (even though /root is not a credential
+    prefix on its own).
+    """
     workspace = Path("/workspace")
 
     assert sensitive_target_in_command("rm /tmp/ok; ls /root", workspace=workspace) is None
-    assert sensitive_path_in_text("rm /tmp/ok; ls /root", workspace=workspace) == "/root"
+    # ls /root is benign — not a credential path; rm -rf /root IS blocked as
+    # a destructive target even though /root is not in _SENSITIVE_PREFIXES.
+    assert sensitive_target_in_command("rm /tmp/ok; rm -rf /root", workspace=workspace) == "/root"
+    assert sensitive_path_in_text("rm /tmp/ok; ls /root", workspace=workspace) is None
     assert (
         sensitive_path_in_text("rm /tmp/ok; cat /root/.bash_history", workspace=workspace)
-        == "/root"
+        == "/.bash_history"
     )
 
 


### PR DESCRIPTION
Fixes #1374

## Summary

`sensitive_path_in_text("ls $HOME")` and `sensitive_path_in_text("ls /root")` return `/root`, false-positiving the sensitive-path hard block so a benign `ls $HOME` is refused at the shell-tool boundary. The existing test `test_sensitive_paths_env_vars.py::test_ordinary_text_with_a_dollar_sign_is_untouched` (asserts `ls $HOME` is `None`) fails on this. Root cause: `_SENSITIVE_PREFIXES` contains the bare `"/root"` entry, so `is_sensitive_path("/root")` matches itself; the real home-dir credential paths (`~/.ssh`, `~/.aws`, ...) are already covered via the expanded `~` candidates, so `/root` only adds false positives on benign reads.

## What
- src/agentos/sandbox/sensitive_paths.py — remove `"/root"` from `_SENSITIVE_PREFIXES`; add an explicit destructive-only catch in `sensitive_target_in_command` for `/root` (and its `$HOME` expansion) so `rm -rf /root` / `rm -rf $HOME` stay hard-blocked.
- tests/test_sandbox/test_sensitive_paths.py — update `test_sensitive_reads_in_a_later_segment_are_blocked_at_the_tool_boundary` to assert `ls /root` is `None` (read) and `rm -rf /root` is `/root` (destructive), reconciling it with the newer env-vars test.

## Verification
- `uv run pytest tests/test_sandbox/test_sensitive_paths.py tests/test_sandbox/test_sensitive_paths_env_vars.py -q` — 46 passed
- `uv run pytest tests/test_sandbox/ -q` — 85 passed, 2 skipped
- `uv run ruff check src/agentos/sandbox/sensitive_paths.py tests/test_sandbox/test_sensitive_paths.py` — clean
- `uv run mypy src/agentos/sandbox/sensitive_paths.py --show-error-codes` — no issues
