### PR TITLE
fix(pptx): preserve paragraph boundaries in table cells and use para.text (#1430)

### DIFF
--- a/src/agentos/skills/bundled/pptx/scripts/extract_text.py
+++ b/src/agentos/skills/bundled/pptx/scripts/extract_text.py
@@ -47,16 +47,45 @@ def _load_python_pptx():
     return Presentation
 
 
+def _paragraph_text(para, *, join: str = "") -> str:
+    """Return a paragraph's full text.
+
+    Uses ``para.text`` (which includes text in runs that a ``run.text``
+    walk would miss, e.g. placeholder-level or non-run paragraph text)
+    instead of joining only ``para.runs`` (issue #1430).
+    """
+    para_text = getattr(para, "text", None)
+    if para_text is None:
+        para_text = "".join(run.text for run in para.runs)
+    return para_text.strip()
+
+
 def _shape_text(shape) -> list[str]:
     """Return non-empty paragraph strings from a shape's text frame."""
     if not getattr(shape, "has_text_frame", False):
         return []
     out: list[str] = []
     for para in shape.text_frame.paragraphs:
-        line = "".join(run.text for run in para.runs).strip()
+        line = _paragraph_text(para)
         if line:
             out.append(line)
     return out
+
+
+def _cell_text(cell) -> str:
+    """Return a table cell's text, preserving paragraph boundaries.
+
+    Paragraphs inside a cell are joined with a space so multi-paragraph
+    cells read as separate lines instead of being smushed together
+    ("Q1 Revenue(USD)" instead of "Q1 Revenue (USD)").
+    """
+    paragraphs = [p for p in cell.text_frame.paragraphs]
+    parts: list[str] = []
+    for para in paragraphs:
+        para_text = _paragraph_text(para)
+        if para_text:
+            parts.append(para_text)
+    return " ".join(parts)
 
 
 def _table_text(shape) -> list[str]:
@@ -65,14 +94,7 @@ def _table_text(shape) -> list[str]:
         return []
     out: list[str] = []
     for row in shape.table.rows:
-        cells = [
-            "".join(
-                run.text
-                for para in cell.text_frame.paragraphs
-                for run in para.runs
-            ).strip()
-            for cell in row.cells
-        ]
+        cells = [_cell_text(cell) for cell in row.cells]
         cells = [c for c in cells if c]
         if cells:
             out.append(" | ".join(cells))


### PR DESCRIPTION
Table cell text extraction joined run.text across all paragraphs with empty string, smushing multi-paragraph cells ("Q1 Revenue(USD)" instead of "Q1 Revenue (USD)"). _shape_text used para.runs instead of para.text, missing non-run paragraph text.

**Vulnerability:** Data loss in PPTX text extraction — multi-paragraph table cells lose paragraph boundaries; placeholder-level text is omitted.

**Fix:** Extract _paragraph_text() helper preferring para.text (includes all text) with fallback to joining runs. Extract _cell_text() that joins paragraph texts with space separator.

**Verification:** uv run pytest tests/test_skill_pptx_delivery.py -q passes.