### PR TITLE
fix(tools): apply patch operations atomically

### DIFF
--- a/src/agentos/tools/builtin/patch.py
+++ b/src/agentos/tools/builtin/patch.py
@@ -9,12 +9,16 @@ import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
+import structlog
+
 from agentos.identity.workspace import BOOTSTRAP_FILENAMES
 from agentos.sandbox.integration import sandboxed
 from agentos.tools.path_policy import reject_foreign_host_path
 from agentos.tools.registry import tool
 from agentos.tools.types import ToolError, current_tool_context
 from agentos.tools.write_tracking import record_workspace_file_write
+
+log = structlog.get_logger(__name__)
 
 # ---------------------------------------------------------------------------
 # Data structures
@@ -502,50 +506,160 @@ def _apply_hunk(file_lines: list[str], hunk: Hunk) -> list[str]:
     return result[:pos] + new_lines + result[pos + hunk.old_count :]
 
 
-def _apply_update(path: str, hunks: list[Hunk], root: Path | None = None) -> None:
-    resolved = _validate_path(path, root)
-    if not resolved.exists():
-        raise FileNotFoundError(f"File not found for update: {path}")
-
-    text = resolved.read_text(encoding="utf-8")
+def _updated_text(text: str, hunks: list[Hunk]) -> str:
+    """Return *text* with every hunk applied, without touching the filesystem."""
     lines = text.splitlines(keepends=True)
-
     # Apply hunks in reverse order so earlier line numbers stay valid
     for hunk in sorted(hunks, key=lambda h: h.old_start, reverse=True):
         lines = _apply_hunk(lines, hunk)
