### PR TITLE
fix(identity): preserve underscores inside IDENTITY.md values (#1428)

### DIFF
--- a/src/agentos/identity/parser.py
+++ b/src/agentos/identity/parser.py
@@ -21,9 +21,15 @@ _KNOWN_IDENTITY_FIELDS = frozenset(["name", "emoji", "creature", "vibe", "theme"
 
 
 def _strip_markdown_inline(text: str) -> str:
-    """Strip inline markdown formatting: bold, italic, code."""
+    """Strip inline markdown formatting: bold, italic, code.
+
+    Per CommonMark, underscore-delimited emphasis requires word-boundary
+    flanking: ``_`` is only a delimiter when NOT surrounded by word
+    characters on both sides.  A bare ``_`` inside ``snake_case`` or
+    ``my_agent_name`` must be preserved (issue #1428).
+    """
     text = re.sub(r"\*{1,3}(.*?)\*{1,3}", r"\1", text)
-    text = re.sub(r"_{1,3}(.*?)_{1,3}", r"\1", text)
+    text = re.sub(r"(?<!\w)_{1,3}(?=\S)(.+?)(?<=\S)_{1,3}(?!\w)", r"\1", text)
     text = re.sub(r"`([^`]+)`", r"\1", text)
     return text
 

--- a/tests/test_identity/test_identity_parser.py
+++ b/tests/test_identity/test_identity_parser.py
@@ -1,0 +1,53 @@
+"""Tests for identity/parser.py — IDENTITY.md parsing and inline stripping."""
+
+from agentos.identity.parser import parse_identity
+
+
+def test_identity_preserves_underscores_in_values() -> None:
+    """Underscores inside words must be kept; only emphasis markers stripped.
+
+    Per CommonMark, _ underscores are only emphasis delimiters when they
+    are flanked by word-boundary characters. A bare _ inside
+    snake_case, my_agent_name, etc. is literal (issue #1428).
+    """
+    doc = """# Identity
+- name: my_agent_name
+- creature: snake_case_bot
+- theme: _cyberpunk_
+"""
+    result = parse_identity(doc)
+    assert result.name == "my_agent_name"
+    assert result.creature == "snake_case_bot"
+    assert result.theme == "cyberpunk"
+
+
+def test_identity_bold_and_code_are_stripped() -> None:
+    """Bold, italic, and code markers are still stripped normally."""
+    doc = """# Identity
+- name: **Alice**
+- creature: `robot`
+- emoji: ~~nah~~
+"""
+    result = parse_identity(doc)
+    assert result.name == "Alice"
+    assert result.creature == "robot"
+
+
+def test_identity_single_underscore_unaffected() -> None:
+    """A single underscore between two words is preserved."""
+    doc = """# Identity
+- name: x_y
+"""
+    result = parse_identity(doc)
+    assert result.name == "x_y"
+
+
+def test_identity_strips_surrounding_emphasis() -> None:
+    """Emphasis markers around a word are still stripped."""
+    doc = """# Identity
+- name: _hello_
+- creature: __hello__
+"""
+    result = parse_identity(doc)
+    assert result.name == "hello"
+    assert result.creature == "hello"


### PR DESCRIPTION
_strip_markdown_inline removed underscore pairs anywhere, rewriting my_agent_name to myagentname. No error is raised — the value is silently corrupted.

**Root Cause:** regex r"_{1,3}(.*?)_{1,3}" has no word-boundary guard. Contradicts CommonMark which forbids intra-word _ emphasis.

**Fix:** Add (?<!\w) lookbehind and (?!\w) lookahead so underscores are only stripped as emphasis when not flanked by word chars.

**Verification:** Added 4 tests (snake_case values, single underscores, real emphasis, bold+code). All pass: uv run pytest tests/test_identity/test_identity_parser.py -q