### PR TITLE
fix(identity): keep underscores inside IDENTITY.md field values

### DIFF
--- a/src/agentos/identity/parser.py
+++ b/src/agentos/identity/parser.py
@@ -20,11 +20,22 @@ _PLACEHOLDERS = frozenset(
 _KNOWN_IDENTITY_FIELDS = frozenset(["name", "emoji", "creature", "vibe", "theme", "avatar"])
 
 
+# CommonMark disallows intra-word emphasis with ``_``: a ``_`` flanked by
+# alphanumerics on both sides is literal text, not a delimiter. Matching it
+# anyway ate the underscores out of ordinary values -- ``snake_case_bot``
+# parsed as ``snakecasebot`` -- so the boundary assertions below are what keep
+# a name a name. ``*`` has no such rule (``a*b*c`` really is emphasis in
+# CommonMark), so the asterisk pattern is deliberately left as it was.
+_INLINE_EMPHASIS_ASTERISK_RE = re.compile(r"\*{1,3}(.*?)\*{1,3}")
+_INLINE_EMPHASIS_UNDERSCORE_RE = re.compile(r"(?<![0-9A-Za-z])_{1,3}(.*?)_{1,3}(?![0-9A-Za-z])")
+_INLINE_CODE_RE = re.compile(r"`([^`]+)`")
+
+
 def _strip_markdown_inline(text: str) -> str:
     """Strip inline markdown formatting: bold, italic, code."""
-    text = re.sub(r"\*{1,3}(.*?)\*{1,3}", r"\1", text)
-    text = re.sub(r"_{1,3}(.*?)_{1,3}", r"\1", text)
-    text = re.sub(r"`([^`]+)`", r"\1", text)
+    text = _INLINE_EMPHASIS_ASTERISK_RE.sub(r"\1", text)
+    text = _INLINE_EMPHASIS_UNDERSCORE_RE.sub(r"\1", text)
+    text = _INLINE_CODE_RE.sub(r"\1", text)
     return text
 
 

--- a/tests/test_identity/test_identity_parser.py
+++ b/tests/test_identity/test_identity_parser.py
@@ -42,6 +42,7 @@ def test_underscores_inside_a_value_are_preserved(value: str) -> None:
 @pytest.mark.parametrize(
     ("written", "expected"),
     [
+        ("_italic_", "italic"),
         ("_cyberpunk_", "cyberpunk"),
         ("__bold__", "bold"),
         ("**strong**", "strong"),

--- a/tests/test_identity/test_identity_parser.py
+++ b/tests/test_identity/test_identity_parser.py
@@ -1,0 +1,76 @@
+"""IDENTITY.md parsing — inline markdown must not eat parts of a value.
+
+`_strip_markdown_inline` removes bold/italic/code markers before a field value
+is stored. Without a flanking condition the underscore pattern also matched
+inside ordinary words, so `snake_case_bot` was stored as `snakecasebot`
+(issue #1428).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentos.identity.parser import parse_identity
+
+
+def _identity(**fields: str) -> str:
+    lines = "\n".join(f"- {key}: {value}" for key, value in fields.items())
+    return f"# Identity\n{lines}\n"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "my_agent_name",
+        "snake_case_bot",
+        "a_b_c_d",
+        "x_y",
+        "foo_bar_",
+        "_leading",
+        "trailing_",
+    ],
+)
+def test_underscores_inside_a_value_are_preserved(value: str) -> None:
+    """CommonMark forbids intra-word emphasis with ``_``, so these are literal.
+
+    Two underscores anywhere on the line used to pair up as an emphasis run and
+    both were deleted, which `snake_case` naming produces routinely.
+    """
+    assert parse_identity(_identity(name=value)).name == value
+
+
+@pytest.mark.parametrize(
+    ("written", "expected"),
+    [
+        ("_cyberpunk_", "cyberpunk"),
+        ("__bold__", "bold"),
+        ("**strong**", "strong"),
+        ("*em*", "em"),
+        ("`code`", "code"),
+        ("a _b_ c", "a b c"),
+    ],
+)
+def test_real_inline_markdown_is_still_stripped(written: str, expected: str) -> None:
+    """The helper still has a job: emphasis at a word boundary is markup."""
+    assert parse_identity(_identity(name=written)).name == expected
+
+
+def test_asterisk_emphasis_inside_a_word_still_collapses() -> None:
+    """``*`` carries no intra-word restriction, so this is left as it was.
+
+    CommonMark treats ``a*b*c`` as emphasis, unlike the underscore spelling.
+    Pinning it here records that the asterisk branch was deliberately not
+    changed alongside the underscore fix.
+    """
+    assert parse_identity(_identity(name="fast*and*loud")).name == "fastandloud"
+
+
+def test_several_underscored_fields_survive_together() -> None:
+    """The whole document parses, not just the field under test."""
+    parsed = parse_identity(
+        _identity(name="my_agent_name", creature="snake_case_bot", theme="_cyberpunk_")
+    )
+
+    assert parsed.name == "my_agent_name"
+    assert parsed.creature == "snake_case_bot"
+    assert parsed.theme == "cyberpunk"


### PR DESCRIPTION
## Summary

`_strip_markdown_inline` in `src/agentos/identity/parser.py` stripped inline emphasis with

```python
text = re.sub(r"_{1,3}(.*?)_{1,3}", r"\1", text)
```

The pattern carries no boundary condition, so any two underscores on the same line pair up as a delimiter run and both are deleted. Verified on `upstream/main` (`cc913e9`):

```
name     : 'myagentname'      (file said my_agent_name)
creature : 'snakecasebot'     (file said snake_case_bot)
```

This contradicts CommonMark, which explicitly disallows intra-word emphasis for `_`: a `_` flanked by alphanumerics on both sides can neither open nor close emphasis.

The failure is silent — nothing errors, the value simply comes back different from the file. `parser.py:86` applies the helper to the **stored field value**, not only to the placeholder comparison at line 33, and `engine/runtime.py:4399` parses `IDENTITY.md` for the running agent, so an agent named `my_agent_name` is told its name is `myagentname`. It needs two underscores on one line, which is why it has not been obvious — and which `snake_case` naming produces routinely.

## Changes

**`src/agentos/identity/parser.py`** (+13/-4)

The three inline patterns are now named module constants (compiled once instead of on every field), and the underscore one gains the CommonMark flanking condition:

```python
_INLINE_EMPHASIS_UNDERSCORE_RE = re.compile(r"(?<![0-9A-Za-z])_{1,3}(.*?)_{1,3}(?![0-9A-Za-z])")
```

`*` is deliberately left as it was. CommonMark places no intra-word restriction on `*`, so `a*b*c` really is emphasis and collapsing it to `abc` is correct — changing that too would be a behaviour change this issue does not ask for. The comment at the constants says so, so the omission reads as a decision rather than an oversight.

No other file is touched. The same pattern appears nowhere else in `src/agentos` (checked).

## Tests

**`tests/test_identity/test_identity_parser.py`** — new file, 15 cases. `parse_identity` had **no test coverage at all** before this, so these are also the first tests for the parser. Every assertion goes through the public `parse_identity`, not the private helper, so they pin behaviour rather than the regex.

*Regression tests — these 5 fail on `upstream/main` and pass with the fix:*

| Test | Covers |
|---|---|
| `test_underscores_inside_a_value_are_preserved` | `my_agent_name`, `snake_case_bot`, `a_b_c_d`, `foo_bar_` (the `x_y`, `_leading` and `trailing_` cases in the same parametrize were never broken and pass either way) |
| `test_several_underscored_fields_survive_together` | a whole document: `name`, `creature` and `theme` at once |

*Guard tests — these pass in both states by construction; flagging that rather than counting them as regressions:*

| Test | Covers |
|---|---|
| `test_real_inline_markdown_is_still_stripped` | `_cyberpunk_`, `__bold__`, `**strong**`, `*em*`, `` `code` ``, `a _b_ c` — the helper still has a job |
| `test_asterisk_emphasis_inside_a_word_still_collapses` | `fast*and*loud` → `fastandloud`, recording that the asterisk branch was not changed |

One note on the filename: the natural name for this file was `tests/test_identity/test_parser.py`, but `tests/test_scheduler/test_parser.py` already exists and the test directories have no `__init__.py`. Two same-named test modules abort pytest **at collection**, taking the whole suite down rather than failing one test — so the file is named `test_identity_parser.py`.

## Status

- `uv run ruff check src tests` ✅
- `uv run mypy src/agentos --show-error-codes` ✅ (623 source files, no issues)
- `uv run pytest -q` ✅ **9734 passed, 30 skipped**, 0 failed
- Self-check: reverted `parser.py` with `git checkout upstream/main -- <file>` and confirmed the 5 regression cases fail without the fix.
- `ruff format --diff` on both changed files reports no hunks.

Fixes #1428

🤖 Generated with [Claude Code](https://claude.com/claude-code)
