### PR TITLE
fix(discord): reopen the upload body on every send_file retry

### DIFF
--- a/src/agentos/channels/discord.py
+++ b/src/agentos/channels/discord.py
@@ -1029,14 +1029,21 @@ class DiscordChannel:
         check_channel_file_size(file_path, self.MAX_FILE_BYTES, "Discord")
         await self._rate_limiter.acquire()
         client = self._get_client()
-        with open(file_path, "rb") as f:
-            resp = await retry_request(
-                client.post,
-                f"/channels/{channel_id}/messages",
-                data={"content": content} if content else {},
-                files={"file": (Path(file_path).name, f)},
-                headers=self._auth_headers(),
-            )
+        path = Path(file_path)
+
+        async def _upload() -> httpx.Response:
+            # Reopened per attempt: retry_request re-invokes this on 429, on
+            # 5xx and on connect/timeout errors, and a handle consumed by the
+            # first attempt would upload an empty body on the second.
+            with path.open("rb") as f:
+                return await client.post(
+                    f"/channels/{channel_id}/messages",
+                    data={"content": content} if content else {},
+                    files={"file": (path.name, f)},
+                    headers=self._auth_headers(),
+                )
+
+        resp = await retry_request(_upload)
         resp.raise_for_status()
         data = resp.json()
         message_id = str(data.get("id", ""))

