### PR TITLE
fix(tools): clamp web_fetch max_chars below the documented minimum instead of disabling truncation

### DIFF
--- a/src/agentos/tools/builtin/web_fetch.py
+++ b/src/agentos/tools/builtin/web_fetch.py
@@ -159,12 +159,18 @@ def _resolve_download_limit_bytes() -> int:
 
 
 def _resolve_effective_max_chars(max_chars: int | None) -> int | None:
-    """Resolve explicit max_chars or the default cap for omitted values."""
+    """Resolve explicit max_chars or the default cap for omitted values.
+
+    An explicit value below the documented minimum (100) is clamped up to
+    it, not dropped to "no cap" — ``_apply_max_chars`` treats ``None`` as
+    unlimited, so returning ``None`` here for e.g. ``max_chars=1`` used to
+    mean the *smallest* request came back with the *entire* untruncated
+    page, the opposite of what the caller asked for (see issue #1400).
+    """
     max_allowed = _active_run_budget_policy().max_single_fetch_chars
     if max_chars is not None:
-        if max_chars < 100:
-            return None
-        return min(max_chars, max_allowed) if max_allowed is not None else max_chars
+        clamped = max(max_chars, 100)
+        return min(clamped, max_allowed) if max_allowed is not None else clamped
     default = _resolve_default_max_chars()
     return min(default, max_allowed) if max_allowed is not None else default
 

--- a/tests/test_tools/test_web_fetch.py
+++ b/tests/test_tools/test_web_fetch.py
@@ -69,3 +69,27 @@ def test_resolve_effective_max_chars_allows_uncapped_run_policy() -> None:
         assert _resolve_effective_max_chars(999_999) == 999_999
     finally:
         current_tool_context.reset(token)
+
+
+def test_resolve_effective_max_chars_clamps_below_minimum_instead_of_disabling_cap() -> None:
+    """Issue #1400: a max_chars below the documented minimum (100) must be
+    clamped up to it, not treated as "no cap" — requesting 1 char should
+    never come back with more text than requesting 1,000 would."""
+    assert _resolve_effective_max_chars(1) == 100
+    assert _resolve_effective_max_chars(0) == 100
+    assert _resolve_effective_max_chars(-5) == 100
+    assert _resolve_effective_max_chars(100) == 100
+    assert _resolve_effective_max_chars(150) == 150
+
+
+def test_apply_max_chars_actually_truncates_a_below_minimum_request() -> None:
+    result = {
+        "url": "https://example.test",
+        "final_url": "https://example.test",
+        "text": _wrap_content("https://example.test", "x" * 50_000),
+    }
+
+    effective = _resolve_effective_max_chars(1)
+    truncated = _apply_max_chars(result, effective)
+
+    assert truncated["returned_length"] <= 100

--- a/tests/test_tools/test_web_fetch.py
+++ b/tests/test_tools/test_web_fetch.py
@@ -93,3 +93,21 @@ def test_apply_max_chars_actually_truncates_a_below_minimum_request() -> None:
     truncated = _apply_max_chars(result, effective)
 
     assert truncated["returned_length"] <= 100
+
+
+def test_resolve_effective_max_chars_run_budget_cap_still_applies_below_minimum() -> None:
+    """A sub-100 request must not escape the run-budget ceiling just because
+    it gets clamped up to the 100 floor first — the floor and the ceiling
+    are independent constraints, and the ceiling always wins when it's the
+    tighter of the two (per andreapn's review on #1400)."""
+    ctx = ToolContext(tool_run_budget_policy=ToolRunBudgetPolicy(max_single_fetch_chars=50))
+    token = current_tool_context.set(ctx)
+    try:
+        # Clamped up to 100, then back down to the tighter run-budget cap.
+        assert _resolve_effective_max_chars(1) == 50
+        assert _resolve_effective_max_chars(0) == 50
+        # A request already above the run-budget cap is unaffected by the
+        # floor logic and is still bound by the same ceiling.
+        assert _resolve_effective_max_chars(999) == 50
+    finally:
+        current_tool_context.reset(token)


### PR DESCRIPTION
Fixes #1400

`_resolve_effective_max_chars()` returned `None` for any `max_chars`
below the documented minimum (100), and `_apply_max_chars()` treats
`None` as "unlimited" — so requesting the smallest possible extract
(e.g. `max_chars=1`) returned the *entire* untruncated page instead of a
tightly bounded one. Fixed by clamping any explicit value below 100 up
to it, matching the tool schema's documented minimum and the existing
pattern used for the env-configured default.

Validated: ruff clean, mypy clean, tests/test_tools suite green (966
passed, 3 skipped — unrelated). Added a regression test proving a
below-minimum request is now actually truncated.

---

Unrelated to this PR, but since I have your attention here: I also
privately reported a security-relevant finding via GHSA-hvx9-4v42-qrqj
about 24h ago and haven't heard back — could someone take a look when
you get a chance? No rush, just want to confirm it reached someone.