### PR TITLE
fix(skills): make xlsx set_cell honour an explicit null

### DIFF
--- a/src/agentos/mcp_server/bridge.py
+++ b/src/agentos/mcp_server/bridge.py
@@ -157,10 +157,18 @@ class AgentOSMCPBridge:
             )
             max_events = _clamp_limit(max_events, _MAX_EVENTS_WAIT_EVENTS)
             timeout_ms = min(max(0, timeout_ms), _MAX_EVENTS_WAIT_TIMEOUT_MS)
-            deadline = time.monotonic() + timeout_ms / 1000
+            effective_timeout_s = timeout_ms / 1000
+            deadline = time.monotonic() + effective_timeout_s
 
             while len(events) < max_events:
-                remaining = deadline - time.monotonic()
+                # min(..., effective_timeout_s): deadline - time.monotonic()
+                # can round *above* effective_timeout_s by a few nanoseconds
+                # of float error (two monotonic() readings added and
+                # subtracted back rarely cancel exactly at large clock
+                # values), which would hand recv_event a timeout a hair
+                # over the caller's clamp. The clamp is the contract; the
+                # min() makes it exact instead of "usually exact".
+                remaining = min(deadline - time.monotonic(), effective_timeout_s)
                 if remaining <= 0:
                     break
                 try:

--- a/src/agentos/skills/bundled/xlsx/scripts/edit_xlsx.py
+++ b/src/agentos/skills/bundled/xlsx/scripts/edit_xlsx.py
@@ -4,8 +4,24 @@ Operations:
     {"op": "set_cell", "sheet": "Q3", "row": 1, "col": 1, "value": "..."}
     {"op": "set_cell", "sheet": "Q3", "row": 2, "col": 2, "value": "=SUM(B3:B10)"}
     {"op": "set_cell", "sheet": "Q3", "row": 3, "col": 3, "value": "=hello", "as_text": true}
+    {"op": "set_cell", "sheet": "Q3", "row": 4, "col": 4, "value": null}
     {"op": "rename_sheet", "old": "Sheet1", "new": "Summary"}
     {"op": "merge_cells", "sheet": "Q3", "range": "A1:C1"}