--- a/tests/test_channels/test_discord_retry.py
+++ b/tests/test_channels/test_discord_retry.py
@@ -1,0 +1,228 @@
+"""Transient-HTTP retries on the Discord adapter's outbound calls.
+
+The file-upload case is the one that used to corrupt data: ``send_file``
+opened the handle *outside* ``retry_request``, so the second attempt after a
+429/5xx/timeout re-sent an exhausted stream and Discord stored a 0-byte file
+without anything raising. These tests assert on the bytes each attempt
+actually carried, not merely that the file was reopened.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from agentos.channels.discord import DiscordChannel, DiscordChannelConfig
+
+_REQUEST = httpx.Request("POST", "https://discord.test/api")
+
+
+def _resp(
+    status_code: int = 200,
+    body: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+) -> httpx.Response:
+    return httpx.Response(
+        status_code,
+        json=body if body is not None else {"id": "42"},
+        headers=headers,
+        request=_REQUEST,
+    )
+
+
+def _channel() -> DiscordChannel:
+    return DiscordChannel(
+        config=DiscordChannelConfig(token="bot-test", default_channel_id="C123")
+    )
+
+
+def _attach(channel: DiscordChannel, side_effect: Any) -> AsyncMock:
+    client = AsyncMock()
+    client.post = AsyncMock(side_effect=side_effect)
+    channel._client = client
+    return client.post
+
+
+@pytest.fixture
+def no_sleep():
+    """Collapse ``retry_request``'s backoff so the assertions stay fast."""
+    with patch("agentos.channels._util.asyncio.sleep", new=AsyncMock()) as sleep:
+        yield sleep
+
+
+def _recording_post(
+    bodies: list[bytes], statuses: list[int]
+) -> Any:
+    """Return a ``client.post`` stub that records the uploaded body per attempt."""
+    remaining = list(statuses)
+
+    async def _post(url: str, **kwargs: Any) -> httpx.Response:
+        bodies.append(kwargs["files"]["file"][1].read())
+        status = remaining.pop(0) if remaining else 200
+        headers = {"Retry-After": "1"} if status == 429 else None
+        return _resp(status, headers=headers)
+
+    return _post
+
+
+async def test_send_file_rate_limited_retry_uploads_full_body(
+    tmp_path: Path, no_sleep
+) -> None:
+    """429 is the likeliest Discord retry — the second attempt must not be empty."""
+    sample = tmp_path / "note.txt"
+    sample.write_bytes(b"hello world")
+
+    channel = _channel()
+    bodies: list[bytes] = []
+    _attach(channel, _recording_post(bodies, [429, 200]))
+
+    result = await channel.send_file("C123", str(sample), content="here")
+
+    assert result.provider_message_id == "42"
+    assert bodies == [b"hello world", b"hello world"]
+
+
+async def test_send_file_server_error_retry_uploads_full_body(
+    tmp_path: Path, no_sleep
+) -> None:
+    sample = tmp_path / "note.txt"
+    sample.write_bytes(b"payload-bytes")
+
+    channel = _channel()
+    bodies: list[bytes] = []
+    _attach(channel, _recording_post(bodies, [503, 200]))
+
+    await channel.send_file("C123", str(sample))
+
+    assert bodies == [b"payload-bytes", b"payload-bytes"]
+
+
+async def test_send_file_timeout_retry_uploads_full_body(tmp_path: Path, no_sleep) -> None:
+    """A timeout raises before the body is recorded, so attempt 2 is the first record."""
+    sample = tmp_path / "note.txt"
+    sample.write_bytes(b"abc123")
+
+    channel = _channel()
+    bodies: list[bytes] = []
+    attempts = 0
+
+    async def _post(url: str, **kwargs: Any) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        bodies.append(kwargs["files"]["file"][1].read())
+        if attempts == 1:
+            raise httpx.ConnectTimeout("slow")
+        return _resp(200)
+
+    _attach(channel, _post)
+
+    await channel.send_file("C123", str(sample))
+
+    assert attempts == 2
+    assert bodies == [b"abc123", b"abc123"]
+
+
+async def test_send_file_succeeds_first_try_without_retry(tmp_path: Path, no_sleep) -> None:
+    sample = tmp_path / "note.txt"
+    sample.write_bytes(b"once")
+
+    channel = _channel()
+    bodies: list[bytes] = []
+    post = _attach(channel, _recording_post(bodies, [200]))
+
+    await channel.send_file("C123", str(sample), content="caption")
+
+    assert post.await_count == 1
+    assert bodies == [b"once"]
+    no_sleep.assert_not_awaited()
+
+
+async def test_send_file_passes_content_and_filename(tmp_path: Path, no_sleep) -> None:
+    """The closure must keep the same payload shape the direct call had."""
+    sample = tmp_path / "report.md"
+    sample.write_bytes(b"# report")
+
+    channel = _channel()
+    seen: list[dict[str, Any]] = []
+
+    async def _post(url: str, **kwargs: Any) -> httpx.Response:
+        seen.append({"url": url, **kwargs})
+        return _resp(200)
+
+    _attach(channel, _post)
+
+    await channel.send_file("C999", str(sample), content="see attached")
+
+    assert seen[0]["url"] == "/channels/C999/messages"
+    assert seen[0]["data"] == {"content": "see attached"}
+    assert seen[0]["files"]["file"][0] == "report.md"
+    assert seen[0]["headers"] == {"Authorization": "Bot bot-test"}
+
+
+async def test_send_file_omits_data_when_no_content(tmp_path: Path, no_sleep) -> None:
+    sample = tmp_path / "report.md"
+    sample.write_bytes(b"# report")
+
+    channel = _channel()
+    seen: list[dict[str, Any]] = []
+
+    async def _post(url: str, **kwargs: Any) -> httpx.Response:
+        seen.append(dict(kwargs))
+        return _resp(200)
+
+    _attach(channel, _post)
+
+    await channel.send_file("C123", str(sample))
+
+    assert seen[0]["data"] == {}
+
+
+async def test_send_file_records_sent_message_for_edit_routing(
+    tmp_path: Path, no_sleep
+) -> None:
+    sample = tmp_path / "note.txt"
+    sample.write_bytes(b"body")
+
+    channel = _channel()
+    bodies: list[bytes] = []
+    _attach(channel, _recording_post(bodies, [429, 200]))
+
+    await channel.send_file("C777", str(sample))
+
+    assert channel._sent_messages["42"] == "C777"
+
+
+async def test_send_file_raises_after_retries_are_exhausted(
+    tmp_path: Path, no_sleep
+) -> None:
+    sample = tmp_path / "note.txt"
+    sample.write_bytes(b"body")
+
+    channel = _channel()
+    post = _attach(channel, [httpx.ConnectError("down")] * 4)
+
+    with pytest.raises(httpx.ConnectError):
+        await channel.send_file("C123", str(sample))
+
+    assert post.await_count == 4  # initial attempt + max_retries=3
+
+
+async def test_send_file_surfaces_fatal_client_error_without_retry(
+    tmp_path: Path, no_sleep
+) -> None:
+    sample = tmp_path / "note.txt"
+    sample.write_bytes(b"body")
+
+    channel = _channel()
+    bodies: list[bytes] = []
+    post = _attach(channel, _recording_post(bodies, [403]))
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await channel.send_file("C123", str(sample))
+
+    assert post.await_count == 1
+    no_sleep.assert_not_awaited()


