### PR TITLE
fix(cli): quote printed command hints for the platform they will be pasted into

### DIFF
--- a/src/agentos/cli/doctor_cmd.py
+++ b/src/agentos/cli/doctor_cmd.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import copy
 import os
-import shlex
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -17,6 +16,7 @@ from rich.table import Table
 from agentos.cli.gateway_rpc import default_gateway_url, gateway_url_from_config
 from agentos.cli.output import print_json
 from agentos.cli.url_utils import normalize_gateway_url
+from agentos.cli_quoting import config_cli_arg, quote_cli_arg
 from agentos.health.model import FixStep, HealthFinding, build_report
 from agentos.health.recovery_commands import command_with_config as _command_with_config
 
@@ -27,7 +27,7 @@ _API_KEY_PLACEHOLDER = "YOUR_API_KEY"
 def _config_option(config_path: str | Path | None) -> str:
     if config_path is None:
         return ""
-    return f" --config {shlex.quote(str(config_path))}"
+    return config_cli_arg(config_path)
 
 
 def _onboard_status_command(config_path: str | Path | None) -> str:
@@ -48,7 +48,7 @@ def _gateway_commands(
     host = parsed.hostname or "127.0.0.1"
     port = parsed.port or (443 if parsed.scheme == "wss" else 18791)
     if host not in _LOCAL_GATEWAY_HOSTS:
-        remote_target = shlex.quote(gateway_url)
+        remote_target = quote_cli_arg(gateway_url)
         return [
             {
                 "label": "Inspect remote gateway",

--- a/src/agentos/cli/gateway_cmd.py
+++ b/src/agentos/cli/gateway_cmd.py
@@ -19,6 +19,7 @@ from agentos.cli.gateway_lifecycle import (
     remote_gateway_status,
 )
 from agentos.cli.ui import ACCENT_MARKUP, console
+from agentos.cli_quoting import config_cli_arg
 from agentos.gateway.boot import start_gateway_server
 from agentos.gateway.config import GatewayConfig, is_public_bind, resolve_listen_address
 from agentos.gateway.config_persist import read_raw_bind_overrides, set_runtime_overrides
@@ -167,7 +168,8 @@ def run_gateway(
             console.print(f"{entry['label']}: {entry['command']}")
         if config.config_path:
             console.print(
-                f"Inspect onboarding: agentos onboard status --config {config.config_path}"
+                "Inspect onboarding: agentos onboard status"
+                f"{config_cli_arg(config.config_path)}"
             )
         raise typer.Exit(code=1) from exc
     except KeyboardInterrupt:

--- a/src/agentos/cli/onboard_cmd.py
+++ b/src/agentos/cli/onboard_cmd.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json as _json
-import shlex
 import tomllib
 from pathlib import Path
 
@@ -21,6 +20,7 @@ from agentos.cli.ui import (
     markup_escape,
     warning_panel,
 )
+from agentos.cli_quoting import config_cli_arg
 from agentos.onboarding.config_store import load_config, resolve_config_path
 from agentos.onboarding.flow import (
     OnboardOptions,
@@ -229,7 +229,7 @@ def _status_cockpit_summary(status: OnboardingStatus) -> str:
 def _config_cli_arg(config_path: Path | None) -> str:
     if config_path is None:
         return ""
-    return f" --config {shlex.quote(str(config_path))}"
+    return config_cli_arg(config_path)
 
 
 def _headless_section_paths(

--- a/src/agentos/cli_quoting.py
+++ b/src/agentos/cli_quoting.py
@@ -1,0 +1,49 @@
+"""Platform-aware quoting for commands AgentOS prints as copy-pasteable hints.
+
+Every "next step" line the CLI prints is meant to be pasted straight back into
+the user's shell. ``shlex.quote`` only knows POSIX rules, so on Windows a path
+with a space came back single-quoted — ``--config 'C:\\Users\\John Doe\\x.toml'``
+— which neither ``cmd.exe`` nor PowerShell parses as one argument. Windows is
+also where user profiles with spaces are most common, so that hint failed
+exactly where it was needed most.
+
+Hints are the only thing quoted here. Commands AgentOS *executes* build an
+argv list and never go through a shell.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+from pathlib import Path
+
+# Anything that makes a Windows shell split or reinterpret a bare token:
+# whitespace, the quote characters, the ``cmd.exe`` metacharacters
+# (``^ & | < > ( ) % !``) and the PowerShell ones (``$ ` { } [ ] ; , = @``).
+_WINDOWS_SPECIAL = frozenset(" \t\n\"'`^&|<>()[]{};,=$!%@")
+
+
+def _is_windows_shell() -> bool:
+    """Which shell family the reader is most likely pasting into."""
+    return os.name == "nt"
+
+
+def quote_cli_arg(value: str) -> str:
+    """Quote *value* for the shell the reader is most likely to paste into."""
+    if not _is_windows_shell():
+        return shlex.quote(value)
+    if not value:
+        return '""'
+    if not any(char in _WINDOWS_SPECIAL for char in value):
+        return value
+    # A Windows filename cannot contain ``"``, so the replacement only guards
+    # hand-written values; ``""`` is the literal-quote spelling both cmd.exe
+    # and PowerShell accept inside a double-quoted string.
+    return '"' + value.replace('"', '""') + '"'
+
+
+def config_cli_arg(config_path: str | Path | None) -> str:
+    """Render the ``--config <path>`` suffix, or ``""`` when there is no path."""
+    if not config_path:
+        return ""
+    return f" --config {quote_cli_arg(str(config_path))}"

--- a/src/agentos/health/evaluator.py
+++ b/src/agentos/health/evaluator.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import shlex
 from typing import Any
 
+from agentos.cli_quoting import quote_cli_arg
 from agentos.health.control_ui import BUILD_CMD
 from agentos.health.model import FixStep, HealthFinding
 
@@ -39,7 +39,7 @@ def _int_from_payload(payload: dict[str, Any], *keys: str) -> int:
 
 
 def _command_arg(value: str) -> str:
-    return shlex.quote(value)
+    return quote_cli_arg(value)
 
 
 def _diagnostic_incomplete(

--- a/src/agentos/health/recovery_commands.py
+++ b/src/agentos/health/recovery_commands.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import shlex
 from pathlib import Path
+
+from agentos.cli_quoting import config_cli_arg
 
 CONFIG_AWARE_COMMAND_PREFIXES = (
     "agentos gateway restart",
@@ -36,4 +37,4 @@ def supports_config_option(command: str) -> bool:
 def command_with_config(command: str, config_path: str | Path | None) -> str:
     if not config_path or " --config " in command or not supports_config_option(command):
         return command
-    return f"{command} --config {shlex.quote(str(config_path))}"
+    return f"{command}{config_cli_arg(config_path)}"

--- a/src/agentos/onboarding/flow.py
+++ b/src/agentos/onboarding/flow.py
@@ -6,12 +6,12 @@ import importlib
 import importlib.util
 import os
 import re
-import shlex
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
+from agentos.cli_quoting import config_cli_arg
 from agentos.onboarding.channel_specs import (
     ChannelSetupField,
     ChannelSetupSpec,
@@ -205,7 +205,7 @@ def run_noninteractive_search_configure(
 def _config_cli_arg(config_path: str | Path | None) -> str:
     if config_path is None:
         return ""
-    return f" --config {shlex.quote(str(config_path))}"
+    return config_cli_arg(config_path)
 
 
 def _first_blocking_setup_section(cfg: Any) -> str:

--- a/src/agentos/onboarding/next_steps.py
+++ b/src/agentos/onboarding/next_steps.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import os
 import platform
-import shlex
 from pathlib import Path
 from typing import Any
 
+from agentos.cli_quoting import config_cli_arg
 from agentos.onboarding.image_generation_specs import (
     get_image_generation_provider_setup_spec,
 )
@@ -165,9 +165,7 @@ def _missing_env_warning(surface: str, env_key: str) -> str:
 
 
 def _config_cli_arg(config_path: str | Path | None) -> str:
-    if not config_path:
-        return ""
-    return f" --config {shlex.quote(str(config_path))}"
+    return config_cli_arg(config_path)
 
 
 def _image_generation_provider_id(config: Any) -> str:

--- a/tests/test_cli/test_cli_quoting.py
+++ b/tests/test_cli/test_cli_quoting.py
@@ -1,0 +1,202 @@
+"""Platform-aware quoting for the commands AgentOS prints as hints.
+
+The hints are meant to be pasted straight back into the user's shell.
+``shlex.quote`` is POSIX-only, so on Windows a path with a space came back
+single-quoted — ``--config 'C:\\Program Files\\Agent OS\\custom.toml'`` — which
+neither ``cmd.exe`` nor PowerShell parses as one argument. These tests pin both
+platforms by driving ``os.name`` directly, so the Windows behaviour is
+covered on every CI leg rather than only the Windows one.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from agentos import cli_quoting
+from agentos.cli_quoting import config_cli_arg, quote_cli_arg
+
+WINDOWS_PATH = r"C:\Program Files\Agent OS\custom.toml"
+
+
+@pytest.fixture
+def on_windows(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli_quoting, "_is_windows_shell", lambda: True)
+
+
+@pytest.fixture
+def on_posix(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli_quoting, "_is_windows_shell", lambda: False)
+
+
+def test_windows_path_with_spaces_uses_double_quotes(on_windows: None) -> None:
+    assert quote_cli_arg(WINDOWS_PATH) == '"C:\\Program Files\\Agent OS\\custom.toml"'
+
+
+def test_windows_path_without_spaces_is_left_bare(on_windows: None) -> None:
+    assert quote_cli_arg(r"C:\agentos\config.toml") == r"C:\agentos\config.toml"
+
+
+def test_windows_backslashes_are_not_escaped(on_windows: None) -> None:
+    """A quoted Windows path must keep single backslashes — they are separators."""
+    quoted = quote_cli_arg(WINDOWS_PATH)
+
+    assert "\\\\" not in quoted
+    assert quoted.strip('"') == WINDOWS_PATH
+
+
+def test_windows_never_emits_posix_single_quotes(on_windows: None) -> None:
+    assert "'" not in quote_cli_arg(WINDOWS_PATH)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        r"C:\opt\a&b\config.toml",
+        r"C:\opt\a;b\config.toml",
+        r"C:\opt\a$b\config.toml",
+        r"C:\opt\a(b)\config.toml",
+        "C:\\opt\\a`b\\config.toml",
+    ],
+)
+def test_windows_shell_metacharacters_are_quoted(value: str, on_windows: None) -> None:
+    assert quote_cli_arg(value) == f'"{value}"'
+
+
+def test_windows_embedded_double_quote_is_doubled(on_windows: None) -> None:
+    assert quote_cli_arg('a"b') == '"a""b"'
+
+
+def test_windows_empty_value_is_quoted(on_windows: None) -> None:
+    assert quote_cli_arg("") == '""'
+
+
+def test_posix_still_uses_shlex_quoting(on_posix: None) -> None:
+    assert quote_cli_arg("/srv/agent os/custom.toml") == "'/srv/agent os/custom.toml'"
+
+
+def test_posix_plain_value_is_left_bare(on_posix: None) -> None:
+    assert quote_cli_arg("/srv/agentos/custom.toml") == "/srv/agentos/custom.toml"
+
+
+def test_config_cli_arg_renders_a_leading_space_and_flag(on_windows: None) -> None:
+    assert config_cli_arg(WINDOWS_PATH) == ' --config "C:\\Program Files\\Agent OS\\custom.toml"'
+
+
+def test_config_cli_arg_accepts_a_path_object(on_posix: None) -> None:
+    # ``str(Path(...))`` uses the native separator, so this compares against the
+    # same rendering rather than hard-coding a POSIX path.
+    path = Path("data") / "a b.toml"
+
+    assert config_cli_arg(path) == config_cli_arg(str(path))
+    assert config_cli_arg(path) == f" --config {quote_cli_arg(str(path))}"
+    assert config_cli_arg(path).endswith("'")  # the space forced POSIX quoting
+
+
+@pytest.mark.parametrize("empty", [None, ""])
+def test_config_cli_arg_is_empty_without_a_path(empty: str | None) -> None:
+    assert config_cli_arg(empty) == ""
+
+
+# ── The sweep: no hint site may reach for shlex.quote again ─────────────────
+
+_HINT_MODULES = (
+    "cli/doctor_cmd.py",
+    "cli/gateway_cmd.py",
+    "cli/onboard_cmd.py",
+    "health/evaluator.py",
+    "health/recovery_commands.py",
+    "onboarding/flow.py",
+    "onboarding/next_steps.py",
+)
+
+
+@pytest.mark.parametrize("relative", _HINT_MODULES)
+def test_hint_modules_do_not_use_shlex_quote(relative: str) -> None:
+    source = (Path(cli_quoting.__file__).parent / relative).read_text(encoding="utf-8")
+
+    assert "shlex.quote" not in source, (
+        f"{relative} builds a copy-pasteable hint — use "
+        "agentos.cli_quoting.quote_cli_arg so Windows gets double quotes"
+    )
+
+
+@pytest.mark.parametrize("relative", _HINT_MODULES)
+def test_hint_modules_do_not_interpolate_a_bare_config_path(relative: str) -> None:
+    """``--config {path}`` with no quoting helper is the same bug, unquoted."""
+    source = (Path(cli_quoting.__file__).parent / relative).read_text(encoding="utf-8")
+
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.JoinedStr):
+            continue
+        parts = [
+            part.value
+            for part in node.values
+            if isinstance(part, ast.Constant) and isinstance(part.value, str)
+        ]
+        assert not any(part.rstrip().endswith("--config") for part in parts), (
+            f"{relative} interpolates a path straight after --config; "
+            "use agentos.cli_quoting.config_cli_arg"
+        )
+
+
+# ── The hint sites themselves, driven on both platforms ─────────────────────
+
+
+def test_onboarding_next_step_hint_is_pasteable_on_windows(on_windows: None) -> None:
+    from agentos.onboarding import next_steps
+
+    assert next_steps._config_cli_arg(WINDOWS_PATH) == (
+        ' --config "C:\\Program Files\\Agent OS\\custom.toml"'
+    )
+
+
+def test_onboarding_flow_hint_is_pasteable_on_windows(on_windows: None) -> None:
+    from agentos.onboarding import flow
+
+    assert flow._config_cli_arg(WINDOWS_PATH) == (
+        ' --config "C:\\Program Files\\Agent OS\\custom.toml"'
+    )
+
+
+def test_onboard_cmd_hint_is_pasteable_on_windows(on_windows: None) -> None:
+    from agentos.cli import onboard_cmd
+
+    assert onboard_cmd._config_cli_arg(Path(WINDOWS_PATH)) == (
+        ' --config "C:\\Program Files\\Agent OS\\custom.toml"'
+    )
+
+
+def test_doctor_onboard_commands_are_pasteable_on_windows(on_windows: None) -> None:
+    from agentos.cli import doctor_cmd
+
+    assert doctor_cmd._onboard_if_needed_command(WINDOWS_PATH) == (
+        'agentos onboard --if-needed --config "C:\\Program Files\\Agent OS\\custom.toml"'
+    )
+
+
+def test_recovery_command_is_pasteable_on_windows(on_windows: None) -> None:
+    from agentos.health.recovery_commands import command_with_config
+
+    assert command_with_config("agentos gateway start", WINDOWS_PATH) == (
+        'agentos gateway start --config "C:\\Program Files\\Agent OS\\custom.toml"'
+    )
+
+
+def test_recovery_command_keeps_posix_quoting_on_posix(on_posix: None) -> None:
+    from agentos.health.recovery_commands import command_with_config
+
+    assert command_with_config("agentos gateway start", "/srv/agent os/c.toml") == (
+        "agentos gateway start --config '/srv/agent os/c.toml'"
+    )
+
+
+def test_platform_detection_follows_os_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The fixtures patch a seam — pin that the seam reads the real platform."""
+    monkeypatch.setattr(cli_quoting.os, "name", "nt")
+    assert cli_quoting._is_windows_shell() is True
+
+    monkeypatch.setattr(cli_quoting.os, "name", "posix")
+    assert cli_quoting._is_windows_shell() is False

--- a/tests/test_cli/test_doctor_cmd.py
+++ b/tests/test_cli/test_doctor_cmd.py
@@ -1,18 +1,22 @@
 from __future__ import annotations
 
 import json
-import shlex
 from typing import Any
 
 from typer.testing import CliRunner
 
 from agentos.cli.main import app
+from agentos.cli_quoting import quote_cli_arg
 
 runner = CliRunner()
 
 
 def _config_arg(path: Any) -> str:
-    return shlex.quote(str(path))
+    # Matches the hint quoting the CLI itself uses, which is platform-aware:
+    # POSIX single quotes on POSIX, Windows double quotes on Windows. Pinning
+    # `shlex.quote` here asserted POSIX quoting of a `C:\...` path on the
+    # Windows leg -- the defect this helper exists to prevent.
+    return quote_cli_arg(str(path))
 
 
 class _FakeGatewayClient:

--- a/tests/test_cli/test_onboard_cmd.py
+++ b/tests/test_cli/test_onboard_cmd.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 import json as _json
 import platform
 import re
-import shlex
 import tomllib
 
 import pytest
 from typer.testing import CliRunner
 
 from agentos.cli.main import app
+from agentos.cli_quoting import quote_cli_arg
 
 runner = CliRunner()
 _ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
@@ -32,7 +32,8 @@ def _env_hint(env_key: str) -> str:
 
 
 def _config_arg(path) -> str:
-    return shlex.quote(str(path))
+    # Platform-aware, like the hints themselves -- see test_cli_quoting.py.
+    return quote_cli_arg(str(path))
 
 
 def test_onboard_noninteractive_provider(tmp_path, monkeypatch):

--- a/tests/test_health/test_evaluator.py
+++ b/tests/test_health/test_evaluator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from agentos.cli_quoting import quote_cli_arg
 from agentos.health.evaluator import (
     evaluate_browser,
     evaluate_channels,
@@ -506,8 +507,11 @@ def test_channels_evaluator_quotes_channel_names_in_recovery_commands() -> None:
     )
 
     commands = [step.command for step in findings[0].fix_steps]
-    assert "agentos channels restart 'feishu work' --yes" in commands
-    assert "agentos channels status 'feishu work' --json" in commands
+    # Quoted for the platform the reader will paste into, not always POSIX.
+    name = quote_cli_arg("feishu work")
+    assert name != "feishu work", "a name with a space must be quoted"
+    assert f"agentos channels restart {name} --yes" in commands
+    assert f"agentos channels status {name} --json" in commands
 
 
 def test_channels_evaluator_treats_disabled_channel_as_optional_info() -> None:


### PR DESCRIPTION
## Linked issue

Fixes #1180
Refs #1231

- [x] This pull request fully resolves the linked issue.

## Summary

This is the **consolidation** you asked for on #1180 rather than a third
one-site patch. Every "next step" line AgentOS prints is meant to be pasted
straight back into the user's shell, and each site built it with
`shlex.quote`, which only knows POSIX rules. On Windows a config path with a
space came back single-quoted — `--config 'C:\Program Files\Agent OS\x.toml'`
— which neither `cmd.exe` nor PowerShell parses as one argument. Windows is
also where paths with spaces are most common, so the hint broke exactly where
it was needed most.

New `src/agentos/cli_quoting.py` holds one `quote_cli_arg` (POSIX
`shlex.quote`; on Windows, double quotes only when the value actually needs
them) and one `config_cli_arg` for the ` --config <path>` suffix that **five**
call sites had each open-coded. The repo-wide grep you suggested turned up
seven hint sites, all converted:

| File | Was |
|---|---|
| `onboarding/flow.py:208` | `shlex.quote` (this issue) |
| `onboarding/next_steps.py:170` | `shlex.quote` (this issue) |
| `cli/gateway_cmd.py:169-171` | **unquoted** f-string interpolation (#1231) |
| `cli/doctor_cmd.py:30` | `shlex.quote` |
| `cli/doctor_cmd.py:51` | `shlex.quote` on the remote `--gateway` target |
| `cli/onboard_cmd.py:232` | `shlex.quote` |
| `health/recovery_commands.py:39` | `shlex.quote` |
| `health/evaluator.py:42` | `shlex.quote` on a channel name |

`skills/install_kinds.py:163` keeps `shlex.quote` deliberately: it builds a
POSIX `curl … && chmod +x ~/.local/bin/…` line, not a cross-platform hint.

On **#1231**: this PR covers `gateway_cmd.py:169-171` too, so it can serve as
the survivor and #1231 can close as merged into it — but that is your call and
@0xEaEd's, and I'm happy to have it re-pointed at #1231 instead. #1185, #1235
and #1243 are not orphaned by anything here; they can just close alongside
whichever issue you retire.

No CLI surface change — no commands, flags, config keys, ports or paths move —
so `skills/bundled/agentos/SKILL.md` and `docs/cli.md` need no update.

## Tests

New `tests/test_cli/test_cli_quoting.py`, 38 tests.

**The sweep is two of them**, so this cannot come back a third time:
`test_hint_modules_do_not_use_shlex_quote` and
`test_hint_modules_do_not_interpolate_a_bare_config_path` (the latter walks the
AST for an f-string whose constant part ends in `--config`) run over all seven
modules and fail if either pattern reappears.

The rest pin behaviour on both platforms — through a `_is_windows_shell()`
seam rather than the real `os.name`, so **Windows quoting is covered on every
CI leg**, not only the Windows one (a separate test pins that the seam reads
`os.name`, so the seam itself cannot rot):

- Windows: spaces double-quoted; backslashes not escaped; never a POSIX single
  quote; `& ; $ ( ) \`` and friends quoted; a plain path left bare; an
  embedded `"` doubled; empty value → `""`.
- POSIX: `shlex.quote` behaviour unchanged, plain values still bare.
- The hint sites themselves, end to end: `flow._config_cli_arg`,
  `next_steps._config_cli_arg`, `onboard_cmd._config_cli_arg`,
  `doctor_cmd._onboard_if_needed_command` and `command_with_config` all produce
  `--config "C:\Program Files\Agent OS\custom.toml"` on Windows and POSIX
  quoting on POSIX.

Red before the fix / green after:

```
$ uv run pytest tests/test_cli/test_cli_quoting.py -q   # before
12 failed, 19 passed
$ uv run pytest tests/test_cli/test_cli_quoting.py -q   # after
38 passed
```

Full gate on this branch:

```
uv run ruff check src tests            # All checks passed!
uv run mypy src/agentos                # clean apart from the pre-existing mem0 stub error
uv run pytest -q                       # 3 failed, 9725 passed, 26 skipped
```

The 3 failures are the pre-existing environment ones (`mem0` installed
locally, `weasyprint`/pango missing) and reproduce identically on a clean tree.
Fixture paths avoid `C:\Users\…` and `/home/…` so
`test_public_release_hygiene.py` stays green.

## Merge-order independence

One of five PRs opened together (#1164, #1166, #1169, #1172, #1180). They
touch disjoint files except #1166/#1169, which touch different functions of
`tools/builtin/patch.py` about 45 lines apart. All 120 merge orderings
verified conflict-free locally, and the all-five merged tree passes the full
suite.

`CHANGELOG.md` is deliberately **not** touched: `[Unreleased]` is currently
empty, so five PRs each inserting a `### Fixed` block at the same line would
conflict with each other in every possible merge order. Happy to follow up
with a single `docs(changelog)` PR covering all five once they land (the same
shape as 38fbdb2), or to add the entry here if you would rather take the
conflict — just say which.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vCV6bdPciGkEywDSsyuGs
