### PR TITLE
perf(memory): skip transcripts the session index already has

### DIFF
--- a/src/agentos/memory/session_source.py
+++ b/src/agentos/memory/session_source.py
@@ -59,15 +59,37 @@ def _format_timestamp(ms: int | None) -> str:
     return datetime.fromtimestamp(ms / 1000, tz=UTC).isoformat()
 
 
+def session_source_path(session: Any) -> str:
+    """Return the derived document path for a session.
+
+    Split out of :func:`build_session_source_document` so the freshness
+    pre-check in :meth:`SessionSourceIndexer.sync` addresses the same row the
+    document is later written to. Deriving it twice would let the two spellings
+    drift and the check would silently target nothing.
+    """
+    agent_id = _normalize_agent_id(getattr(session, "agent_id", None) or "main")
+    safe_agent = _safe_segment(agent_id, fallback="main")
+    safe_session_id = _safe_segment(session.session_id, fallback="session")
+    return f"sessions/{safe_agent}/{safe_session_id}.md"
+
+
+def session_source_mtime(session: Any) -> float:
+    """Return the document mtime for a session, in seconds.
+
+    Taken from ``updated_at`` alone, which is why it can be read before the
+    transcript is: ``SessionManager.append_message`` touches ``updated_at`` on
+    every append, so a session that gained a message always compares newer.
+    """
+    return (getattr(session, "updated_at", None) or 0) / 1000
+
+
 def build_session_source_document(
     session: Any,
     entries: list[Any],
 ) -> SessionSourceDocument:
     """Render a session transcript into a deterministic derived source document."""
     agent_id = _normalize_agent_id(getattr(session, "agent_id", None) or "main")
