### PR TITLE
fix(skills): preserve paragraph boundaries in pptx text extraction (#1430)

### DIFF
--- a/src/agentos/skills/bundled/pptx/scripts/extract_text.py
+++ b/src/agentos/skills/bundled/pptx/scripts/extract_text.py
@@ -53,7 +53,7 @@ def _shape_text(shape) -> list[str]:
         return []
     out: list[str] = []
     for para in shape.text_frame.paragraphs:
-        line = "".join(run.text for run in para.runs).strip()
+        line = para.text.strip()
         if line:
             out.append(line)
     return out
@@ -66,11 +66,7 @@ def _table_text(shape) -> list[str]:
     out: list[str] = []
     for row in shape.table.rows:
         cells = [
-            "".join(
-                run.text
-                for para in cell.text_frame.paragraphs
-                for run in para.runs
-            ).strip()
+            " ".join(para.text.strip() for para in cell.text_frame.paragraphs if para.text.strip())
             for cell in row.cells
         ]
         cells = [c for c in cells if c]
@@ -107,9 +103,7 @@ def _notes_text(slide) -> str:
 
 
 def main(argv: list[str] | None = None) -> int:
-    ap = argparse.ArgumentParser(
-        description="Extract slide text from a .pptx file."
-    )
+    ap = argparse.ArgumentParser(description="Extract slide text from a .pptx file.")
     ap.add_argument("path", type=Path, help="Path to .pptx file")
     ap.add_argument("--json", action="store_true", help="Emit JSON")
     ap.add_argument(
@@ -142,11 +136,7 @@ def main(argv: list[str] | None = None) -> int:
             {
                 "slide": i,
                 "text": _slide_text(slide),
-                **(
-                    {"notes": _notes_text(slide)}
-                    if args.include_notes
-                    else {}
-                ),
+                **({"notes": _notes_text(slide)} if args.include_notes else {}),
             }
         )
 

--- a/tests/test_skill_pptx_extract_text.py
+++ b/tests/test_skill_pptx_extract_text.py
@@ -1,0 +1,70 @@
+"""pptx skill extract_text unit tests."""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from pptx import Presentation
+from pptx.util import Inches
+
+from agentos.skills.bundled.pptx.scripts import extract_text
+
+
+def test_shape_text_and_table_text_extraction(tmp_path: Path) -> None:
+    """extract_text extracts paragraph text and multi-paragraph table cells cleanly."""
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+
+    # 1. Textbox shape with paragraph text
+    tb = slide.shapes.add_textbox(Inches(1), Inches(1), Inches(4), Inches(1))
+    tb.text_frame.text = "Slide Headline"
+    p_body = tb.text_frame.add_paragraph()
+    p_body.text = "Secondary point"
+
+    # 2. Table with multi-paragraph cell
+    table_shape = slide.shapes.add_table(2, 2, Inches(1), Inches(2.5), Inches(5), Inches(2))
+    table = table_shape.table
+    table.cell(0, 0).text_frame.text = "Metric"
+    table.cell(0, 1).text_frame.text = "Value"
+
+    c1 = table.cell(1, 0)
+    c1.text_frame.text = "Q1 Revenue"
+    p_extra = c1.text_frame.add_paragraph()
+    p_extra.text = "(USD)"
+
+    c2 = table.cell(1, 1)
+    c2.text_frame.text = "$100M"
+
+    # Test helpers directly
+    shape_lines = extract_text._shape_text(tb)
+    assert shape_lines == ["Slide Headline", "Secondary point"]
+
+    table_lines = extract_text._table_text(table_shape)
+    assert table_lines == ["Metric | Value", "Q1 Revenue (USD) | $100M"]
+
+    # Save presentation and test CLI entrypoint
+    pptx_path = tmp_path / "deck.pptx"
+    prs.save(str(pptx_path))
+
+    # Test main with --json
+    stdout_capture = io.StringIO()
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(sys, "stdout", stdout_capture)
+    try:
+        ret = extract_text.main([str(pptx_path), "--json"])
+        assert ret == 0
+    finally:
+        monkeypatch.undo()
+
+    payload = json.loads(stdout_capture.getvalue())
+    assert len(payload) == 1
+    slide_data = payload[0]
+    assert slide_data["slide"] == 1
+    assert "Slide Headline" in slide_data["text"]
+    assert "Secondary point" in slide_data["text"]
+    assert "Metric | Value" in slide_data["text"]
+    assert "Q1 Revenue (USD) | $100M" in slide_data["text"]


### PR DESCRIPTION
Fixes #1430

## Summary
Preserves paragraph boundaries when extracting text from PowerPoint `.pptx` table cells and shapes.

## What was changed
- In `src/agentos/skills/bundled/pptx/scripts/extract_text.py`:
  - Updated `_table_text` to join multiple paragraphs within a cell with a space delimiter (`" ".join(para.text.strip() for para in cell.text_frame.paragraphs if para.text.strip())`), preventing words from adjacent paragraphs within the same cell from being concatenated without whitespace (e.g. `Q1 Revenue` and `(USD)` becoming `Q1 Revenue(USD)`).
  - Updated `_shape_text` to access `para.text.strip()` directly, matching the approach used in `_notes_text` and supporting paragraph text set directly on the paragraph element.
- Added regression unit tests in `tests/test_skill_pptx_extract_text.py` verifying shape text, multi-paragraph table cells, and `--json` CLI output.

## Quality Gate Verification
- `uv run ruff check src tests` (clean)
- `uv run ruff format --check src tests` (clean)
- `uv run mypy src/agentos --show-error-codes` (clean)
- `uv run pytest tests/test_skill_pptx_extract_text.py tests/test_skill_pptx_delivery.py -v` (passed)