-
-    resolved.write_text("".join(lines), encoding="utf-8")
-
-
-def _apply_add(path: str, content: str, root: Path | None = None) -> None:
-    resolved = _validate_path(path, root)
-    if resolved.exists():
-        raise FileExistsError(f"File already exists: {path}")
-    resolved.parent.mkdir(parents=True, exist_ok=True)
-    resolved.write_text(content, encoding="utf-8")
+    return "".join(lines)
 
 
-def _apply_delete(path: str, root: Path | None = None) -> None:
-    resolved = _validate_path(path, root)
-    if not resolved.exists():
-        raise FileNotFoundError(f"File not found for deletion: {path}")
-    resolved.unlink()
+@dataclass
+class _StagedOp:
+    """One fully resolved operation, ready to be written verbatim."""
+
+    label: str  # "Add File: path" — names the op in any failure message
+    path: Path
+    content: str | None  # None means "delete this path"
+
+
+def _op_label(op: PatchOp) -> str:
+    if isinstance(op, AddFile):
+        return f"Add File: {op.path}"
+    if isinstance(op, UpdateFile):
+        return f"Update File: {op.path}"
+    return f"Delete File: {op.path}"
+
+
+def _plan_ops(
+    ops: list[PatchOp], root: Path | None = None
+) -> tuple[list[_StagedOp], tuple[int, int, int]]:
+    """Resolve and dry-run every operation in memory.
+
+    Nothing is written here, so a patch whose third op has a bad context is
+    rejected before its first op reaches disk. ``pending`` carries the state
+    an earlier op in the same patch would have produced, so an ``Add`` followed
+    by an ``Update`` of the same file still composes the way sequential
+    application did.
+    """
+    staged: list[_StagedOp] = []
+    pending: dict[Path, str | None] = {}
+    added = modified = deleted = 0
+
+    def _will_exist(resolved: Path) -> bool:
+        """Whether the path exists once the ops before this one have run."""
+        if resolved in pending:
+            return pending[resolved] is not None
+        return resolved.exists()
+
+    for op in ops:
+        label = _op_label(op)
+        try:
+            resolved = _validate_path(op.path, root)
+            content: str | None
+            if isinstance(op, AddFile):
+                if _will_exist(resolved):
+                    raise FileExistsError(f"File already exists: {op.path}")
+                content = op.content
+                added += 1
+            elif isinstance(op, UpdateFile):
+                if not _will_exist(resolved):
+                    raise FileNotFoundError(f"File not found for update: {op.path}")
+                # Only an update needs the text; an add/delete of a file this
+                # tool never decodes must not start failing on bad UTF-8.
+                current = pending.get(resolved) if resolved in pending else None
+                if current is None:
+                    current = resolved.read_text(encoding="utf-8")
+                content = _updated_text(current, op.hunks)
+                modified += 1
+            else:
+                if not _will_exist(resolved):
+                    raise FileNotFoundError(f"File not found for deletion: {op.path}")
+                content = None
+                deleted += 1
+        except ToolError:
+            raise
+        except (OSError, ValueError) as exc:
+            # Keep the exception type — callers and tests distinguish
+            # FileNotFoundError from ValueError — but say which op failed.
+            raise type(exc)(f"{label}: {exc}") from exc
+
+        staged.append(_StagedOp(label=label, path=resolved, content=content))
+        pending[resolved] = content
+
+    return staged, (added, modified, deleted)
+
+
+def _missing_ancestors(path: Path) -> list[Path]:
+    """Directories that would have to be created for *path* to be writable."""
+    created: list[Path] = []
+    parent = path.parent
+    while not parent.exists() and parent != parent.parent:
+        created.append(parent)
+        parent = parent.parent
+    return created
+
+
+def _commit_staged(staged: list[_StagedOp]) -> None:
+    """Write every staged op, restoring the originals if any write fails.
+
+    Planning has already ruled out the predictable failures; this rollback
+    covers what it cannot see — a permission change, a full disk, a path that
+    became a directory between plan and commit.
+    """
+    backups: dict[Path, bytes | None] = {}
+    new_dirs: list[Path] = []
+    current: _StagedOp | None = None
+    try:
+        for item in staged:
+            current = item
+            if item.path not in backups:
+                backups[item.path] = item.path.read_bytes() if item.path.is_file() else None
+            if item.content is None:
+                item.path.unlink()
+                continue
+            new_dirs.extend(reversed(_missing_ancestors(item.path)))
+            item.path.parent.mkdir(parents=True, exist_ok=True)
+            item.path.write_text(item.content, encoding="utf-8")
+    except OSError as exc:
+        _restore(backups, new_dirs)
+        label = current.label if current is not None else "patch"
+        raise type(exc)(f"{label}: {exc}") from exc
+
+
+def _restore(backups: dict[Path, bytes | None], new_dirs: list[Path]) -> None:
+    """Best-effort undo of a partially committed batch."""
+    for path, original in backups.items():
+        try:
+            if original is None:
+                if path.is_file():
+                    path.unlink()
+            else:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(original)
+        except OSError:  # pragma: no cover - rollback is best effort
+            log.warning("patch.rollback_failed", path=str(path))
+    for directory in reversed(new_dirs):
+        try:
+            directory.rmdir()
+        except OSError:  # non-empty or already gone — leave it
+            break
 
 
 def _apply_ops(ops: list[PatchOp], root: Path | None = None) -> tuple[int, int, int]:
-    """Execute all patch operations. Returns (added, modified, deleted) counts."""
-    added = modified = deleted = 0
-    for op in ops:
-        if isinstance(op, AddFile):
-            _apply_add(op.path, op.content, root)
-            added += 1
-        elif isinstance(op, UpdateFile):
-            _apply_update(op.path, op.hunks, root)
-            modified += 1
-        elif isinstance(op, DeleteFile):
-            _apply_delete(op.path, root)
-            deleted += 1
-    return added, modified, deleted
+    """Execute all patch operations atomically.
+
+    Every operation is resolved and dry-run first, so a failure anywhere in
+    the batch leaves the workspace untouched — and, because the exception is
+    raised before ``apply_patch``'s post-write hooks are skipped, the runtime's
+    view of the filesystem cannot drift from what is actually on disk.
+
+    Returns (added, modified, deleted) counts.
+    """
+    staged, counts = _plan_ops(ops, root)
+    _commit_staged(staged)
+    return counts
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tools/test_apply_patch_atomicity.py
+++ b/tests/test_tools/test_apply_patch_atomicity.py
@@ -1,0 +1,288 @@
+"""``apply_patch`` is all-or-nothing across the operations in one patch.
+
+``_apply_ops`` used to write each op to disk as it iterated, so a patch whose
+second op had a bad context left the first one committed — and because the
+exception escaped ``apply_patch`` before its post-write hooks ran, the runtime's
+record of what had been written disagreed with the filesystem. Every op is now
+resolved and dry-run in memory first.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+
+import pytest
+
+from agentos.tools.builtin import patch as patch_tool
+from agentos.tools.types import ToolContext, current_tool_context
+
+
+def _original_async(fn: Callable[..., Awaitable[str]]) -> Callable[..., Awaitable[str]]:
+    return fn.__wrapped__.__wrapped__  # type: ignore[attr-defined, no-any-return]
+
+
+async def _apply(workspace: Path, patch_text: str) -> str:
+    token = current_tool_context.set(ToolContext(workspace_dir=str(workspace)))
+    try:
+        return await _original_async(patch_tool.apply_patch)(patch_text)
+    finally:
+        current_tool_context.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_add_is_not_committed_when_a_later_update_fails(tmp_path: Path) -> None:
+    (tmp_path / "file2.txt").write_text("real content\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Context mismatch"):
+        await _apply(
+            tmp_path,
+            """*** Begin Patch
+*** Add File: file1.txt
++new file content
+*** Update File: file2.txt
+@@@ -1,1 +1,1 @@@
+-nonexistent context
++replacement
+*** End Patch""",
+        )
+
+    assert not (tmp_path / "file1.txt").exists()
+    assert (tmp_path / "file2.txt").read_text(encoding="utf-8") == "real content\n"
+
+
+@pytest.mark.asyncio
+async def test_add_is_not_committed_when_a_later_update_targets_a_missing_file(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(FileNotFoundError, match="File not found for update"):
+        await _apply(
+            tmp_path,
+            """*** Begin Patch
+*** Add File: file1.txt
++new file content
+*** Update File: missing.txt
+@@@ -1,1 +1,1 @@@
+-a
++b
+*** End Patch""",
+        )
+
+    assert not (tmp_path / "file1.txt").exists()
+
+
+@pytest.mark.asyncio
+async def test_earlier_update_is_rolled_back_when_a_later_delete_fails(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "keep.txt"
+    target.write_text("original\n", encoding="utf-8")
+
+    with pytest.raises(FileNotFoundError, match="File not found for deletion"):
+        await _apply(
+            tmp_path,
+            """*** Begin Patch
+*** Update File: keep.txt
+@@@ -1,1 +1,1 @@@
+-original
++changed
+*** Delete File: gone.txt
+*** End Patch""",
+        )
+
+    assert target.read_text(encoding="utf-8") == "original\n"
+
+
+@pytest.mark.asyncio
+async def test_delete_is_not_committed_when_a_later_add_collides(tmp_path: Path) -> None:
+    doomed = tmp_path / "doomed.txt"
+    doomed.write_text("still here\n", encoding="utf-8")
+    (tmp_path / "taken.txt").write_text("occupied\n", encoding="utf-8")
+
+    with pytest.raises(FileExistsError, match="File already exists"):
+        await _apply(
+            tmp_path,
+            """*** Begin Patch
+*** Delete File: doomed.txt
+*** Add File: taken.txt
++clobber
+*** End Patch""",
+        )
+
+    assert doomed.read_text(encoding="utf-8") == "still here\n"
+    assert (tmp_path / "taken.txt").read_text(encoding="utf-8") == "occupied\n"
+
+
+@pytest.mark.asyncio
+async def test_failure_message_names_the_operation_that_failed(tmp_path: Path) -> None:
+    (tmp_path / "file2.txt").write_text("real content\n", encoding="utf-8")
+
+    with pytest.raises(ValueError) as excinfo:
+        await _apply(
+            tmp_path,
+            """*** Begin Patch
+*** Add File: file1.txt
++new file content
+*** Update File: file2.txt
+@@@ -1,1 +1,1 @@@
+-nonexistent context
++replacement
+*** End Patch""",
+        )
+
+    message = str(excinfo.value)
+    assert message.startswith("Update File: file2.txt: ")
+    assert "Context mismatch" in message
+
+
+@pytest.mark.asyncio
+async def test_no_directory_is_left_behind_by_a_failed_nested_add(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        await _apply(
+            tmp_path,
+            """*** Begin Patch
+*** Add File: nested/deep/file1.txt
++content
+*** Delete File: gone.txt
+*** End Patch""",
+        )
+
+    assert not (tmp_path / "nested").exists()
+
+
+@pytest.mark.asyncio
+async def test_a_fully_valid_multi_op_patch_still_applies_every_operation(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "update_me.txt").write_text("before\n", encoding="utf-8")
+    (tmp_path / "delete_me.txt").write_text("bye\n", encoding="utf-8")
+
+    result = await _apply(
+        tmp_path,
+        """*** Begin Patch
+*** Add File: nested/added.txt
++added
+*** Update File: update_me.txt
+@@@ -1,1 +1,1 @@@
+-before
++after
+*** Delete File: delete_me.txt
+*** End Patch""",
+    )
+
+    assert "1 file(s) added" in result
+    assert "1 file(s) modified" in result
+    assert "1 file(s) deleted" in result
+    assert (tmp_path / "nested" / "added.txt").read_text(encoding="utf-8") == "added"
+    assert (tmp_path / "update_me.txt").read_text(encoding="utf-8") == "after\n"
+    assert not (tmp_path / "delete_me.txt").exists()
+
+
+@pytest.mark.asyncio
+async def test_an_add_then_update_of_the_same_file_still_composes(tmp_path: Path) -> None:
+    """Planning is sequential: the update must see what the add would write."""
+    result = await _apply(
+        tmp_path,
+        """*** Begin Patch
+*** Add File: staged.txt
++first
+*** Update File: staged.txt
+@@@ -1,1 +1,1 @@@
+-first
++second
+*** End Patch""",
+    )
+
+    assert "1 file(s) added" in result
+    assert (tmp_path / "staged.txt").read_text(encoding="utf-8") == "second\n"
+
+
+@pytest.mark.asyncio
+async def test_an_add_after_a_delete_of_the_same_path_is_allowed(tmp_path: Path) -> None:
+    target = tmp_path / "swap.txt"
+    target.write_text("old\n", encoding="utf-8")
+
+    await _apply(
+        tmp_path,
+        """*** Begin Patch
+*** Delete File: swap.txt
+*** Add File: swap.txt
++new
+*** End Patch""",
+    )
+
+    assert target.read_text(encoding="utf-8") == "new"
+
+
+@pytest.mark.asyncio
+async def test_an_update_after_a_delete_of_the_same_path_is_rejected(tmp_path: Path) -> None:
+    target = tmp_path / "swap.txt"
+    target.write_text("old\n", encoding="utf-8")
+
+    with pytest.raises(FileNotFoundError, match="File not found for update"):
+        await _apply(
+            tmp_path,
+            """*** Begin Patch
+*** Delete File: swap.txt
+*** Update File: swap.txt
+@@@ -1,1 +1,1 @@@
+-old
++new
+*** End Patch""",
+        )
+
+    assert target.read_text(encoding="utf-8") == "old\n"
+
+
+@pytest.mark.asyncio
+async def test_write_tracking_matches_disk_after_a_successful_patch(tmp_path: Path) -> None:
+    """The post-write hooks only ever describe a batch that actually landed."""
+    recorded: list[str] = []
+    original = patch_tool.record_workspace_file_write
+
+    def _spy(path: str) -> None:
+        recorded.append(path)
+
+    patch_tool.record_workspace_file_write = _spy  # type: ignore[assignment]
+    try:
+        await _apply(
+            tmp_path,
+            """*** Begin Patch
+*** Add File: tracked.txt
++tracked
+*** End Patch""",
+        )
+        before_failure = list(recorded)
+        recorded.clear()
+
+        with pytest.raises(FileNotFoundError):
+            await _apply(
+                tmp_path,
+                """*** Begin Patch
+*** Add File: untracked.txt
++untracked
+*** Delete File: gone.txt
+*** End Patch""",
+            )
+    finally:
+        patch_tool.record_workspace_file_write = original  # type: ignore[assignment]
+
+    assert before_failure  # the successful patch was recorded
+    # The failed patch recorded nothing and wrote nothing.
+    assert recorded == []
+    assert not (tmp_path / "untracked.txt").exists()
+
+
+def test_plan_ops_writes_nothing_on_its_own(tmp_path: Path) -> None:
+    ops = patch_tool._parse_patch(
+        """*** Begin Patch
+*** Add File: planned.txt
++planned
+*** End Patch"""
+    )
+
+    staged, counts = patch_tool._plan_ops(ops, tmp_path)
+
+    assert counts == (1, 0, 0)
+    assert [item.label for item in staged] == ["Add File: planned.txt"]
+    assert not (tmp_path / "planned.txt").exists()


### PR DESCRIPTION
## Linked issue

Fixes #1169

- [x] This pull request fully resolves the linked issue.

## Summary

`_apply_ops` wrote each operation to disk as it iterated, so a patch whose
second op failed left the first one committed. The second half of the report is
the part I optimised for: because the exception escapes `apply_patch` before
`patch.py:597-599`, `_record_workspace_file_writes`,
`_notify_memory_source_writes` and `_notify_bootstrap_source_writes` are all
skipped — the filesystem is mutated while the runtime's view of it is not, so
artifact delivery and memory indexing silently disagree with disk.

**Pre-validation over rollback, as far as it goes** — per the design note:

- `_plan_ops` resolves every op and runs every hunk **in memory** before
  anything is written, so the predictable failures (missing file, existing
  file, context mismatch) are raised with a clean workspace.
- A `pending` overlay carries what an earlier op in the same patch would have
  produced, so `Add` → `Update` of the same path still composes exactly the way
  sequential application did, and `Delete` → `Add` of the same path still works.
- `_commit_staged` is the staged fallback for what planning *cannot* see — a
  permission change, a full disk, a path that became a directory between plan
  and commit. It snapshots each target before touching it and restores the
  whole batch, including removing directories it created, if any write fails.

**Which op failed is now in the message**, since the `ValueError` text is the
only diagnostic users get:

```
Update File: file2.txt: Context mismatch at line 1: expected 'nonexistent context', got 'real content'
```

The exception *type* is preserved (`raise type(exc)(...) from exc`), so callers
and tests that distinguish `FileNotFoundError` from `ValueError` still can, and
`match=` assertions still match.

One deliberate detail: only an `Update` decodes the file. An `Add` or `Delete`
of a file this tool never reads as text must not start failing on bad UTF-8, so
existence checks go through `_will_exist` rather than a read.

`_apply_add`/`_apply_update`/`_apply_delete` are folded into the plan/commit
pair; nothing outside this module referenced them.

## Tests

New `tests/test_tools/test_apply_patch_atomicity.py`, 12 tests, driven through
the real `apply_patch` entry point:

- The issue's exact repro — `Add file1.txt` + `Update file2.txt` with bad
  context — and the missing-target variant: `file1.txt` must not exist
  afterwards.
- Rollback of an earlier `Update` when a later `Delete` fails, and of an
  earlier `Delete` when a later `Add` collides.
- The failure message names the op (`startswith("Update File: file2.txt: ")`).
- No directory left behind by a failed nested `Add`.
- A fully valid three-op patch still adds, modifies and deletes.
- Composition: `Add` → `Update` of the same path composes; `Delete` → `Add`
  is allowed; `Delete` → `Update` is rejected and the original survives.
- The post-write hooks only ever describe a batch that actually landed —
  `record_workspace_file_write` records nothing for a failed patch.
- `_plan_ops` on its own writes nothing.

Red before the fix / green after:

```
$ uv run pytest tests/test_tools/test_apply_patch_atomicity.py -q   # before
9 failed, 3 passed
$ uv run pytest tests/test_tools/test_apply_patch_atomicity.py -q   # after
12 passed
```

Full gate on this branch:

```
uv run ruff check src tests            # All checks passed!
uv run mypy src/agentos                # clean apart from the pre-existing mem0 stub error
uv run pytest -q                       # 3 failed, 9699 passed, 26 skipped
```

The 3 failures are the pre-existing environment ones (`mem0` installed
locally, `weasyprint`/pango missing) and reproduce identically on a clean tree.
The whole existing `tests/test_tools` suite (1033 tests) passes unchanged.

## Merge-order independence

One of five PRs opened together (#1164, #1166, #1169, #1172, #1180). They
touch disjoint files except #1166/#1169, which touch different functions of
`tools/builtin/patch.py` about 45 lines apart. All 120 merge orderings
verified conflict-free locally, and the all-five merged tree passes the full
suite.

`CHANGELOG.md` is deliberately **not** touched: `[Unreleased]` is currently
empty, so five PRs each inserting a `### Fixed` block at the same line would
conflict with each other in every possible merge order. Happy to follow up
with a single `docs(changelog)` PR covering all five once they land (the same
shape as 38fbdb2), or to add the entry here if you would rather take the
conflict — just say which.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vCV6bdPciGkEywDSsyuGs
