### PR TITLE
fix(tools): normalize offset display and handle out-of-range sheets (#1402)

### DIFF
--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -737,12 +737,19 @@ def _format_spreadsheet(
     limit: int,
 ) -> str:
     parts = [f"Workbook: {path.name}"]
+    # Normalize to a 1-indexed offset: offset=0 / negative offsets mean
+    # "start from the first row" and must display as row 1, not row 0
+    # (issue #1402).
+    offset = max(1, offset)
     start = max(0, offset - 1)
     for sheet_name, rows in sheets:
         width = max((len(row) for row in rows), default=0)
         parts.append("")
         parts.append(f"Sheet: {sheet_name} ({len(rows)} rows x {width} columns)")
         selected = rows[start : start + limit]
+        if not selected:
+            parts.append(f"(No rows to show at offset {offset} — sheet has {len(rows)} rows.)")
+            continue
         for idx, row in enumerate(selected, start=start + 1):
             parts.append(f"{idx}\t" + "\t".join(row))
         if start + limit < len(rows):

--- a/tests/test_security/test_file_read_redaction.py
+++ b/tests/test_security/test_file_read_redaction.py
@@ -302,3 +302,35 @@ def test_redact_terminal_output_still_masks_a_short_header_value() -> None:
     out = redact_terminal_output("Authorization: Bearer abc123def45", "curl -v https://x")
 
     assert "abc123def45" not in out
+
+
+def test_format_spreadsheet_offsets_display_row_1_not_row_0() -> None:
+    """offset=0 must display 'Showing rows 1-N', not 'Showing rows 0-N' (#1402)."""
+    from pathlib import Path
+
+    from agentos.tools.builtin.filesystem import _format_spreadsheet
+
+    p = Path("test.xlsx")
+    sheets = [("Sheet1", [["a"], ["b"], ["c"], ["d"], ["e"]])]
+    result = _format_spreadsheet(path=p, sheets=sheets, offset=0, limit=3)
+    assert "Showing rows 1" in result, f"Got: {result}"
+    assert "Showing rows 0" not in result
+
+    result = _format_spreadsheet(path=p, sheets=sheets, offset=2, limit=2)
+    assert "Showing rows 2" in result
+
+
+def test_format_spreadsheet_handles_offset_past_sheet_end_gracefully() -> None:
+    """Offset past the end of a sheet must show an informative message (#1402)."""
+    from pathlib import Path
+
+    from agentos.tools.builtin.filesystem import _format_spreadsheet
+
+    sheets = [
+        ("Sheet1", [["a"], ["b"]] * 50),
+        ("Sheet2", [["x"], ["y"], ["z"]]),
+    ]
+    result = _format_spreadsheet(path=Path("multi.xlsx"), sheets=sheets, offset=25, limit=10)
+    # Sheet2 only has 3 rows, offset 25 is past the end
+    assert "No rows to show" in result
+    assert "Sheet2" in result


### PR DESCRIPTION
Two bugs in _format_spreadsheet: (1) offset=0 displays "Showing rows 0-10" instead of "Showing rows 1-10". (2) Multi-sheet workbooks with offset past a sheet's row count silently produce an empty table.

**Fix:** Normalize offset = max(1, offset). Emit "(No rows to show at offset N — sheet has M rows.)" for out-of-range sheets.

**Verification:** Added 2 tests (offset=0 display, out-of-range sheet message). 33 existing redaction tests pass.