### PR TITLE
fix(telegram): keep Markdown markers out of a link's href

### DIFF
--- a/src/agentos/channels/_telegram_formatting.py
+++ b/src/agentos/channels/_telegram_formatting.py
@@ -43,11 +43,30 @@ def _replace_code_spans(text: str) -> tuple[str, list[str]]:
 def _render_inline(text: str) -> str:
     protected, code_chunks = _replace_code_spans(text)
     rendered = html.escape(protected)
-    rendered = _LINK_RE.sub(r'<a href="\2">\1</a>', rendered)
+    hrefs: list[str] = []
+
+    def _park_href(match: re.Match[str]) -> str:
+        # Park the URL before the inline passes below run. They match `**`,
+        # `__`, `~~` and `*` anywhere in the string, so a URL carrying those
+        # was rewritten inside the attribute -- `foo__bar__baz` came out as
+        # `foo<b>bar</b>baz` and Telegram rejected the message with
+        # "can't find end tag of href".
+        #
+        # Only the URL is parked. The link *text* stays exposed on purpose:
+        # `[**bold**](url)` is meant to render bold, and hiding the whole
+        # anchor would silently drop that.
+        hrefs.append(match.group(2))
+        return f'<a href="\x00TG_HREF_{len(hrefs) - 1}\x00">{match.group(1)}</a>'
+
+    rendered = _LINK_RE.sub(_park_href, rendered)
     rendered = re.sub(r"\*\*(?=\S)(.+?)(?<=\S)\*\*", r"<b>\1</b>", rendered)
     rendered = re.sub(r"__(?=\S)(.+?)(?<=\S)__", r"<b>\1</b>", rendered)
     rendered = re.sub(r"~~(?=\S)(.+?)(?<=\S)~~", r"<s>\1</s>", rendered)
     rendered = re.sub(r"(?<!\*)\*(?=\S)(.+?)(?<=\S)\*(?!\*)", r"<i>\1</i>", rendered)
+    # Restore in reverse order of protection: code spans were parked first, so
+    # they come back last and a restored code span is never rescanned.
+    for index, href in enumerate(hrefs):
+        rendered = rendered.replace(f"\x00TG_HREF_{index}\x00", href)
     for index, chunk in enumerate(code_chunks):
         rendered = rendered.replace(f"\x00TG_CODE_{index}\x00", chunk)
     return rendered
@@ -55,10 +74,22 @@ def _render_inline(text: str) -> str:
 
 def _plain_inline(text: str) -> str:
     """Remove common inline Markdown markers for table labels."""
-    text = _LINK_RE.sub(r"\1 (\2)", text)
+    # Same hazard as `_render_inline`, with a worse outcome: the marker strip
+    # below is a plain `str.replace`, so a URL containing `__`, `**` or `~~`
+    # lost those characters outright and the reader was handed a link that does
+    # not resolve. Park the URLs, strip the markers, put them back.
+    hrefs: list[str] = []
+
+    def _park_href(match: re.Match[str]) -> str:
+        hrefs.append(match.group(2))
+        return f"{match.group(1)} (\x00TG_HREF_{len(hrefs) - 1}\x00)"
+
+    text = _LINK_RE.sub(_park_href, text)
     text = text.replace("`", "")
     for marker in ("**", "__", "~~"):
         text = text.replace(marker, "")
+    for index, href in enumerate(hrefs):
+        text = text.replace(f"\x00TG_HREF_{index}\x00", href)
     return text.strip()
 
 

--- a/tests/test_channels/test_telegram_formatting.py
+++ b/tests/test_channels/test_telegram_formatting.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import pytest
 
-from agentos.channels._telegram_formatting import render_telegram_html
+from agentos.channels._telegram_formatting import _plain_inline, render_telegram_html
 from agentos.channels.telegram import TelegramApiError, TelegramChannel, TelegramChannelConfig
 from agentos.channels.types import OutgoingMessage
 