+
+set_cell "value" semantics:
+    An explicit JSON ``null`` clears the cell (sets it to ``None``). This is
+    the only way to express "clear this cell" in this op schema, so it is
+    treated as a clear rather than a no-op — openpyxl's own
+    ``Worksheet.cell(..., value=...)`` does the opposite (``if value is not
+    None: cell.value = value``, silently leaving an existing value in place
+    for an explicit null), which is a trap this script does not repeat: the
+    cell's ``.value`` is always assigned directly instead of going through
+    that keyword.
+    A missing "value" key is not a clear — the whole operation is skipped
+    (and not counted in "applied") rather than risk a malformed op silently
+    wiping a cell it never meant to touch.
+    ``0``, ``false``, and ``""`` are ordinary values, not clears; only a
+    literal ``null`` triggers clear semantics.
 """
 
 from __future__ import annotations
@@ -41,11 +57,24 @@ def apply_ops(wb: Any, ops: list[dict[str, Any]]) -> int:
             sheet_name = op.get("sheet")
             row = op.get("row")
             col = op.get("col")
-            value = op.get("value")
             if sheet_name not in wb.sheetnames or row is None or col is None:
                 continue
+            if "value" not in op:
+                # No value supplied at all: nothing to apply. Treating a
+                # missing key the same as an explicit null would let a
+                # malformed operation silently clear a cell it never named
+                # a value for.
+                continue
+            value = op["value"]
             ws = wb[sheet_name]
-            ws.cell(row=int(row), column=int(col), value=_coerce(value, bool(op.get("as_text"))))
+            # ws.cell(row=..., column=..., value=...) only assigns when
+            # value is not None, so routing an explicit null through that
+            # keyword is a silent no-op. Fetch the cell first, then assign
+            # .value directly in both branches — the only way to actually
+            # clear a cell, and it leaves the cell's style untouched either
+            # way, same as the keyword form did for a non-null value.
+            cell = ws.cell(row=int(row), column=int(col))
+            cell.value = value if value is None else _coerce(value, bool(op.get("as_text")))
             applied += 1
         elif kind == "rename_sheet":
             old = op.get("old")

--- a/tests/_symlink_support.py
+++ b/tests/_symlink_support.py
@@ -1,0 +1,41 @@
+"""Shared symlink-capability probe for tests that exercise real symlinks.
+
+Deliberately not named conftest.py: tests/test_skills/conftest.py already
+claims that bare module name, and neither tests/ nor its subdirectories
+carry __init__.py, so two files both named "conftest" would race for the
+same entry in sys.modules — whichever pytest imports first wins that name
+for the rest of the session, and any other file's `from conftest import X`
+resolves to whichever one won, not necessarily the one in the same
+directory. A uniquely-named module sidesteps that entirely.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+
+def _symlinks_supported() -> bool:
+    """Probe whether this process can actually create filesystem symlinks.
+
+    Windows requires SeCreateSymbolicLinkPrivilege — Developer Mode enabled,
+    or an elevated process — to call os.symlink(); without it every symlink
+    test fails identically with OSError: [WinError 1314]. Detected with a
+    real create-in-tempdir probe rather than a bare `sys.platform == "win32"`
+    check: Windows with Developer Mode on (or running elevated) supports
+    symlinks fine, and gating on OS name alone would skip tests that could
+    actually run there.
+    """
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "target"
+            target.write_text("x", encoding="utf-8")
+            (Path(tmp) / "link").symlink_to(target)
+        return True
+    except OSError:
+        return False
+
+
+#: Shared skip condition for tests that exercise real symlink creation.
+#: Usage: @pytest.mark.skipif(not SYMLINKS_SUPPORTED, reason="...")
+SYMLINKS_SUPPORTED = _symlinks_supported()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,3 +18,29 @@ os.environ.setdefault("AGENTOS_TURN_CALL_LOG", "0")
 # is cold. Default tests must stay offline; tests that exercise the refresh
 # opt back in with monkeypatch.setenv.
 os.environ.setdefault("AGENTOS_OPENCAP_LIVE_PRICING", "0")
+
+
+def _symlinks_supported() -> bool:
+    """Probe whether this process can actually create filesystem symlinks.
+
+    Windows requires SeCreateSymbolicLinkPrivilege — Developer Mode enabled,
+    or an elevated process — to call os.symlink(); without it every symlink
+    test fails identically with OSError: [WinError 1314]. Detected with a
+    real create-in-tempdir probe rather than a bare `sys.platform == "win32"`
+    check: Windows with Developer Mode on (or running elevated) supports
+    symlinks fine, and gating on OS name alone would skip tests that could
+    actually run there.
+    """
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "target"
+            target.write_text("x", encoding="utf-8")
+            (Path(tmp) / "link").symlink_to(target)
+        return True
+    except OSError:
+        return False
+
+
+#: Shared skip condition for tests that exercise real symlink creation.
+#: Usage: @pytest.mark.skipif(not SYMLINKS_SUPPORTED, reason="...")
+SYMLINKS_SUPPORTED = _symlinks_supported()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,29 +18,3 @@ os.environ.setdefault("AGENTOS_TURN_CALL_LOG", "0")
 # is cold. Default tests must stay offline; tests that exercise the refresh
 # opt back in with monkeypatch.setenv.
 os.environ.setdefault("AGENTOS_OPENCAP_LIVE_PRICING", "0")
