### PR TITLE
fix(gateway): skip reservation tokens when cancelling in-flight tasks

### DIFF
--- a/src/agentos/gateway/channel_dispatch.py
+++ b/src/agentos/gateway/channel_dispatch.py
@@ -155,7 +155,10 @@ class _ChannelInFlightSet:
 
     def __init__(self, cap: int) -> None:
         self._cap = cap
-        self._tasks: set[asyncio.Task[Any]] = set()
+        # Holds real tasks *and* the bare reservation tokens ``try_acquire``
+        # parks here to make the cap check atomic. Anything that treats a
+        # member as a task has to filter first.
+        self._tasks: set[asyncio.Task[Any] | object] = set()
 
     @property
     def cap(self) -> int:
@@ -178,18 +181,26 @@ class _ChannelInFlightSet:
         runs on a single thread, this check-then-add pair is atomic — no await
         occurs between the guard and the mutation.
         """
-        if len(self._tasks) >= self._cap:  # type: ignore[arg-type]
+        if len(self._tasks) >= self._cap:
             return False
-        self._tasks.add(token)  # type: ignore[arg-type]
+        self._tasks.add(token)
         return True
 
     def release(self, token: object) -> None:
         """Release a reservation previously acquired via try_acquire."""
-        self._tasks.discard(token)  # type: ignore[arg-type]
+        self._tasks.discard(token)
 
     async def cancel_all(self) -> None:
-        """Cancel every in-flight task and await completion (for shutdown)."""
-        tasks = list(self._tasks)
+        """Cancel every in-flight task and await completion (for shutdown).
+
+        The set also holds the bare ``object()`` reservation tokens parked by
+        ``try_acquire``, which have no ``cancel``. Cancelling them raised
+        ``AttributeError`` mid-loop, so the tasks after the token were never
+        cancelled and the ``gather`` never ran — a shutdown that left real
+        work running. Filter to actual tasks, then clear the whole set so the
+        reservations do not leak either.
+        """
+        tasks = [t for t in self._tasks if isinstance(t, asyncio.Task)]
         for t in tasks:
             t.cancel()
         if tasks:

--- a/tests/test_gateway/test_channel_concurrent_dispatch.py
+++ b/tests/test_gateway/test_channel_concurrent_dispatch.py
@@ -296,6 +296,79 @@ async def test_close_cancels_inflight() -> None:
     assert all(t.done() for t in tasks), "all tasks must be done after cancel_all"
 
 
+@pytest.mark.asyncio
+async def test_cancel_all_handles_reservation_tokens_alongside_tasks() -> None:
+    """A bare reservation token must not abort the shutdown loop.
+
+    ``try_acquire`` parks a plain ``object()`` in the same set as the real
+    tasks. ``cancel_all`` used to call ``.cancel()`` on every member, so the
+    token raised ``AttributeError`` and every task after it in iteration order
+    was left running.
+    """
+    ifs = _ChannelInFlightSet(cap=8)
+
+    cancelled: list[str] = []
+
+    async def _long_running(label: str) -> None:
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancelled.append(label)
+            raise
+
+    tasks = [asyncio.create_task(_long_running(str(i))) for i in range(3)]
+    for task in tasks:
+        ifs.add(task)
+    # Interleave several tokens so no iteration order can dodge them.
+    tokens = [object() for _ in range(3)]
+    for token in tokens:
+        assert ifs.try_acquire(token)
+
+    await asyncio.sleep(0)
+
+    await ifs.cancel_all()
+
+    assert sorted(cancelled) == ["0", "1", "2"]
+    assert all(t.done() for t in tasks)
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_clears_reservation_tokens() -> None:
+    """Shutdown must not leave reservations occupying the cap."""
+    ifs = _ChannelInFlightSet(cap=2)
+    assert ifs.try_acquire(object())
+    assert ifs.try_acquire(object())
+    assert ifs.full()
+
+    await ifs.cancel_all()
+
+    assert not ifs.full()
+    assert ifs.try_acquire(object())
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_on_a_reservation_only_set_is_a_no_op() -> None:
+    ifs = _ChannelInFlightSet(cap=4)
+    assert ifs.try_acquire(object())
+
+    await ifs.cancel_all()  # must not raise
+
+    assert not ifs.full()
+
+
+def test_reservation_tokens_count_toward_the_cap() -> None:
+    """The token's whole purpose — the cap check must still see it."""
+    ifs = _ChannelInFlightSet(cap=1)
+    token = object()
+
+    assert ifs.try_acquire(token)
+    assert ifs.full()
+    assert not ifs.try_acquire(object())
+
+    ifs.release(token)
+    assert not ifs.full()
+
+
 # ── typing_keepalive lifecycle bound to reply task ──────────────────────────
 
 


