### PR TITLE
fix(memory): preserve file permissions in atomic_write_text (#1376)

### DIFF
--- a/src/agentos/memory/atomic_write.py
+++ b/src/agentos/memory/atomic_write.py
@@ -14,6 +14,7 @@ file or the new one, never a truncated one.
 from __future__ import annotations
 
 import os
+import stat
 import tempfile
 from pathlib import Path
 
@@ -60,7 +61,13 @@ def atomic_write_text(target: Path, content: str, *, encoding: str = "utf-8") ->
             handle.write(encoded)
             handle.flush()
             os.fsync(handle.fileno())
+        try:
+            existing_mode = stat.S_IMODE(os.stat(target).st_mode)
+        except OSError:
+            existing_mode = None
         os.replace(tmp_name, target)
+        if existing_mode is not None:
+            os.chmod(target, existing_mode)
     except BaseException:
         try:
             os.unlink(tmp_name)


### PR DESCRIPTION
## Summary
`atomic_write_text` now preserves the original file's Unix permissions (`st_mode`) when overwriting an existing file. Previously, every atomic write reset the target's permissions to the OS-default umask, which could escalate or drop permissions unexpectedly on shared files.

## Vulnerability
When `atomic_write_text` overwrites an existing file (e.g. a config file with `0o600` containing secrets, or a shared script with `0o755`), the tempfile-based write creates the temporary file under the process's umask. Renaming the tempfile over the original replaces the inode, discarding the original's permission bits. A file that was `0o600` (owner-only read) could become world-readable at `0o644`, leaking secrets. A file that was `0o755` (executable) could lose its executable bit, breaking production workflows.

## Root Cause
The atomic write pattern uses `tempfile.NamedTemporaryFile` (or similar) which creates files with default permissions. The `os.rename()` at the end replaces the inode entirely, so the old permissions are lost. No `os.chmod()` call restored them. On Linux, the tempfile's permissions are determined by `umask` at creation time, not by the target file's permissions.

## Fix
Before writing, capture `os.stat(existing_path).st_mode`. After the atomic rename, call `os.chmod(dest_path, original_mode)` to restore the original permissions. If no existing file (first write), behavior is unchanged — default umask applies.

## Verification
- Created file with `0o600`, called `atomic_write_text` on same path → mode still `0o600`
- Created file with `0o755`, called `atomic_write_text` → mode still `0o755`
- New file (no pre-existing) → default umask applies (unchanged behavior)
- All existing tests continue to pass