### PR TITLE
fix(telegram): protect link URLs from inline formatting regexes (#1435)

### DIFF
--- a/src/agentos/channels/_telegram_formatting.py
+++ b/src/agentos/channels/_telegram_formatting.py
@@ -43,11 +43,29 @@ def _replace_code_spans(text: str) -> tuple[str, list[str]]:
 def _render_inline(text: str) -> str:
     protected, code_chunks = _replace_code_spans(text)
     rendered = html.escape(protected)
-    rendered = _LINK_RE.sub(r'<a href="\2">\1</a>', rendered)
+
+    # Convert links first and stash just the URL so inline formatting
+    # regexes never touch characters inside href attributes (issue
+    # #1435: double underscores / asterisks / tildes in URLs were being
+    # wrapped in <b>/<i>/<s> tags, corrupting the HTML). Link text is
+    # left in place so it can still be formatted (e.g. [**bold**](url)).
+    url_placeholders: list[str] = []
+    def _protect_link(match: re.Match[str]) -> str:
+        placeholder = f"\x00TG_URL_{len(url_placeholders)}\x00"
+        url_placeholders.append(match.group(2))
+        return f'<a href="{placeholder}">{match.group(1)}</a>'
+
+    rendered = _LINK_RE.sub(_protect_link, rendered)
+
     rendered = re.sub(r"\*\*(?=\S)(.+?)(?<=\S)\*\*", r"<b>\1</b>", rendered)
     rendered = re.sub(r"__(?=\S)(.+?)(?<=\S)__", r"<b>\1</b>", rendered)
     rendered = re.sub(r"~~(?=\S)(.+?)(?<=\S)~~", r"<s>\1</s>", rendered)
     rendered = re.sub(r"(?<!\*)\*(?=\S)(.+?)(?<=\S)\*(?!\*)", r"<i>\1</i>", rendered)
+
+    # Restore protected URLs into their href attributes
+    for index, url in enumerate(url_placeholders):
+        rendered = rendered.replace(f"\x00TG_URL_{index}\x00", url)
+
     for index, chunk in enumerate(code_chunks):
         rendered = rendered.replace(f"\x00TG_CODE_{index}\x00", chunk)
     return rendered

--- a/tests/test_channels/test_telegram_formatting.py
+++ b/tests/test_channels/test_telegram_formatting.py
@@ -207,3 +207,34 @@ def test_mixed_ragged_rows_all_render_without_raw_pipes() -> None:
     assert "extra" not in rendered
     # No raw pipe characters.
     assert "|" not in rendered
+
+
+def test_telegram_markdown_does_not_format_markers_inside_link_urls() -> None:
+    """Markdown markers inside link URLs must not become HTML tags (#1435).
+
+    A URL containing double underscores, asterisks, or tildes was being
+    wrapped in <b>/<i>/<s> tags when the inline formatting regexes ran
+    over the already-rendered <a href="..."> tag, producing invalid HTML
+    that Telegram rejects with "Can't parse entities".
+    """
+    rendered = render_telegram_html("[test](https://example.com/foo__bar__baz)")
+    assert rendered == '<a href="https://example.com/foo__bar__baz">test</a>'
+
+    rendered = render_telegram_html("[test](https://example.com/foo*bar*baz)")
+    assert rendered == '<a href="https://example.com/foo*bar*baz">test</a>'
+
+    rendered = render_telegram_html("[test](https://example.com/foo~~bar~~baz)")
+    assert rendered == '<a href="https://example.com/foo~~bar~~baz">test</a>'
+
+
+def test_telegram_markdown_still_formats_link_text_and_bold_outside_links() -> None:
+    """Link text keeps inline formatting while URLs stay untouched (#1435)."""
+    rendered = render_telegram_html("[**bold**](https://example.com/x__y)")
+    assert rendered == '<a href="https://example.com/x__y"><b>bold</b></a>'
+
+    rendered = render_telegram_html(
+        "[test](https://example.com/foo__bar__baz) and **bold** text"
+    )
+    assert rendered == (
+        '<a href="https://example.com/foo__bar__baz">test</a> and <b>bold</b> text'
+    )


### PR DESCRIPTION
## Summary
`render_telegram_html` converts Markdown links to HTML `<a>` tags before processing inline Markdown formatting. When a URL contains `__`, `*`, or `~~` markers, the formatting regexes match inside the `href` attribute and inject `<b>/<i>/<s>` tags, producing invalid HTML.

**Vulnerability:** Malformed HTML causes Telegram Bot API to reject the message with \`400 Bad Request: Can't parse entities\`. The message is silently dropped.

**Root Cause:** Link conversion runs before inline formatting. The formatting regexes have no URL-awareness and match characters inside \`href="..."\`.

**Fix:** Stash the URL portion of each rendered \`<a>\` tag before running inline formatting regexes, then restore it. Link text (e.g. \`[**bold**](url)\`) remains formattable.

**Verification:** Added \`test_telegram_markdown_does_not_format_markers_inside_link_urls\` and \`test_telegram_markdown_still_formats_link_text_and_bold_outside_links\`. All 12 existing formatting tests pass. Run with: \`uv run pytest tests/test_channels/test_telegram_formatting.py -q\`