-
-
-def _symlinks_supported() -> bool:
-    """Probe whether this process can actually create filesystem symlinks.
-
-    Windows requires SeCreateSymbolicLinkPrivilege — Developer Mode enabled,
-    or an elevated process — to call os.symlink(); without it every symlink
-    test fails identically with OSError: [WinError 1314]. Detected with a
-    real create-in-tempdir probe rather than a bare `sys.platform == "win32"`
-    check: Windows with Developer Mode on (or running elevated) supports
-    symlinks fine, and gating on OS name alone would skip tests that could
-    actually run there.
-    """
-    try:
-        with tempfile.TemporaryDirectory() as tmp:
-            target = Path(tmp) / "target"
-            target.write_text("x", encoding="utf-8")
-            (Path(tmp) / "link").symlink_to(target)
-        return True
-    except OSError:
-        return False
-
-
-#: Shared skip condition for tests that exercise real symlink creation.
-#: Usage: @pytest.mark.skipif(not SYMLINKS_SUPPORTED, reason="...")
-SYMLINKS_SUPPORTED = _symlinks_supported()

--- a/tests/test_mcp_server/test_bridge.py
+++ b/tests/test_mcp_server/test_bridge.py
@@ -392,6 +392,42 @@ async def test_events_wait_remaining_never_exceeds_effective_timeout(
 
 
 @pytest.mark.asyncio
+async def test_events_wait_remaining_pinned_clock_reading_from_1264(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1264's exact deterministic repro: a *single* time.monotonic() reading
+    used for both the deadline and the first "remaining" computation. Real
+    calls are microseconds apart, but the rounding artifact this guards
+    against doesn't need two different readings -- (t + 300.0) - t fails to
+    cancel back to exactly 300.0 for this specific t on its own, landing at
+    300.0000000000018 pre-fix. #1264 sampled ~400k plausible monotonic()
+    values and found this shape on about 1 in 1700 of them, which is what
+    made test_events_wait_clamps_effective_deadline (above) an intermittent
+    Windows CI flake on unrelated pull requests rather than a local
+    reproduction anyone could pin down.
+
+    Rebinds the module-level `time` name (as the other rounding test above
+    does) rather than mutating the real time module's .monotonic attribute,
+    which would also corrupt asyncio's own internal timing during the test.
+    """
+    client = RecordingEventClient()
+    bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)
+
+    class _FakeTime:
+        @staticmethod
+        def monotonic() -> float:
+            return 16330.771337564662
+
+    monkeypatch.setattr(bridge_module, "time", _FakeTime())
+
+    await bridge.events_wait("agent:main:main", timeout_ms=3_600_000)
+
+    assert client.recv_timeouts
+    first_timeout = client.recv_timeouts[0]
+    assert first_timeout == bridge_module._MAX_EVENTS_WAIT_TIMEOUT_MS / 1000
+
+
+@pytest.mark.asyncio
 async def test_events_wait_preserves_timeout_below_the_cap() -> None:
     client = RecordingEventClient()
     bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)

--- a/tests/test_mcp_server/test_bridge.py
+++ b/tests/test_mcp_server/test_bridge.py
@@ -357,6 +357,41 @@ async def test_events_wait_clamps_effective_deadline() -> None:
 
 
 @pytest.mark.asyncio
+async def test_events_wait_remaining_never_exceeds_effective_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """deadline - time.monotonic() can round a hair above the intended
+    clamp: two time.monotonic() readings added and then subtracted back
+    rarely cancel exactly in float64 once the clock's base value is large
+    (a long-uptime CI runner, say), so the per-call recv timeout must be
+    clamped explicitly rather than trusted to always come out <=
+    effective_timeout_s on its own."""
+    client = RecordingEventClient()
+    bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)
+
+    # First call computes the deadline; second computes the first
+    # "remaining", using a reading fractionally *before* the first -- the
+    # same shape a real float64 rounding artifact produces. Rebinding the
+    # module-level `time` name (rather than mutating the real time module)
+    # keeps this from also breaking asyncio's own internal timing.
+    readings = iter([1_000_000.0, 999_999.9999999])
+
+    class _FakeTime:
+        @staticmethod
+        def monotonic() -> float:
+            return next(readings)
+
+    monkeypatch.setattr(bridge_module, "time", _FakeTime())
+
+    await bridge.events_wait("agent:main:main", timeout_ms=3_600_000)
+
+    assert client.recv_timeouts
+    first_timeout = client.recv_timeouts[0]
+    assert first_timeout is not None
+    assert first_timeout <= bridge_module._MAX_EVENTS_WAIT_TIMEOUT_MS / 1000
+
+
+@pytest.mark.asyncio
 async def test_events_wait_preserves_timeout_below_the_cap() -> None:
     client = RecordingEventClient()
     bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)

--- a/tests/test_memory_curated_durability.py
+++ b/tests/test_memory_curated_durability.py
@@ -14,7 +14,7 @@ import os
 from pathlib import Path
 
 import pytest
-from conftest import SYMLINKS_SUPPORTED
+from _symlink_support import SYMLINKS_SUPPORTED
 
 from agentos.memory.curated import (
     _CONSOLIDATION_FAILURE_WINDOW_S,

--- a/tests/test_memory_curated_durability.py
+++ b/tests/test_memory_curated_durability.py
@@ -14,6 +14,7 @@ import os
 from pathlib import Path
 
 import pytest
+from conftest import SYMLINKS_SUPPORTED
 
 from agentos.memory.curated import (
     _CONSOLIDATION_FAILURE_WINDOW_S,
@@ -150,6 +151,7 @@ def test_drift_still_detected_and_backed_up(store: CuratedMemoryStore, tmp_path:
 # -- atomic replace preserves symlinks -------------------------------------
 
 
+@pytest.mark.skipif(not SYMLINKS_SUPPORTED, reason="platform/user lacks symlink privilege")
 def test_write_through_symlink_keeps_the_symlink(tmp_path: Path):
     """Deployments symlink MEMORY.md into dotfiles; a write must not detach it."""
     real_dir = tmp_path / "real"

--- a/tests/test_scheduler/test_script_jobs.py
+++ b/tests/test_scheduler/test_script_jobs.py
@@ -11,6 +11,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from conftest import SYMLINKS_SUPPORTED
 
 from agentos.scheduler.delivery import DeliveryChain
 from agentos.scheduler.handlers import make_script_run_handler
@@ -100,6 +101,7 @@ def test_absolute_path_outside_scripts_dir_is_blocked(agentos_home):
         resolve_script_path("/etc/passwd")
 
 
+@pytest.mark.skipif(not SYMLINKS_SUPPORTED, reason="platform/user lacks symlink privilege")
 def test_symlink_escape_is_blocked(agentos_home, tmp_path):
     outside = tmp_path / "outside.py"
     outside.write_text("print('pwned')", encoding="utf-8")

--- a/tests/test_scheduler/test_script_jobs.py
+++ b/tests/test_scheduler/test_script_jobs.py
@@ -11,7 +11,7 @@ import sys
 from pathlib import Path
 
 import pytest
-from conftest import SYMLINKS_SUPPORTED
+from _symlink_support import SYMLINKS_SUPPORTED
 
 from agentos.scheduler.delivery import DeliveryChain
 from agentos.scheduler.handlers import make_script_run_handler

--- a/tests/test_skill_xlsx.py
+++ b/tests/test_skill_xlsx.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -129,6 +130,175 @@ def test_text_escapes_formula(tmp_path: Path) -> None:
     cell_value = sheet["rows"][1][0]["value"]
     assert isinstance(cell_value, str)
     assert cell_value.lstrip("'") == "=hello"
+
+
+def _run_edit_xlsx_cli(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    *,
+    src: Path,
+    ops: list[dict[str, object]],
+    out: Path,
+) -> dict[str, object]:
+    """Invoke edit_xlsx's real CLI entry point (argv -> main()), not
+    apply_ops() directly, so a save/reload through the same path the issue's
+    exact reproduction used is what the regression actually exercises."""
+    sys.path.insert(0, str(SCRIPTS))
+    try:
+        import edit_xlsx  # type: ignore[import-not-found]
+    finally:
+        sys.path.pop(0)
+
+    ops_path = out.with_name(out.stem + "-ops.json")
+    ops_path.write_text(json.dumps(ops), encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", ["edit_xlsx.py", str(src), str(ops_path), "--out", str(out)])
+    capsys.readouterr()
+    assert edit_xlsx.main() == 0
+    return json.loads(capsys.readouterr().out)
+
+
+@pytest.mark.parametrize(
+    ("initial_value", "kind"),
+    [
+        ("old value", "text"),
+        (42, "numeric"),
+        ("=A1+A2", "formula"),
+    ],
+)
+def test_set_cell_explicit_null_clears_the_cell(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    initial_value: object,
+    kind: str,
+) -> None:
+    """An explicit JSON null must clear the cell and report the edit as
+    applied -- not silently leave the previous value in place while still
+    exiting 0 with {"applied": 1} (#1260).
+
+    openpyxl's own Worksheet.cell(..., value=...) only assigns when value is
+    not None, so routing a null through that keyword is a no-op; this pins
+    that edit_xlsx does not repeat the trap for any of the three cell kinds
+    the issue reported failing. Verified the same way the issue's own
+    reproduction did: reopen the saved output with openpyxl directly (not
+    through inspect_xlsx, which omits an empty cell from its "rows" output
+    entirely -- it would report nothing there whether the cell had cleared
+    correctly or the whole sheet had gone missing).
+
+    A second, never-touched cell keeps the sheet non-empty after the clear;
+    a single-cell sheet's dimensions can otherwise shift once its only cell
+    goes to None, which is a detail of how the sheet is inspected, not of
+    whether the clear itself worked.
+    """
+    sys.path.insert(0, str(SCRIPTS))
+    try:
+        import create_xlsx  # type: ignore[import-not-found]
+    finally:
+        sys.path.pop(0)
+
+    src = tmp_path / "input.xlsx"
+    create_xlsx.build({"sheets": [{"name": "Sheet", "rows": [[initial_value, "anchor"]]}]}).save(
+        str(src)
+    )
+
+    out = tmp_path / f"output-{kind}.xlsx"
+    result = _run_edit_xlsx_cli(
+        monkeypatch,
+        capsys,
+        src=src,
+        ops=[{"op": "set_cell", "sheet": "Sheet", "row": 1, "col": 1, "value": None}],
+        out=out,
+    )
+
+    assert result == {"applied": 1}
+    from openpyxl import load_workbook
+
+    reloaded = load_workbook(str(out), data_only=False)
+    cell = reloaded["Sheet"].cell(row=1, column=1)
+    assert cell.value is None, f"{kind} cell was not cleared: {cell.value!r}"
+    assert reloaded["Sheet"].cell(row=1, column=2).value == "anchor"
+
+
+def test_set_cell_missing_value_key_is_not_applied(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A set_cell op with no "value" key at all must be skipped, not treated
+    as a clear -- a malformed operation must never silently wipe a cell it
+    named no value for."""
+    sys.path.insert(0, str(SCRIPTS))
+    try:
+        import create_xlsx  # type: ignore[import-not-found]
+    finally:
+        sys.path.pop(0)
+
+    src = tmp_path / "input.xlsx"
+    create_xlsx.build({"sheets": [{"name": "Sheet", "rows": [["old value"]]}]}).save(str(src))
+
+    out = tmp_path / "output.xlsx"
+    result = _run_edit_xlsx_cli(
+        monkeypatch,
+        capsys,
+        src=src,
+        ops=[{"op": "set_cell", "sheet": "Sheet", "row": 1, "col": 1}],
+        out=out,
+    )
+
+    assert result == {"applied": 0}
+    from openpyxl import load_workbook
+
+    reloaded = load_workbook(str(out), data_only=False)
+    assert reloaded["Sheet"].cell(row=1, column=1).value == "old value"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_after_reload"),
+    [
+        (0, 0),
+        (False, False),
+        # openpyxl does not round-trip a written "" distinctly from an
+        # unwritten cell -- confirmed with plain openpyxl, no edit_xlsx
+        # involved: writing "" and reloading reads back None regardless.
+        # That is a pre-existing property of the format/library, unrelated
+        # to this fix's null-clear semantics, so it is pinned as-is rather
+        # than asserted to equal "".
+        ("", None),
+    ],
+)
+def test_set_cell_falsy_values_are_not_treated_as_clear(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    value: object,
+    expected_after_reload: object,
+) -> None:
+    """0 and False are ordinary values, not clears -- only a literal JSON
+    null triggers clear semantics. applied must still read 1: the op was a
+    genuine, deliberate write, not skipped like a missing "value" key."""
+    sys.path.insert(0, str(SCRIPTS))
+    try:
+        import create_xlsx  # type: ignore[import-not-found]
+    finally:
+        sys.path.pop(0)
+
+    src = tmp_path / "input.xlsx"
+    create_xlsx.build({"sheets": [{"name": "Sheet", "rows": [["old value"]]}]}).save(str(src))
+
+    out = tmp_path / "output.xlsx"
+    result = _run_edit_xlsx_cli(
+        monkeypatch,
+        capsys,
+        src=src,
+        ops=[{"op": "set_cell", "sheet": "Sheet", "row": 1, "col": 1, "value": value}],
+        out=out,
+    )
+
+    assert result == {"applied": 1}
+    from openpyxl import load_workbook
+
+    reloaded = load_workbook(str(out), data_only=False)
+    assert reloaded["Sheet"].cell(row=1, column=1).value == expected_after_reload
 
 
 def test_inspect_xlsx_creates_parent_directory(

--- a/tests/test_skills_hub_download_security.py
+++ b/tests/test_skills_hub_download_security.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from conftest import SYMLINKS_SUPPORTED
+from _symlink_support import SYMLINKS_SUPPORTED
 
 from agentos.skills.hub import deps
 from agentos.skills.install_kinds import InstallSpecError

--- a/tests/test_skills_hub_download_security.py
+++ b/tests/test_skills_hub_download_security.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from conftest import SYMLINKS_SUPPORTED
 
 from agentos.skills.hub import deps
 from agentos.skills.install_kinds import InstallSpecError
@@ -67,6 +68,7 @@ def test_resolve_download_dest_accepts_a_plain_binary_name(fake_home: Path) -> N
     assert dest == fake_home / ".local" / "bin" / "ripgrep"
 
 
+@pytest.mark.skipif(not SYMLINKS_SUPPORTED, reason="platform/user lacks symlink privilege")
 def test_resolve_download_dest_refuses_to_write_through_a_symlink(fake_home: Path) -> None:
     outside = fake_home / "secret.txt"
     outside.write_text("original", encoding="utf-8")


### PR DESCRIPTION
Summary closes #1260 
edit_xlsx.py's set_cell op passed values straight through ws.cell(..., value=...), which openpyxl only assigns when value is not None — so an explicit JSON null silently left the previous cell value untouched while the script still exited 0 reporting {"applied": 1}.
Fixes it by fetching the cell and assigning .value directly in both branches (the only way to actually clear a cell), so an explicit null now clears it as intended, preserving cell styles either way.
A missing "value" key is now distinguished from an explicit null and skipped (not counted in applied), so a malformed op can't silently wipe a cell it named no value for.
0/False/"" are unaffected — gated by identity (value is None), not truthiness.
Documented the null semantics in the module docstring.
Closes #1260.

Test plan
 New tests invoke the real CLI entry point (main() via argv), covering text/numeric/formula cells (the three kinds the issue reported), a missing-value-key control, and 0/False/"" controls
 Verified via direct openpyxl reload rather than inspect_xlsx (which omits empty cells from its output entirely)
 All 4 new assertions confirmed to fail against the pre-fix code with the exact symptom reported
 uv run pytest tests/test_skill_xlsx.py — 12/12 pass
 ruff check clean