### PR TITLE
fix(xlsx): accept string-form merged ranges in create_xlsx build (#1401)

### DIFF
--- a/src/agentos/skills/bundled/xlsx/scripts/create_xlsx.py
+++ b/src/agentos/skills/bundled/xlsx/scripts/create_xlsx.py
@@ -54,7 +54,9 @@ def build(spec: dict[str, Any]) -> Workbook:
             ws.append([_coerce(v) for v in row])
 
         for merged in sheet_spec.get("merged") or []:
-            if isinstance(merged, dict) and "range" in merged:
+            if isinstance(merged, str):
+                ws.merge_cells(merged)
+            elif isinstance(merged, dict) and "range" in merged:
                 ws.merge_cells(str(merged["range"]))
 
         freeze = sheet_spec.get("freeze")

--- a/tests/test_skill_xlsx.py
+++ b/tests/test_skill_xlsx.py
@@ -148,3 +148,31 @@ def test_inspect_xlsx_creates_parent_directory(
     monkeypatch.setattr(sys, "argv", ["inspect_xlsx.py", str(src), "--out", str(out)])
     assert inspect_xlsx.main() == 0
     assert out.is_file()
+
+
+def test_create_xlsx_string_merged_ranges(tmp_path: Path) -> None:
+    """String-form merged ranges must not be silently dropped (#1401)."""
+    sys.path.insert(0, str(SCRIPTS))
+    try:
+        import create_xlsx
+        import inspect_xlsx
+    finally:
+        sys.path.pop(0)
+
+    spec = {
+        "sheets": [
+            {
+                "name": "Sheet1",
+                "rows": [[1, 2], [3, 4]],
+                "merged": ["A1:B1"],
+            }
+        ]
+    }
+    src = tmp_path / "merged.xlsx"
+    create_xlsx.build(spec).save(str(src))
+    assert src.exists()
+
+    inspected = inspect_xlsx.inspect(src, data_only=False)
+    sheet = next(s for s in inspected["sheets"] if s["name"] == "Sheet1")
+    # The merged cell range must be present in the output
+    assert any("A1:B1" in r for r in sheet["merged"]), f"Merged ranges: {sheet['merged']}"


### PR DESCRIPTION
build() only handled dict-form merged ranges ({'range': 'A1:B1'}), silently dropping string-form ('A1:B1') that inspect_xlsx.py natively emits.

**Vulnerability:** Round-tripping xlsx files with merged cells silently loses all merged range information.

**Fix:** Add isinstance(merged, str) branch before the dict check.

**Verification:** Added test_create_xlsx_string_merged_ranges. 6 existing xlsx tests pass.