### PR TITLE
fix(git_commit): only git add -A when files is None, not when files is [] (#1203)

### DIFF
--- a/src/agentos/tools/builtin/git.py
+++ b/src/agentos/tools/builtin/git.py
@@ -204,12 +204,13 @@ async def git_commit(
     workdir: str | None = None,
 ) -> str:
     cwd = _effective_workdir(workdir)
-    if files:
+    if files is not None and files:
         for file_path in files:
             _reject_foreign_git_path(file_path)
         await _run_git("add", "--", *files, cwd=cwd)
-    else:
+    elif files is None:
         await _run_git("add", "-A", cwd=cwd)
+    # files=[] explictly passes an empty list — commit staged only, no git add
     return await _run_git("commit", "-m", message, cwd=cwd)
 
 


### PR DESCRIPTION
## Summary
Clarified the semantics of `git_commit()`: `files=[]` now performs a staging-only commit (no additional files added), while `files=None` adds all changed files before committing. Previously both behaviors were ambiguous.

## Vulnerability
Calling `git_commit(files=[])` (empty list) previously added all files (same as `files=None`), making it impossible to create a commit that records only what was already staged. This broke workflows where a user or tool wants to commit staged changes without `git_commit` implicitly adding more files. For example, a selective staging workflow: stage specific files with `git add`, then call `git_commit(files=[])` expecting only the staged changes to be committed.

## Root Cause
The `files` parameter defaulted to `None` which meant "add all", and an empty list `[]` was treated the same as `None` due to `if not files:` logic. Both `None` and `[]` are falsy in Python.

## Fix
- `files=None` → `git add -A` then `git commit` (original behavior)
- `files=[]` → `git commit` only (staged-only commit)
- `files=["file1.py"]` → `git add file1.py` then `git commit`

## Verification
- `git_commit()` or `git_commit(files=None)`: adds all and commits
- `git_commit(files=[])`: commits staged changes only
- `git_commit(files=["file1.py"])`: adds file1.py and commits