### PR TITLE
fix(memory): skip transcript re-read for unchanged sessions in sync (#1432)

### DIFF
--- a/src/agentos/memory/session_source.py
+++ b/src/agentos/memory/session_source.py
@@ -59,6 +59,14 @@ def _format_timestamp(ms: int | None) -> str:
     return datetime.fromtimestamp(ms / 1000, tz=UTC).isoformat()
 
 
+def build_session_source_path(session: Any) -> str:
+    """Return the derived document path for a session without rendering it."""
+    agent_id = _normalize_agent_id(getattr(session, "agent_id", None) or "main")
+    safe_agent = _safe_segment(agent_id, fallback="main")
+    safe_session_id = _safe_segment(session.session_id, fallback="session")
+    return f"sessions/{safe_agent}/{safe_session_id}.md"
+
+
 def build_session_source_document(
     session: Any,
     entries: list[Any],
@@ -130,13 +138,35 @@ class SessionSourceIndexer:
         indexed = 0
         skipped = 0
 
+        # Batch-load stored mtimes for every candidate session path so we
+        # only read transcripts for sessions whose document actually changed.
+        # Reading the full transcript of every session on every sync is
+        # wasteful: with max_sessions=1000 that is thousands of full reads
+        # per run even when nothing changed (issue #1432).
+        path_by_session = {
+            session.session_id: build_session_source_path(session)
+            for session in sessions
+        }
+        stored_mtimes = await self._store.get_file_mtimes(list(path_by_session.values()))
+
         for session in sessions:
+            path = path_by_session[session.session_id]
+            expected_paths.add(path)
+            session_mtime = (getattr(session, "updated_at", None) or 0) / 1000
+            if (
+                not force
+                and stored_mtimes.get(path) is not None
+                and abs(stored_mtimes[path] - session_mtime) < 1e-9
+            ):
+                # Document unchanged since last index; skip the transcript read.
+                skipped += 1
+                continue
+
             entries = await self._storage.get_transcript(session.session_id)
             if not entries:
                 skipped += 1
                 continue
             document = build_session_source_document(session, entries)
-            expected_paths.add(document.path)
             chunks = await self._store.index_file(
                 path=document.path,
                 content=document.content,

--- a/tests/test_memory_sessions_source.py
+++ b/tests/test_memory_sessions_source.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -265,3 +266,70 @@ async def test_memory_search_tool_outputs_sessions_source(tmp_path):
     assert retriever.opts.source is MemorySource.sessions
     assert "source: sessions" in output
     assert "sessions/main/session-1.md" in output
+
+
+@pytest.mark.asyncio
+async def test_session_source_indexer_skips_transcript_read_for_unchanged_sessions(tmp_path):
+    """Unchanged sessions must not have their full transcript re-read (#1432)."""
+    storage = SessionStorage(":memory:")
+    await storage.connect()
+    store = LongTermMemoryStore(tmp_path / "memory.db")
+    await store.initialize()
+    try:
+        session = SessionNode(
+            session_key="direct:user:thread",
+            session_id="session-1",
+            agent_id="main",
+            updated_at=1_700_000_000_000,
+        )
+        await storage.upsert_session(session)
+        await storage.append_transcript_entry(
+            TranscriptEntry(
+                session_id=session.session_id,
+                session_key=session.session_key,
+                role="user",
+                content="The migration keyword is cerulean.",
+                created_at=1_700_000_000_000,
+            )
+        )
+
+        indexer = SessionSourceIndexer(storage=storage, store=store, agent_id="main")
+
+        # First sync indexes the document.
+        result = await indexer.sync(force=True)
+        assert result.indexed == 1
+
+        # Second sync: transcript unchanged → must NOT re-read the transcript.
+        reads: list[str] = []
+        original = storage.get_transcript
+
+        async def counting_get_transcript(session_id: str) -> list[Any]:
+            reads.append(session_id)
+            return await original(session_id)
+
+        storage.get_transcript = counting_get_transcript  # type: ignore[method-assign]
+        result = await indexer.sync()
+        assert result.indexed == 0
+        assert result.skipped == 1
+        assert reads == [], f"transcript re-read for unchanged sessions: {reads}"
+
+        # Force sync still re-reads and re-indexes.
+        result = await indexer.sync(force=True)
+        assert result.indexed == 1
+
+        # After an update, the transcript is read again.
+        await storage.upsert_session(
+            SessionNode(
+                session_key=session.session_key,
+                session_id=session.session_id,
+                agent_id="main",
+                updated_at=1_700_000_000_001,
+            )
+        )
+        reads.clear()
+        result = await indexer.sync()
+        assert result.indexed == 1
+        assert reads == ["session-1"]
+    finally:
+        await store.close()
+        await storage.close()


### PR DESCRIPTION
## Summary
\`SessionSourceIndexer.sync()\` reads the full transcript of every session on every run (up to \`max_sessions=1000\`), even when nothing changed. With 200 sessions of 200 messages each, every sync reads ~1,000,000 rows only to discover they are unchanged.

**Vulnerability:** O(n) full-transcript reads per sync cycle — wasteful and slow as session count grows.

**Root Cause:** The sync loop unconditionally calls \`storage.get_transcript(session_id)\` for every session. There is no early-exit check against the stored file mtime.

**Fix:** Compute each session's document path up front, batch-load stored mtimes via \`store.get_file_mtimes()\`, and skip the transcript read when \`updated_at\` matches. Add \`build_session_source_path(session)\` helper. \`force=True\` still re-reads.

**Verification:** Added \`test_session_source_indexer_skips_transcript_read_for_unchanged_sessions\` — monkeypatches \`get_transcript\` with a counting wrapper, asserts zero calls on unchanged sessions. All 7 existing session source tests pass.