### PR TITLE
feat(cli): add agentos --version

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -8,7 +8,11 @@ Run:
 ```sh
 agentos --help
 agentos <command> --help
+agentos --version
 ```
+
+`--version` prints the installed version and exits, so the version is
+available without `uv tool list` or `pip show`.
 
 ## Main Commands
 

--- a/src/agentos/cli/main.py
+++ b/src/agentos/cli/main.py
@@ -113,6 +113,34 @@ app.add_typer(search_app, name="search")
 app.add_typer(sessions_app, name="sessions")
 app.add_typer(skills_app, name="skills")
 
+
+def _version_callback(value: bool) -> None:
+    """Print the installed version and exit, before any command runs.
+
+    Eager so ``agentos --version`` answers without Typer demanding a
+    subcommand, which is what ``no_args_is_help`` would otherwise do.
+    """
+    if not value:
+        return
+    from agentos import __version__
+
+    typer.echo(__version__)
+    raise typer.Exit()
+
+
+@app.callback()
+def _root(
+    version: bool = typer.Option(
+        False,
+        "--version",
+        help="Show the installed AgentOS version and exit.",
+        callback=_version_callback,
+        is_eager=True,
+    ),
+) -> None:
+    """AgentOS - Python agent runtime with multi-channel support."""
+
+
 app.command("init")(init_command)
 app.command("doctor")(doctor_command)
 app.command("upgrade")(upgrade_command)

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -121,6 +121,9 @@ non-TTY contexts fall back automatically.
 Top-level: `init`, `onboard`, `configure`, `doctor`, `upgrade`, `chat`,
 `agent`, `reset`, plus these groups (each supports `--help`):
 
+`agentos --version` prints the installed version and exits — use it rather
+than reading a version out of `uv tool list` or `pip show`.
+
 | Group | Subcommands |
 | --- | --- |
 | `gateway` | `run`, `start`, `status`, `stop`, `restart` (`--port`, `--bind`, `--listen`, `--config`, `--json`, `--debug`) |

--- a/tests/test_cli/test_version_flag.py
+++ b/tests/test_cli/test_version_flag.py
@@ -1,0 +1,61 @@
+"""`agentos --version` — the CLI's own answer for "which build is this".
+
+Before this existed the version was only reachable from outside the tool
+(`uv tool list`, `pip show`), which is exactly what issue #1364 reports.
+"""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from agentos import __version__
+from agentos.cli.main import app
+
+runner = CliRunner()
+
+
+def test_version_flag_prints_the_installed_version_and_exits_zero() -> None:
+    """The flag answers with the version alone and succeeds.
+
+    `agentos --version` previously failed with `No such option: --version`,
+    so there was no in-tool way to read the version at all.
+    """
+    result = runner.invoke(app, ["--version"])
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == __version__
+
+
+def test_version_flag_is_answered_before_the_subcommand_is_resolved() -> None:
+    """The option is eager, so it wins over command resolution.
+
+    Asserting this with a name that is not a command is what makes the
+    eagerness visible: a non-eager option would let Click fail on the unknown
+    command first and the version would never print.
+    """
+    result = runner.invoke(app, ["--version", "not-a-real-command"])
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == __version__
+
+
+def test_bare_invocation_still_shows_help() -> None:
+    """Adding a root callback must not change the no-argument behaviour."""
+    result = runner.invoke(app, [])
+
+    assert "Usage:" in result.stdout
+
+
+def test_version_flag_is_listed_in_help() -> None:
+    """A flag nobody can discover does not solve the reporter's problem."""
+    result = runner.invoke(app, ["--help"])
+
+    assert result.exit_code == 0
+    assert "--version" in result.stdout
+
+
+def test_subcommands_still_dispatch_through_the_new_callback() -> None:
+    """The root callback sits in front of every command; it must stay inert."""
+    for path in (["doctor", "--help"], ["config", "--help"], ["sessions", "--help"]):
+        result = runner.invoke(app, path)
+        assert result.exit_code == 0, path