-    safe_agent = _safe_segment(agent_id, fallback="main")
-    safe_session_id = _safe_segment(session.session_id, fallback="session")
-    path = f"sessions/{safe_agent}/{safe_session_id}.md"
+    path = session_source_path(session)
 
     lines = [
         "---",
@@ -100,7 +122,7 @@ def build_session_source_document(
     if rendered_entries == 0:
         lines.append("(no user or assistant transcript content)")
 
-    mtime = (getattr(session, "updated_at", None) or 0) / 1000
+    mtime = session_source_mtime(session)
     return SessionSourceDocument(
         path=path,
         content="\n".join(lines).rstrip() + "\n",
@@ -130,7 +152,16 @@ class SessionSourceIndexer:
         indexed = 0
         skipped = 0
 
+        unchanged = set() if force else await self._unchanged_document_paths(sessions)
+
         for session in sessions:
+            if not force:
+                path = session_source_path(session)
+                if path in unchanged:
+                    # Still expected, or the stale-path sweep below would
+                    # delete a document that is simply up to date.
+                    expected_paths.add(path)
+                    continue
             entries = await self._storage.get_transcript(session.session_id)
             if not entries:
                 skipped += 1
@@ -155,6 +186,46 @@ class SessionSourceIndexer:
                 removed += 1
 
         return SessionSourceSyncResult(indexed=indexed, removed=removed, skipped=skipped)
+
+    async def _unchanged_document_paths(self, sessions: list[Any]) -> set[str]:
+        """Document paths already indexed at or past their session's mtime.
+
+        ``index_file`` decides "unchanged" by hashing the rendered document, so
+        reaching that decision used to cost a full transcript read, a redaction
+        pass over every entry and the whole document render -- per session, for
+        every session, on every sync. One message in one session was enough to
+        pay it for all of them, and ``sync`` runs on session start, on the
+        timer, on watch events and ahead of memory searches.
+
+        The mtime that ``index_file`` records comes from ``updated_at`` alone
+        (:func:`session_source_mtime`), so the same comparison can be made from
+        the session rows in a single batched query. ``get_file_mtimes`` is the
+        existing accessor for it -- ``memory/retrieval.py`` already reads the
+        table this way.
+
+        Conservative in both directions: a session with no ``updated_at`` is
+        never skipped, and a store without the accessor skips nothing. Opening
+        a session also touches ``updated_at``, so an untouched transcript can
+        still be re-read -- that is the old behaviour, not a regression.
+        """
+        get_file_mtimes = getattr(self._store, "get_file_mtimes", None)
+        if not callable(get_file_mtimes):
+            return set()
+
+        candidates: dict[str, float] = {}
+        for session in sessions:
+            mtime = session_source_mtime(session)
+            if mtime > 0:
+                candidates[session_source_path(session)] = mtime
+        if not candidates:
+            return set()
+
+        known = await get_file_mtimes(list(candidates))
+        return {
+            path
+            for path, mtime in candidates.items()
+            if known.get(path) is not None and mtime <= known[path]
+        }
 
     async def _list_sessions(self) -> tuple[list[Any], bool]:
         page_size = min(100, self._max_sessions)

--- a/tests/test_memory_sessions_source.py
+++ b/tests/test_memory_sessions_source.py
@@ -8,6 +8,7 @@ from agentos.memory.retrieval import MemoryRetriever
 from agentos.memory.session_source import (
     SessionSourceIndexer,
     build_session_source_document,
+    session_source_path,
 )
 from agentos.memory.store import LongTermMemoryStore
 from agentos.memory.sync_manager import MemorySyncManager
@@ -265,3 +266,155 @@ async def test_memory_search_tool_outputs_sessions_source(tmp_path):
     assert retriever.opts.source is MemorySource.sessions
     assert "source: sessions" in output
     assert "sessions/main/session-1.md" in output
+
+
+class _RecordingSessionStorage:
+    """Session storage that records which transcripts were actually read."""
+
+    def __init__(self, sessions: list[SimpleNamespace]) -> None:
+        self.sessions = sessions
+        self.transcript_reads: list[str] = []
+
+    async def list_sessions(self, agent_id=None, limit=100, offset=0):  # noqa: ANN001
+        return self.sessions[offset : offset + limit]
+
+    async def get_transcript(self, session_id: str):  # noqa: ANN001
+        self.transcript_reads.append(session_id)
+        return [SimpleNamespace(role="user", content="hello", id=1, message_id="m1")]
+
+
+class _StoreWithoutMtimes:
+    """The older store shape: no ``get_file_mtimes`` accessor."""
+
+    def __init__(self, mtimes: dict[str, float]) -> None:
+        self.mtimes = mtimes
+        self.removed: list[str] = []
+
+    async def index_file(self, path, content, source=None, mtime=None):  # noqa: ANN001
+        return 0
+
+    async def list_paths(self, source=None):  # noqa: ANN001
+        return list(self.mtimes)
+
+    async def remove_file(self, path: str) -> None:
+        self.removed.append(path)
+
+
+class _Store(_StoreWithoutMtimes):
+    async def get_file_mtimes(self, paths: list[str]) -> dict[str, float]:
+        return {p: self.mtimes[p] for p in paths if p in self.mtimes}
+
+
+def _session(index: int, updated_at: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        session_id=f"s{index}",
+        agent_id="main",
+        updated_at=updated_at,
+        label=None,
+        display_name=None,
+    )
+
+
+def _indexed_at(sessions: list[SimpleNamespace], mtime: float) -> dict[str, float]:
+    return {session_source_path(session): mtime for session in sessions}
+
+
+async def test_sync_skips_reading_transcripts_that_are_already_indexed() -> None:
+    """An unchanged session must not cost a transcript read.
+
+    ``index_file`` decides "unchanged" by hashing the rendered document, so
+    reaching that verdict used to require the full read, a redaction pass over
+    every entry and the whole render -- per session, for every session, on
+    every sync.
+    """
+    sessions = [_session(i, 1_000_000) for i in range(3)]
+    storage = _RecordingSessionStorage(list(sessions))
+    store = _Store(_indexed_at(sessions, 1000.0))
+
+    result = await SessionSourceIndexer(storage=storage, store=store).sync()
+
+    assert storage.transcript_reads == []
+    assert result.indexed == 0
+
+
+async def test_sync_still_reads_the_session_that_changed() -> None:
+    """The skip is per session: a newer ``updated_at`` is always re-read."""
+    sessions = [_session(0, 1_000_000), _session(1, 5_000_000), _session(2, 1_000_000)]
+    storage = _RecordingSessionStorage(sessions)
+    store = _Store(_indexed_at([_session(i, 0) for i in range(3)], 1000.0))
+
+    await SessionSourceIndexer(storage=storage, store=store).sync()
+
+    assert storage.transcript_reads == ["s1"]
+
+
+async def test_skipped_sessions_are_not_swept_as_stale_paths() -> None:
+    """A skipped document is up to date, not orphaned.
+
+    ``sync`` deletes every indexed path it did not see this run, so a skipped
+    session has to stay in ``expected_paths`` or the fast path would delete the
+    documents it just decided were fine.
+    """
+    sessions = [_session(i, 1_000_000) for i in range(3)]
+    storage = _RecordingSessionStorage(list(sessions))
+    store = _Store(_indexed_at(sessions, 1000.0))
+
+    result = await SessionSourceIndexer(storage=storage, store=store).sync()
+
+    assert store.removed == []
+    assert result.removed == 0
+
+
+async def test_force_still_reads_every_transcript() -> None:
+    """``force=True`` counts an unchanged session as indexed, so it must not skip."""
+    sessions = [_session(i, 1_000_000) for i in range(3)]
+    storage = _RecordingSessionStorage(list(sessions))
+    store = _Store(_indexed_at(sessions, 1000.0))
+
+    await SessionSourceIndexer(storage=storage, store=store).sync(force=True)
+
+    assert len(storage.transcript_reads) == 3
+
+
+async def test_a_store_without_the_mtime_accessor_still_syncs() -> None:
+    """The store is duck-typed; an older one must lose the speed-up, not work."""
+    sessions = [_session(i, 1_000_000) for i in range(3)]
+    storage = _RecordingSessionStorage(list(sessions))
+    store = _StoreWithoutMtimes(_indexed_at(sessions, 1000.0))
+
+    await SessionSourceIndexer(storage=storage, store=store).sync()
+
+    assert len(storage.transcript_reads) == 3
+
+
+async def test_a_session_without_updated_at_is_never_skipped() -> None:
+    """Without a timestamp there is nothing to compare, so read it."""
+    sessions = [_session(0, 0)]
+    storage = _RecordingSessionStorage(sessions)
+    store = _Store(_indexed_at(sessions, 1000.0))
+
+    await SessionSourceIndexer(storage=storage, store=store).sync()
+
+    assert storage.transcript_reads == ["s0"]
+
+
+async def test_a_session_never_indexed_before_is_read() -> None:
+    """No stored mtime means no baseline to skip against."""
+    sessions = [_session(i, 1_000_000) for i in range(3)]
+    storage = _RecordingSessionStorage(list(sessions))
+    store = _Store({})
+
+    await SessionSourceIndexer(storage=storage, store=store).sync()
+
+    assert len(storage.transcript_reads) == 3
+
+
+async def test_an_older_indexed_copy_is_refreshed() -> None:
+    """A stored mtime behind the session's own must not count as up to date."""
+    sessions = [_session(i, 1_000_000) for i in range(3)]
+    storage = _RecordingSessionStorage(list(sessions))
+    store = _Store(_indexed_at(sessions, 1.0))
+
+    await SessionSourceIndexer(storage=storage, store=store).sync()
+
+    assert len(storage.transcript_reads) == 3


### PR DESCRIPTION
## Summary

`SessionSourceIndexer.sync` (`memory/session_source.py:129-146`) did this per session, for **every** session up to `max_sessions` (default 1000):

```python
for session in sessions:
    entries = await self._storage.get_transcript(session.session_id)   # full transcript
    document = build_session_source_document(session, entries)         # redact + render every entry
    chunks = await self._store.index_file(...)                         # -> 0, unchanged
```

`index_file` decides "unchanged" by hashing the rendered document (`memory/store.py:657-661`), so reaching that verdict cost the full read, the redaction pass and the whole render — then threw it away.

Measured on `upstream/main` (`cc913e9`), 50 sessions × 200 messages:

```
377.1 ms discarded per sync   (7.54 ms per session)  ->  ~7.5 s projected at max_sessions=1000
```

What makes it more than a slow background job is the frequency. `sync()` runs on **session start** (`sync_manager.py:225`), the **timer** (`:462`), **watch** events (`:448`), and ahead of **memory searches** (`retrieval.py:192`). The search path's fast exit at `sync_manager.py:176` only applies when nothing is dirty *and* no session delta is pending, so one new message in one session pays the full cost for all 1000 — and `session-start`, `timer` and `watch` are not search reasons and never take that exit at all.

## Changes

**`src/agentos/memory/session_source.py`** (+62/-5)

- `session_source_path()` and `session_source_mtime()` extracted from `build_session_source_document`, so the pre-check and the document writer derive the path from one place. Deriving it twice would let the two spellings drift and the check would silently address nothing.
- `_unchanged_document_paths()` — one batched `store.get_file_mtimes(...)` ahead of the loop, returning the paths already indexed at or past their session's mtime.
- `sync()` skips reading those transcripts.

This adds no API. `get_file_mtimes` already exists (`memory/store.py:1150`) and `memory/retrieval.py:207` already reads the table that way.

**Why the comparison is safe.** The mtime `index_file` records comes from `updated_at` alone, and `SessionManager.append_message` is *"Append a message to the session transcript and touch updated_at"* (`session/manager.py:985`) — it sets `node.updated_at = _now_ms()` and upserts. So a session that gained a message always compares newer and cannot be skipped. The error is one-directional: merely *opening* a session also touches `updated_at`, so an untouched transcript can still be re-read — that is today's behaviour, not a regression.

Three details deliberately handled rather than discovered later:

- A skipped session still goes into `expected_paths`. Without that, the stale-path sweep at the end of `sync` would delete the very documents the fast path just decided were up to date.
- The fast path is **off under `force=True`**, because that path counts an unchanged session as `indexed` — skipping would change the returned counts.
- `get_file_mtimes` is reached through `getattr`/`callable`. `self._store` is typed `Any`, so a store without the accessor loses the speed-up rather than raising.

## Tests

**`tests/test_memory_sessions_source.py`** — 8 new cases, asserting on how many transcripts were actually read (`storage.transcript_reads`) rather than on internals. They use recording fakes, in the same shape as the `FakeStore` / `NoopStore` already in this file; the real store path needs an embedding provider, which is why the existing tests that use it are the narrower ones.

*Regression tests — with the fast path disabled these 2 fail, and they are the only two that do:*

| Test | Covers |
|---|---|
| `test_sync_skips_reading_transcripts_that_are_already_indexed` | three unchanged sessions → **zero** transcript reads, `indexed == 0` |
| `test_sync_still_reads_the_session_that_changed` | one newer `updated_at` among three → reads exactly `["s1"]` |

*Guard tests — these pass in both states by construction. Flagging that rather than counting them as regressions; they exist because each is a way this change could go wrong:*

| Test | Covers |
|---|---|
| `test_skipped_sessions_are_not_swept_as_stale_paths` | `store.removed == []`, `result.removed == 0` |
| `test_force_still_reads_every_transcript` | `force=True` reads all three |
| `test_a_store_without_the_mtime_accessor_still_syncs` | older store shape, no crash, all three read |
| `test_a_session_without_updated_at_is_never_skipped` | no timestamp → read |
| `test_a_session_never_indexed_before_is_read` | no stored mtime → read |
| `test_an_older_indexed_copy_is_refreshed` | stored mtime behind the session's → read |

No existing test was modified.

## Status

- `uv run ruff check src tests` ✅
- `uv run mypy src/agentos --show-error-codes` ✅ (623 source files, no issues)
- `uv run pytest -q` ✅ **9727 passed, 30 skipped**, 0 failed
- Self-check: disabling only `_unchanged_document_paths` leaves exactly the 2 regression tests failing. (Reverting the whole file instead gives a collection error, since the tests import the new `session_source_path` helper — the narrower revert is the one that proves anything.)
- `ruff format --diff` reports one hunk in `session_source.py`, at the `label_value` assignment. It is present unchanged on `upstream/main` and is not touched here; the lines added by this PR are format-clean, and the test file reports no hunks.

Fixes #1432

🤖 Generated with [Claude Code](https://claude.com/claude-code)
