### PR TITLE
fix(tools): apply a prepend hunk at the top of the file

### DIFF
--- a/src/agentos/tools/builtin/patch.py
+++ b/src/agentos/tools/builtin/patch.py
@@ -455,8 +455,12 @@ def _apply_hunk(file_lines: list[str], hunk: Hunk) -> list[str]:
 
     Returns the new list of lines.
     """
-    # old_start is 1-indexed; convert to 0-indexed
-    pos = hunk.old_start - 1
+    # old_start is 1-indexed; convert to 0-indexed. A hunk that prepends to
+    # the file is spelled ``@@@ -0,0 +1,N @@@`` — a shape _parse_hunk_header
+    # explicitly accepts — and 0 - 1 = -1 would splice against the *end* of
+    # the list, inserting the new lines before the last one instead of the
+    # first. Clamp so a zero start means "before line 1".
+    pos = max(hunk.old_start - 1, 0)
     result = list(file_lines)
 
     # Verify context and deleted lines match

--- a/tests/test_tools/test_apply_patch_hunks.py
+++ b/tests/test_tools/test_apply_patch_hunks.py
@@ -1,0 +1,180 @@
+"""Hunk-splice behaviour of ``apply_patch``, including prepend hunks.
+
+``_parse_hunk_header`` accepts ``old_start == 0`` — it even has a dedicated
+default for ``old_count`` in that case — so ``@@@ -0,0 +1,N @@@`` is a
+supported way to prepend to a file. ``_apply_hunk`` converted that to
+``pos = -1`` and spliced ``result[:-1] + new + result[-1:]``, quietly writing
+the new lines *before the last line* instead of the first. These tests assert
+on the final file content, which is what protects the reverse-sort ordering
+in ``_apply_update`` too.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+
+import pytest
+
+from agentos.tools.builtin import patch as patch_tool
+from agentos.tools.types import ToolContext, current_tool_context
+
+
+def _original_async(fn: Callable[..., Awaitable[str]]) -> Callable[..., Awaitable[str]]:
+    return fn.__wrapped__.__wrapped__  # type: ignore[attr-defined, no-any-return]
+
+
+async def _apply(workspace: Path, patch_text: str) -> str:
+    token = current_tool_context.set(ToolContext(workspace_dir=str(workspace)))
+    try:
+        return await _original_async(patch_tool.apply_patch)(patch_text)
+    finally:
+        current_tool_context.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_prepend_hunk_inserts_at_the_top_of_the_file(tmp_path: Path) -> None:
+    target = tmp_path / "test.txt"
+    target.write_text("line1\nline2\nline3\n", encoding="utf-8")
+
+    result = await _apply(
+        tmp_path,
+        """*** Begin Patch
+*** Update File: test.txt
+@@@ -0,0 +1,1 @@@
++header
+*** End Patch""",
+    )
+
+    assert "1 file(s) modified" in result
+    assert target.read_text(encoding="utf-8") == "header\nline1\nline2\nline3\n"
+
+
+@pytest.mark.asyncio
+async def test_prepend_hunk_with_multiple_lines(tmp_path: Path) -> None:
+    target = tmp_path / "test.txt"
+    target.write_text("body\n", encoding="utf-8")
+
+    await _apply(
+        tmp_path,
+        """*** Begin Patch
+*** Update File: test.txt
+@@@ -0,0 +1,2 @@@
++first
++second
+*** End Patch""",
+    )
+
+    assert target.read_text(encoding="utf-8") == "first\nsecond\nbody\n"
+
+
+@pytest.mark.asyncio
+async def test_prepend_hunk_into_single_line_file(tmp_path: Path) -> None:
+    """The one-line file is where the ``-1`` splice looked most like success."""
+    target = tmp_path / "test.txt"
+    target.write_text("only\n", encoding="utf-8")
+
+    await _apply(
+        tmp_path,
+        """*** Begin Patch
+*** Update File: test.txt
+@@@ -0,0 +1,1 @@@
++header
+*** End Patch""",
+    )
+
+    assert target.read_text(encoding="utf-8") == "header\nonly\n"
+
+
+@pytest.mark.asyncio
+async def test_prepend_hunk_alongside_a_later_hunk_in_the_same_file(tmp_path: Path) -> None:
+    """Hunks apply in reverse ``old_start`` order — the prepend must land last."""
+    target = tmp_path / "test.txt"
+    target.write_text("line1\nline2\nline3\n", encoding="utf-8")
+
+    await _apply(
+        tmp_path,
+        """*** Begin Patch
+*** Update File: test.txt
+@@@ -0,0 +1,1 @@@
++header
+@@@ -3,1 +4,1 @@@
+-line3
++LINE3
+*** End Patch""",
+    )
+
+    assert target.read_text(encoding="utf-8") == "header\nline1\nline2\nLINE3\n"
+
+
+@pytest.mark.asyncio
+async def test_prepend_hunk_on_an_empty_file(tmp_path: Path) -> None:
+    target = tmp_path / "test.txt"
+    target.write_text("", encoding="utf-8")
+
+    await _apply(
+        tmp_path,
+        """*** Begin Patch
+*** Update File: test.txt
+@@@ -0,0 +1,1 @@@
++header
+*** End Patch""",
+    )
+
+    assert target.read_text(encoding="utf-8") == "header\n"
+
+
+@pytest.mark.asyncio
+async def test_ordinary_hunk_positions_are_unchanged(tmp_path: Path) -> None:
+    """The clamp must not shift any hunk that already had a 1-indexed start."""
+    target = tmp_path / "test.txt"
+    target.write_text("line1\nline2\nline3\n", encoding="utf-8")
+
+    await _apply(
+        tmp_path,
+        """*** Begin Patch
+*** Update File: test.txt
+@@@ -2,1 +2,1 @@@
+-line2
++LINE2
+*** End Patch""",
+    )
+
+    assert target.read_text(encoding="utf-8") == "line1\nLINE2\nline3\n"
+
+
+@pytest.mark.asyncio
+async def test_insert_after_first_line_still_uses_one_indexed_start(tmp_path: Path) -> None:
+    target = tmp_path / "test.txt"
+    target.write_text("line1\nline2\n", encoding="utf-8")
+
+    await _apply(
+        tmp_path,
+        """*** Begin Patch
+*** Update File: test.txt
+@@@ -1,1 +1,2 @@@
+ line1
++inserted
+*** End Patch""",
+    )
+
+    assert target.read_text(encoding="utf-8") == "line1\ninserted\nline2\n"
+
+
+def test_apply_hunk_clamps_a_zero_start_to_position_zero() -> None:
+    hunk = patch_tool.Hunk(old_start=0, old_count=0, new_start=1, new_count=1)
+    hunk.lines = ["+header"]
+
+    assert patch_tool._apply_hunk(["line1\n", "line2\n"], hunk) == [
+        "header\n",
+        "line1\n",
+        "line2\n",
+    ]
+
+
+def test_apply_hunk_zero_start_with_explicit_old_count_replaces_the_first_line() -> None:
+    """``-0,1`` names one existing line from position 0 — the first one."""
+    hunk = patch_tool.Hunk(old_start=0, old_count=1, new_start=1, new_count=1)
+    hunk.lines = ["-line1", "+LINE1"]
+
+    assert patch_tool._apply_hunk(["line1\n", "line2\n"], hunk) == ["LINE1\n", "line2\n"]