### PR DESCRIPTION
## Summary

The CLI could not report its own version. On `upstream/main` (`cfba23c`):

```
$ agentos --version
╭─ Error ──────────────────────────────────────────────────────────────────────╮
│ No such option: --version                                                    │
╰──────────────────────────────────────────────────────────────────────────────╯
```

There is no `version` command either — the full top-level option list was `--install-completion`, `--show-completion`, `--help`. So the only way to answer "which build is this" was from outside the tool, which is exactly what the reporter had to do (`uv tool list`).

After:

```
$ agentos --version
2026.9.6
$ echo $?
0
```

That is what the issue asks for: *"Print the installed version and exit 0"*.

## Changes

**`src/agentos/cli/main.py`** (+24)

A root `@app.callback()` with an eager `--version` option:

- The value is `agentos.__version__`, which `agentos/__init__.py` already resolves through `importlib.metadata` (falling back across the `use-agent-os` → `agentos` distribution names, then to a sentinel). Reusing it means there is no second source of truth to go stale — that module's own comment calls that out as *"the bug this module exists to prevent"*.
- `is_eager=True` is load-bearing: the app is built with `no_args_is_help=True`, so without eagerness Click resolves the missing subcommand first and the flag never runs.
- The callback body is empty by design; it exists only to host the option, so every existing command dispatches through it unchanged.

**`docs/cli.md`** and **`src/agentos/skills/bundled/agentos/SKILL.md`** — updated in this same change, as CLAUDE.md requires whenever the CLI surface moves.

Deliberately **not** included, to keep the surface change to what #1364 reports:

- No `-V` short form. It is conventional, but the issue is about `--version` and adding an alias is a separate surface decision — happy to add it if you want it.
- No extra detail in the output (Python version, install path, gateway version). The issue asks for the version and exit 0; `agentos doctor` and `agentos diagnostics` are where richer output belongs.

## Tests

**`tests/test_cli/test_version_flag.py`** (new) — 5 cases via `typer.testing.CliRunner`, mirroring the source path (`cli/main.py` → `test_cli/`). No `skipif`; all run on every platform.

*Regression tests — these 3 fail on `upstream/main` and pass with the fix:*

| Test | Covers |
|---|---|
| `test_version_flag_prints_the_installed_version_and_exits_zero` | `exit_code == 0` and stdout is exactly `__version__` |
| `test_version_flag_is_answered_before_the_subcommand_is_resolved` | `["--version", "not-a-real-command"]` still exits 0 and prints the version — this is what makes the eagerness visible rather than assumed |
| `test_version_flag_is_listed_in_help` | the flag appears in `--help`; one nobody can discover does not solve the reporter's problem |

*Guard tests — pass in both states by construction; flagging that rather than counting them as regressions:*

| Test | Covers |
|---|---|
| `test_bare_invocation_still_shows_help` | adding a root callback did not change the no-argument behaviour |
| `test_subcommands_still_dispatch_through_the_new_callback` | `doctor`, `config` and `sessions` still resolve |

One test I wrote and removed rather than ship: it asserted the output against `importlib.metadata.version("use-agent-os")`. That hardcodes one of the two distribution names `__init__.py` accepts, so it would fail on an environment installed under the old `agentos` name or in a source checkout without dist metadata — a CI-only failure waiting to happen, and it only re-tested the stdlib.

## Status

- `uv run ruff check src tests` ✅
- `uv run mypy src/agentos --show-error-codes` ✅ (623 source files, no issues)
- `uv run pytest -q` ✅ **9691 passed, 30 skipped**, 0 failed
- Self-check: reverted `cli/main.py` with `git checkout upstream/main -- <file>` and confirmed the 3 regression tests fail without it.
- `ruff format --diff` reports no hunks in either changed source file.
- Manually verified `agentos --version`, bare `agentos`, `agentos --help`, and `doctor`/`config`/`sessions --help` against the built CLI.

Fixes #1364

🤖 Generated with [Claude Code](https://claude.com/claude-code)
