### PR TITLE
fix(gateway): reject bool for projects.update expectedUpdatedAt

### DIFF
--- a/src/agentos/gateway/rpc_projects.py
+++ b/src/agentos/gateway/rpc_projects.py
@@ -127,7 +127,7 @@ async def _handle_projects_update(params: dict | None, ctx: RpcContext) -> dict:
         raise ValueError("params.name must be a string")
     if knowledge is not None and not isinstance(knowledge, str):
         raise ValueError("params.knowledge must be a string")
-    if expected is not None and not isinstance(expected, int):
+    if expected is not None and (isinstance(expected, bool) or not isinstance(expected, int)):
         raise ValueError("params.expectedUpdatedAt must be an integer timestamp")
 
     try:

--- a/tests/test_gateway/test_rpc_projects.py
+++ b/tests/test_gateway/test_rpc_projects.py
@@ -141,6 +141,39 @@ class TestProjectsListGetUpdateDelete:
         assert winner.payload["project"]["knowledge"] == "v3"
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("bad_expected", [True, False])
+    async def test_update_rejects_boolean_expected_updated_at(
+        self, dispatcher, ctx, bad_expected
+    ) -> None:
+        """bool is a subclass of int in Python, so a bare isinstance(x, int)
+        check lets True/False sail through and reach the compare-and-swap as
+        1/0, which can never match a real millisecond timestamp -- producing
+        a misleading project.conflict instead of a validation error (#1261).
+        A caller that reasonably retries on conflict would loop forever,
+        since resending the same boolean can never satisfy the CAS check.
+        """
+        project = await _create_project(dispatcher, ctx)
+        res = await dispatcher.dispatch(
+            "r1",
+            "projects.update",
+            {
+                "projectId": project["project_id"],
+                "knowledge": "v2",
+                "expectedUpdatedAt": bad_expected,
+            },
+            ctx,
+        )
+        assert res.ok is False
+        assert res.error.code == "INVALID_REQUEST"
+        assert res.error.code != "project.conflict"
+        assert "expectedUpdatedAt" in res.error.message
+        # The malformed write must not have landed, same as a real conflict.
+        fresh = await dispatcher.dispatch(
+            "r2", "projects.get", {"projectId": project["project_id"]}, ctx
+        )
+        assert fresh.payload["project"]["knowledge"] == "Shared facts."
+
+    @pytest.mark.asyncio
     async def test_delete_reports_detached_sessions(self, dispatcher, ctx, manager):
         project = await _create_project(dispatcher, ctx)
         await manager.create(


### PR DESCRIPTION
Summary
Fixed exactly what the reviewer described: isinstance(expected, bool) or not isinstance(expected, int) now rejects both True and False with a proper INVALID_REQUEST before the value reaches update_project's compare-and-swap.

Swept the codebase per the reviewer's request — checked every isinstance(x, int) in gateway/rpc_*.py:

rpc_system.py (timeoutMs/intervalMs/ackMaxChars) — already correctly excludes bool, not a bug
rpc_chat.py's history-limit normalizer — accepts bool but is a lenient clamp (max(1, min(limit, MAX))), not a rejection, so bool passthrough is harmless there
rpc_sessions.py's three occurrences — read from server-side GatewayConfig, not client params, so they're not the client-facing trap this issue is about
expectedUpdatedAt was the one genuine miss.

Regression test asserts the INVALID_REQUEST-shaped error specifically (code, plus code != "project.conflict") rather than just "the call fails," per your explicit ask — confirmed to fail against the pre-fix code with error.code == "project.conflict" for both True and False. Full test file passes (15/15), ruff/mypy clean. closes #1261 