### PR TITLE
fix(router): match C++/C#/.NET port targets regardless of word boundary

### DIFF
--- a/src/agentos/agentos_router/task_type.py
+++ b/src/agentos/agentos_router/task_type.py
@@ -123,11 +123,28 @@ _TRANSLATE_RES: tuple[tuple[str, re.Pattern[str]], ...] = tuple(
 #: is the only guard — it exists because the task is different, not because the
 #: translation is judged hard. Suppression is the safe direction: it forfeits a
 #: saving and hands the turn back to ordinary model routing.
+#: C++, C#, and .NET cannot share the plain-word \b(?:...)\b group above:
+#: \b requires a transition between a \w and a non-\w character on the exact
+#: side being anchored. "C++" ends on "+" (non-word), so the trailing \b in
+#: "...to C++." never fires (the following "." is also non-word — no
+#: transition). Same shape for "C#" ending on "#". ".NET" starts on "."
+#: (non-word), so the *leading* \b fails whenever a normal sentence precedes
+#: it with whitespace (space -> "." is non-word on both sides) — it only
+#: ever matched by accident when glued onto a word, e.g. "asp.net" ("p" ->
+#: "." is a real transition). These three get their own boundary shape
+#: instead: (?!\w) after the C++/C# tail only requires the *next* character
+#: not be a word character (satisfied by end-of-string, space, or
+#: punctuation alike, unlike \b). ".NET" drops the leading \b entirely
+#: (a "." has no meaningful word-transition to require) and keeps only the
+#: trailing \b, which preserves today's "asp.net" match instead of breaking
+#: it (#1198).
 _CODE_TARGET_RE = re.compile(
     r"\b(?:python|javascript|typescript|golang|rust|java|kotlin|swift|scala"
     r"|haskell|ruby|php|perl|sql|bash|powershell|matlab|fortran|cobol"
-    r"|c\+\+|c#|\.net|react|vue|svelte|jquery|regex|assembly|solidity"
-    r"|dart|elixir|erlang|clojure|lua|zig)\b",
+    r"|react|vue|svelte|jquery|regex|assembly|solidity"
+    r"|dart|elixir|erlang|clojure|lua|zig)\b"
+    r"|\b(?:c\+\+|c#)(?!\w)"
+    r"|\.net\b",
     re.IGNORECASE,
 )
 

--- a/tests/test_agentos_router/test_task_type.py
+++ b/tests/test_agentos_router/test_task_type.py
@@ -122,6 +122,70 @@ class TestProgrammingLanguageTarget:
         assert verdict.task_type == TASK_TYPE_TRANSLATE
 
 
+class TestSymbolPortTargets:
+    """C++, C#, and .NET end/start on a non-word character, so the plain
+    \\b(?:...)\\b group that blocks python/rust/etc. never fires for them in
+    ordinary prose (#1198) — a C++/C#/.NET port request was silently
+    misrouted to the cheapest model tier instead of being recognized as
+    code work. These three get their own boundary shape in _CODE_TARGET_RE;
+    this class is the regression suite for that shape specifically.
+    """
+
+    @pytest.mark.parametrize(
+        ("message", "target"),
+        [
+            ("Translate this function to C++.", "C++"),
+            ("Translate this code to C#.", "C#"),
+            ("Translate this service to .NET.", ".NET"),
+            # Case-insensitivity and a mid-sentence (not sentence-final)
+            # mention must both still trigger the guard.
+            ("Please translate this to c++ for the embedded team.", "c++"),
+            ("We need this ported to c# next sprint, then translate the docs.", "c#"),
+            ("Translate the API surface to .net so it matches the rest.", ".net"),
+        ],
+    )
+    def test_symbol_targets_block_the_translate_verdict(self, message: str, target: str) -> None:
+        verdict = detect_task_type(message)
+        assert verdict.task_type is None, f"{target!r} in {message!r} should have blocked"
+        assert verdict.blocked_by == BLOCK_CODE_TARGET
+
+    def test_plain_word_target_still_blocks_for_contrast(self) -> None:
+        """Rust already worked before this fix; it must keep working after."""
+        verdict = detect_task_type("Translate this function to Rust.")
+        assert verdict.task_type is None
+        assert verdict.blocked_by == BLOCK_CODE_TARGET
+
+    def test_natural_language_target_is_not_blocked(self) -> None:
+        """The case the suppression exists to protect: an ordinary human
+        language target must still translate, unaffected by the C++/C#/.NET
+        boundary change."""
+        verdict = detect_task_type("Translate this to Spanish.")
+        assert verdict.task_type == TASK_TYPE_TRANSLATE
+        assert verdict.blocked_by is None
+
+    def test_bare_letter_c_does_not_falsely_block(self) -> None:
+        """'c' alone (no '++' or '#') must not be mistaken for C++/C#."""
+        verdict = detect_task_type("Translate this sentence to c, please.")
+        assert verdict.task_type == TASK_TYPE_TRANSLATE
+        assert verdict.blocked_by is None
+
+    def test_hash_symbol_followed_by_a_word_does_not_match_c_sharp(self) -> None:
+        """(?!\\w) after 'c#' must reject a 'c#' glued onto more word chars,
+        the same way \\b already rejects it for the plain-word targets."""
+        verdict = detect_task_type("Translate this to c#sharpener, a made-up tool name.")
+        assert verdict.task_type == TASK_TYPE_TRANSLATE
+        assert verdict.blocked_by is None
+
+    def test_dotnet_inside_a_compound_token_keeps_prior_behavior(self) -> None:
+        """.NET drops its leading \\b (a '.' has no meaningful word-transition
+        to require), which means it keeps matching inside a token like
+        'asp.net' exactly as it already did before this fix — this pins
+        that as an intentional non-change, not a new regression."""
+        verdict = detect_task_type("Translate this asp.net tutorial into French.")
+        assert verdict.task_type is None
+        assert verdict.blocked_by == BLOCK_CODE_TARGET
+
+
 class TestScanWindow:
     """Instructions bracket a pasted body; the middle is not scanned."""
 


### PR DESCRIPTION
summary
Fixed the exact bug: \b(?:...)\b requires a real \w/non-\w transition on both edges, but C++/C# end on +/# (non-word) and .NET starts on . (non-word) — so the boundary silently never fires in ordinary prose ("...to C++." has no transition between + and .; "to .NET" has no transition between the space and .).

Gave these three their own boundary shape instead of forcing them into the shared group:

\b(?:c\+\+|c#)(?!\w) — negative lookahead instead of trailing \b, satisfied by end-of-string/whitespace/punctuation alike
\.net\b — dropped the leading \b entirely (a . has no meaningful transition to require)
I verified empirically against the old regex before writing the fix that this preserves the existing (if arguably accidental) asp.net-style matching rather than changing it, per your explicit caution — and pinned that as its own test.

Covers both things you asked for plus a bonus catch: the old \bc#\b was also a false positive on c#sharpener (since #→s is a valid \b transition too) — (?!\w) fixes that as a side effect. 48/48 tests pass, 7 confirmed to fail against the pre-fix code, full router suite (199 tests) green, ruff/mypy clean.

closes #1198 