@@ -207,3 +207,82 @@ def test_mixed_ragged_rows_all_render_without_raw_pipes() -> None:
     assert "extra" not in rendered
     # No raw pipe characters.
     assert "|" not in rendered
+
+
+@pytest.mark.parametrize(
+    ("url", "marker"),
+    [
+        ("https://example.com/foo__bar__baz", "__"),
+        ("https://example.com/a**b**c", "**"),
+        ("https://example.com/a~~b~~c", "~~"),
+        ("https://example.com/a*b*c", "*"),
+    ],
+)
+def test_link_href_survives_inline_formatting_markers(url: str, marker: str) -> None:
+    """A URL is an attribute value, not a place to look for Markdown.
+
+    The inline passes matched `**`, `__`, `~~` and `*` anywhere in the string,
+    so they rewrote the characters inside `href="..."`. Telegram then rejected
+    the whole message with "can't find end tag of href", which loses the reply
+    rather than degrading it.
+    """
+    rendered = render_telegram_html(f"[test]({url})")
+
+    assert rendered == f'<a href="{url}">test</a>'
+    assert "<b>" not in rendered
+    assert "<i>" not in rendered
+    assert "<s>" not in rendered
+
+
+def test_two_links_with_markers_both_survive() -> None:
+    """The placeholders are per-link, so several on one line stay distinct."""
+    rendered = render_telegram_html("[a](https://x.test/a__b__c) and [c](https://y.test/d__e__f)")
+
+    assert rendered == (
+        '<a href="https://x.test/a__b__c">a</a> and <a href="https://y.test/d__e__f">c</a>'
+    )
+
+
+def test_formatting_around_a_link_still_renders() -> None:
+    """Parking the URL must not disarm the inline passes for the rest."""
+    rendered = render_telegram_html("**bold** then [t](https://x.test/a__b__c)")
+
+    assert rendered == '<b>bold</b> then <a href="https://x.test/a__b__c">t</a>'
+
+
+def test_formatting_inside_link_text_still_renders() -> None:
+    """Only the URL is protected -- the link text is still Markdown.
+
+    Hiding the whole anchor would have been the simpler fix and would have
+    silently dropped this: `[**bold**](url)` is meant to come out bold.
+    """
+    assert render_telegram_html("[**bold** link](https://x.test/)") == (
+        '<a href="https://x.test/"><b>bold</b> link</a>'
+    )
+    assert render_telegram_html("[*em*](https://x.test/)") == (
+        '<a href="https://x.test/"><i>em</i></a>'
+    )
+
+
+def test_plain_inline_keeps_the_url_intact() -> None:
+    """The table-label path strips markers with `str.replace`.
+
+    That is worse than the HTML path: the characters are removed outright, so
+    `foo__bar__baz` became `foobarbaz` and the reader got a link that does not
+    resolve rather than a message Telegram refuses.
+    """
+    assert _plain_inline("[t](https://x.test/a__b__c)") == "t (https://x.test/a__b__c)"
+    assert _plain_inline("[t](https://x.test/a~~b~~c)") == "t (https://x.test/a~~b~~c)"
+    assert _plain_inline("[t](https://x.test/a**b**c)") == "t (https://x.test/a**b**c)"
+
+
+def test_plain_inline_still_strips_markers_outside_a_url() -> None:
+    """The stripping it exists for keeps working."""
+    assert _plain_inline("**bold** and __also__ and ~~gone~~") == "bold and also and gone"
+
+
+def test_a_url_inside_a_code_span_is_untouched() -> None:
+    """Code spans were already protected; that must not regress."""
+    assert render_telegram_html("`https://x.test/a__b__c`") == (
+        "<code>https://x.test/a__b__c</code>"
+    )


### PR DESCRIPTION
## Summary

`_render_inline` (`channels/_telegram_formatting.py`) substituted `[text](url)` into `<a href="url">text</a>` **before** running the inline passes for `**`, `__`, `~~` and `*`. Those patterns match anywhere in the string, so a URL carrying those characters was rewritten inside the attribute. Verified on `upstream/main` (`cc913e9`):