### PR DESCRIPTION
## Linked issue

Fixes #1166

- [x] This pull request fully resolves the linked issue.

## Summary

`_parse_hunk_header` **explicitly anticipates** `old_start == 0` — `patch.py:135`
reads

```python
old_count = int(m.group(2)) if m.group(2) is not None else (0 if old_start == 0 else 1)
```

so `@@@ -0,0 +1,N @@@` is a supported input shape. `_apply_hunk` then converted
it with `pos = hunk.old_start - 1`, giving `-1`, and the splice

```python
result[:pos] + new_lines + result[pos + hunk.old_count :]
```

resolved to `result[:-1] + new_lines + result[-1:]` — the new lines landed
**before the last line** of the file. The two functions disagreed about the
contract, and the tool reported `1 file(s) modified` and exited clean either
way.

The fix is the clamp the review note asked for rather than a prepend special
case:

```python
pos = max(hunk.old_start - 1, 0)
```

A zero start now means "before line 1". `-0,1` still names the first existing
line, and every 1-indexed hunk keeps the position it had — `old_start` cannot
be negative, the parser's `\d+` sees to that.

## Tests

New `tests/test_tools/test_apply_patch_hunks.py`, 9 tests. They assert on
**final file content** after `_apply_ops`, not on `_apply_hunk`'s return list,
which is what also covers the reverse-`old_start` ordering in `_apply_update`:

- The issue's exact repro: `line1/line2/line3` + `@@@ -0,0 +1,1 @@@ +header`
  → `header\nline1\nline2\nline3\n`.
- **A prepend combined with a later hunk in the same file**, as requested —
  hunks apply in reverse `old_start` order, so the prepend has to land last.
- Multi-line prepend, single-line file, and empty file (the cases where the
  `-1` splice looked most like success and so hid the bug).
- Two guards that ordinary hunks are unmoved: an in-place `-2,1` replacement
  and a `-1,1` insert-after-first-line.
- Unit-level `_apply_hunk` with `old_start=0`, both with the defaulted
  `old_count=0` and with an explicit `-0,1`.

Red before the fix / green after:

```
$ uv run pytest tests/test_tools/test_apply_patch_hunks.py -q   # before
4 failed, 5 passed
$ uv run pytest tests/test_tools/test_apply_patch_hunks.py -q   # after
9 passed
```

Full gate on this branch:

```
uv run ruff check src tests            # All checks passed!
uv run mypy src/agentos                # clean apart from the pre-existing mem0 stub error
uv run pytest -q                       # 3 failed, 9695 passed, 27 skipped
```

The 3 failures are the pre-existing environment ones (`mem0` installed
locally, `weasyprint`/pango missing) and reproduce identically on a clean tree.

## Merge-order independence

One of five PRs opened together (#1164, #1166, #1169, #1172, #1180). They
touch disjoint files except #1166/#1169, which touch different functions of
`tools/builtin/patch.py` about 45 lines apart. All 120 merge orderings
verified conflict-free locally, and the all-five merged tree passes the full
suite.

`CHANGELOG.md` is deliberately **not** touched: `[Unreleased]` is currently
empty, so five PRs each inserting a `### Fixed` block at the same line would
conflict with each other in every possible merge order. Happy to follow up
with a single `docs(changelog)` PR covering all five once they land (the same
shape as 38fbdb2), or to add the entry here if you would rather take the
conflict — just say which.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vCV6bdPciGkEywDSsyuGs
