### PR TITLE
fix(xlsx): use quotePrefix instead of prepending apostrophe for as_text

### DIFF
--- a/src/agentos/skills/bundled/xlsx/scripts/edit_xlsx.py
+++ b/src/agentos/skills/bundled/xlsx/scripts/edit_xlsx.py
@@ -21,14 +21,23 @@ from openpyxl import load_workbook
 
 
 def _coerce(value: Any, as_text: bool) -> Any:
-    if as_text and isinstance(value, str) and value.startswith("="):
-        return "'" + value
+    if as_text:
+        return value
     if isinstance(value, str) and len(value) >= 19 and value[10] == "T":
         try:
             return datetime.fromisoformat(value)
         except ValueError:
             return value
     return value
+
+
+def _apply_cell_format(cell: Any, value: Any, as_text: bool) -> None:
+    """Configure cell formatting for as_text mode."""
+    if not as_text:
+        return
+    cell.number_format = "@"  # Force text format
+    if isinstance(value, str) and value.startswith("="):
+        cell.quotePrefix = True
 
 
 def apply_ops(wb: Any, ops: list[dict[str, Any]]) -> int:
@@ -45,7 +54,9 @@ def apply_ops(wb: Any, ops: list[dict[str, Any]]) -> int:
             if sheet_name not in wb.sheetnames or row is None or col is None:
                 continue
             ws = wb[sheet_name]
-            ws.cell(row=int(row), column=int(col), value=_coerce(value, bool(op.get("as_text"))))
+            as_text = bool(op.get("as_text"))
+            cell = ws.cell(row=int(row), column=int(col), value=_coerce(value, as_text))
+            _apply_cell_format(cell, value, as_text)
             applied += 1
         elif kind == "rename_sheet":
             old = op.get("old")


### PR DESCRIPTION
Fixes #1358

**Problem:** `as_text: true` prepended a literal apostrophe to the value (e.g. `'=hello`), so the apostrophe became part of the cell data and ISO-8601 strings still got parsed as datetimes.

**Fix:**
- `_coerce` now returns the value unchanged when `as_text=True` (prevents datetime auto-parse)
- New `_apply_cell_format` sets `number_format="@"` (force text) and `quotePrefix=True` for formula-like values
- `set_cell` applies the format after setting the value

**Before:** `"'=hello"` (data_type=`s`), datetime parsed
**After:** `"=hello"` (data_type=`f`, `quotePrefix=True`), ISO-8601 stays `"s"`
