### PR TITLE
fix(provider): detect Gemini 'model is not found' errors as MODEL_NOT_FOUND (#1359)

### DIFF
--- a/src/agentos/provider/failures.py
+++ b/src/agentos/provider/failures.py
@@ -183,7 +183,7 @@ def classify_provider_error(
             return ProviderFailureKind.INSUFFICIENT_CREDITS
         if status_code == 429 or "rate limit" in text or "rate_limit" in text:
             return ProviderFailureKind.RATE_LIMITED
-        if "no endpoints found" in text or "model not found" in text:
+        if "no endpoints found" in text or "model not found" in text or "is not found" in text:
             return ProviderFailureKind.MODEL_NOT_FOUND
         if "does not support" in text or "unsupported" in text:
             return ProviderFailureKind.UNSUPPORTED_FEATURE


### PR DESCRIPTION
## Summary
Added `"is not found"` to Gemini model error detection.

## Vulnerability
Bad Gemini model name (e.g. typo) caused raw HTTP 404 instead of structured "model not found" error with hints.

## Root Cause
Gemini error classifier missed the 404 error body string `"is not found"`.

## Fix
Added `"is not found"` to Gemini-specific error patterns.

## Verification
- Invalid model: clear "model not found" error
- Valid model: works normally