### PR DESCRIPTION
## Linked issue

Fixes #1172

- [x] This pull request fully resolves the linked issue.

## Summary

`try_acquire` parks a bare `object()` in `self._tasks` to make the cap check
atomic, and the `# type: ignore[arg-type]` on that insert was the set knowingly
violating its own `set[asyncio.Task[Any]]` annotation. `cancel_all` then called
`.cancel()` on every member, so the token raised
`AttributeError: 'object' object has no attribute 'cancel'` partway through the
loop — which aborted the remaining cancellations **and** the `gather`, leaving
real work running through a shutdown. `_dispatch` calls
`try_acquire(_reservation_token)` with a bare `object()` at line 850, so the
path is live.

Filtered rather than `hasattr`-checked, as the review note asked:

```python
tasks = [t for t in self._tasks if isinstance(t, asyncio.Task)]
```

`self._tasks.clear()` at the end was already there and stays, so reservations do
not leak into the next cap check either. The annotation is widened to
`set[asyncio.Task[Any] | object]` to say what the set actually holds, which lets
all three `# type: ignore[arg-type]` comments go — the ignore was the symptom,
not the fix.

On the longer-term point: the cap-counting and the task-tracking really are two
jobs sharing one set. This PR keeps them sharing it but stops the sharing from
being a lie to the type checker; splitting them is a bigger change than a p2
crash fix should carry, and I'd rather do it as its own PR if you want it.

## Tests

Four tests appended to `tests/test_gateway/test_channel_concurrent_dispatch.py`:

- **Three real tasks interleaved with three reservation tokens** — `cancel_all`
  completes and every task is cancelled, so no iteration order can dodge the
  bug.
- `cancel_all` clears reservations: a cap-2 set full of tokens accepts a new
  reservation afterwards.
- `cancel_all` on a reservation-only set does not raise.
- The token still counts toward the cap and `release` frees it — the guard for
  the behaviour the filter must not break.

Red before the fix / green after:

```
$ uv run pytest tests/test_gateway/test_channel_concurrent_dispatch.py -q   # before
3 failed, 23 passed        # AttributeError: 'object' object has no attribute 'cancel'
$ uv run pytest tests/test_gateway/test_channel_concurrent_dispatch.py -q   # after
26 passed
```

Full gate on this branch:

```
uv run ruff check src tests            # All checks passed!
uv run mypy src/agentos                # clean apart from the pre-existing mem0 stub error
uv run pytest -q                       # 3 failed, 9690 passed, 27 skipped
```

The 3 failures are the pre-existing environment ones (`mem0` installed
locally, `weasyprint`/pango missing) and reproduce identically on a clean tree.

## Merge-order independence

One of five PRs opened together (#1164, #1166, #1169, #1172, #1180). They
touch disjoint files except #1166/#1169, which touch different functions of
`tools/builtin/patch.py` about 45 lines apart. All 120 merge orderings
verified conflict-free locally, and the all-five merged tree passes the full
suite.

`CHANGELOG.md` is deliberately **not** touched: `[Unreleased]` is currently
empty, so five PRs each inserting a `### Fixed` block at the same line would
conflict with each other in every possible merge order. Happy to follow up
with a single `docs(changelog)` PR covering all five once they land (the same
shape as 38fbdb2), or to add the entry here if you would rather take the
conflict — just say which.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vCV6bdPciGkEywDSsyuGs