```
[test](https://example.com/foo__bar__baz)  ->  <a href="https://example.com/foo<b>bar</b>baz">test</a>
[t](https://x.test/a**b**c)                ->  <a href="https://x.test/a<b>b</b>c">t</a>
[t](https://x.test/a~~b~~c)                ->  <a href="https://x.test/a<s>b</s>c">t</a>
[t](https://x.test/a*b*c)                  ->  <a href="https://x.test/a<i>b</i>c">t</a>
```

Telegram rejects that with `400 Bad Request: Can't parse entities: can't find end tag of href` — the reply is lost, not degraded.

## Changes

**`src/agentos/channels/_telegram_formatting.py`** (+31/-3)

- `_render_inline`: the URL is parked behind a `\x00TG_HREF_{i}\x00` placeholder before the inline passes and restored after, matching the `\x00TG_CODE_{i}\x00` shape the file already uses for code spans. Restore order is code-last, so a restored code span is never rescanned for href placeholders.
- `_plain_inline`: same treatment.

**Only the URL is parked, not the whole anchor.** Parking the entire `<a …>…</a>` is the shorter fix and it is wrong: link text is still Markdown, and `[**bold** link](url)` renders `<a href="url"><b>bold</b> link</a>` today. Hiding the anchor would silently drop that, so there is a test pinning it.

### The issue names one function; there are two

`_plain_inline` (used for table headers and labels, lines 131 and 141) has the same hazard with a **worse** outcome. It strips markers with a plain `str.replace`, so the characters are removed outright rather than turned into tags:

```
_plain_inline("[t](https://x.test/a__b__c)")  ->  "t (https://x.test/abc)"
```

The HTML path produces a message Telegram refuses — loud, and the user knows something broke. This one hands the reader a link that quietly points somewhere else. Fixing only the reported function would have left that in place, so both are fixed here.

## Tests

**`tests/test_channels/test_telegram_formatting.py`** — 10 new cases.

*Regression tests — these 7 fail on `upstream/main` and pass with the fix:*

| Test | Covers |
|---|---|
| `test_link_href_survives_inline_formatting_markers` | 4 parametrized cases: `__`, `**`, `~~`, `*` in the URL, each asserting the exact rendered anchor and that no `<b>`/`<i>`/`<s>` was injected |
| `test_two_links_with_markers_both_survive` | two affected links on one line stay distinct |
| `test_formatting_around_a_link_still_renders` | `**bold** then [t](url)` — parking must not disarm the rest of the line |
| `test_plain_inline_keeps_the_url_intact` | the table-label path, all three markers |

*Guard tests — these pass in both states by construction; flagging that rather than counting them as regressions:*

| Test | Covers |
|---|---|
| `test_formatting_inside_link_text_still_renders` | `[**bold** link](url)` and `[*em*](url)` — the behaviour the shorter fix would have broken |
| `test_plain_inline_still_strips_markers_outside_a_url` | the stripping `_plain_inline` exists for |
| `test_a_url_inside_a_code_span_is_untouched` | code spans were already protected; no regression |

No existing test was modified. All 447 tests under `tests/test_channels/` pass.

## Status

- `uv run ruff check src tests` ✅
- `uv run mypy src/agentos --show-error-codes` ✅ (623 source files, no issues)
- `uv run pytest -q` ✅ **9729 passed, 30 skipped**, 0 failed
- Self-check: reverted `_telegram_formatting.py` with `git checkout upstream/main -- <file>` and confirmed exactly the 7 regression cases fail without the fix.
- `ruff format --diff` reports one hunk in the source and four in the test file; all five are present unchanged on `upstream/main` and are not touched here. The lines added by this PR are format-clean.

Fixes #1435

🤖 Generated with [Claude Code](https://claude.com/claude-code)