### PR DESCRIPTION
## Linked issue

Fixes #1164

- [x] This pull request fully resolves the linked issue.

## Summary

`DiscordChannel.send_file` opened the file handle **outside** `retry_request`
and handed the same object to every attempt:

```python
with open(file_path, "rb") as f:
    resp = await retry_request(client.post, ..., files={"file": (..., f)}, ...)
```

`retry_request` (`channels/_util.py:337-375`) re-invokes `func` on 429, on
500/502/503/504, and on `ConnectError`/`TimeoutException` — three live paths
that all call `client.post` again with the *same* stream. By then the first
attempt has read it to EOF, so httpx sends a 0-byte body, Discord stores an
empty file, and `resp.raise_for_status()` sees the 200 for that empty upload.
Nothing raises. Silent corruption, on the rate-limit path that is by far the
most likely retry trigger on Discord.

The fix mirrors `SlackChannel.send_file`, which already had exactly the right
shape and a comment naming this failure mode verbatim — Discord was the
outlier. `send_file` now passes an `async def _upload()` closure to
`retry_request` with no positional args; the closure opens the path per
attempt, so every attempt carries the whole file.

I checked the other adapters while I was here: Telegram's `send_file` does its
`client.post` directly and never goes through `retry_request`, so it was never
exposed. Discord was the only one.

## Tests

New `tests/test_channels/test_discord_retry.py`, 9 tests. Per the review note
on the issue, they assert on the **bytes each attempt actually sent**, not on
how many times `open()` was called — a handle that was rewound but still
truncated would pass the weaker check.

- 429 → retry, 5xx → retry, `ConnectTimeout` → retry: each asserts
  `bodies == [b"...", b"..."]`, i.e. both attempts carried the full body.
- Payload-shape guards for the refactor: URL, `data`, filename and auth
  headers unchanged; `data == {}` when there is no caption; `_sent_messages`
  still recorded for edit routing.
- No-retry paths: success on the first try does not sleep; a 403 surfaces
  without retrying; `ConnectError` still raises after 4 attempts.

Red before the fix / green after:

```
$ uv run pytest tests/test_channels/test_discord_retry.py -q   # before
3 failed, 6 passed        # the three retry paths, each with bodies[1] == b""
$ uv run pytest tests/test_channels/test_discord_retry.py -q   # after
9 passed
```

Full gate on this branch:

```
uv run ruff check src tests            # All checks passed!
uv run mypy src/agentos                # clean apart from the pre-existing mem0 stub error
uv run pytest -q                       # 3 failed, 9695 passed, 27 skipped
```

The 3 failures are the pre-existing environment ones (`mem0` installed
locally, `weasyprint`/pango missing) and reproduce identically on a clean
tree.

## Merge-order independence

One of five PRs opened together (#1164, #1166, #1169, #1172, #1180). They
touch disjoint files except #1166/#1169, which touch different functions of
`tools/builtin/patch.py`. All 120 merge orderings verified conflict-free
locally, and the all-five merged tree passes the full suite.

`CHANGELOG.md` is deliberately **not** touched: `[Unreleased]` is currently
empty, so five PRs each inserting a `### Fixed` block at the same line would
conflict with each other in every possible merge order. Happy to follow up
with a single `docs(changelog)` PR covering all five once they land (the same
shape as 38fbdb2), or to add the entry here if you would rather take the
conflict — just say which.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vCV6bdPciGkEywDSsyuGs
