### PR TITLE
fix(tools): clamp max_chars below 100 to 100 instead of disabling truncation (#1400)

### DIFF
--- a/src/agentos/tools/builtin/web_fetch.py
+++ b/src/agentos/tools/builtin/web_fetch.py
@@ -159,12 +159,16 @@ def _resolve_download_limit_bytes() -> int:
 
 
 def _resolve_effective_max_chars(max_chars: int | None) -> int | None:
-    """Resolve explicit max_chars or the default cap for omitted values."""
+    """Resolve explicit max_chars or the default cap for omitted values.
+
+    Values below 100 are clamped to 100, not silently disabled (issue
+    #1400: returning None allowed the caller to bypass all truncation,
+    returning far more data than the user requested).
+    """
     max_allowed = _active_run_budget_policy().max_single_fetch_chars
     if max_chars is not None:
-        if max_chars < 100:
-            return None
-        return min(max_chars, max_allowed) if max_allowed is not None else max_chars
+        clamped = max(max_chars, 100)
+        return min(clamped, max_allowed) if max_allowed is not None else clamped
     default = _resolve_default_max_chars()
     return min(default, max_allowed) if max_allowed is not None else default
 

--- a/tests/test_tools/test_web_fetch_truncation.py
+++ b/tests/test_tools/test_web_fetch_truncation.py
@@ -1,0 +1,36 @@
+"""Tests for web_fetch max_chars clamping."""
+
+from agentos.tools.builtin.web_fetch import _apply_max_chars, _resolve_effective_max_chars
+
+
+def test_resolve_effective_max_chars_clamps_below_100() -> None:
+    """max_chars < 100 must be clamped to 100, not disabled entirely (#1400)."""
+    result = _resolve_effective_max_chars(50)
+    assert result is not None, "max_chars=50 should be clamped, not None"
+    assert result >= 100, f"Expected >=100, got {result}"
+
+    result = _resolve_effective_max_chars(0)
+    assert result is not None
+    assert result >= 100
+
+
+def test_resolve_effective_max_chars_passes_safe_values() -> None:
+    """Normal max_chars values pass through unchanged (subject to max_allowed)."""
+    result = _resolve_effective_max_chars(100)
+    assert result is not None
+    assert result == 100
+
+    result = _resolve_effective_max_chars(500)
+    assert result is not None
+    assert result == 500
+
+
+def test_apply_max_chars_respects_clamped_limit() -> None:
+    """_apply_max_chars must truncate when capped, not return full content."""
+    full_text = "A" * 50000
+    result = _apply_max_chars({"text": full_text, "url": "https://example.com"}, 100)
+    # The wrapped output includes source info, but returned_length must be <= 100
+    gotten = result.get("returned_length", 0)
+    assert gotten <= 100, f"Expected <=100, got {gotten}"
+    assert result.get("original_length", 0) == 50000
+    assert result.get("truncated") is True


### PR DESCRIPTION
_resolve_effective_max_chars(max_chars=50) returns None, so _apply_max_chars skips all truncation. Requesting max_chars=50 returns the full document — more data than max_chars=1000.

**Vulnerability:** Budget bypass — any value < 100 disables the char limit entirely.

**Fix:** Replace return None with clamped = max(max_chars, 100).

**Verification:** 3 new tests verify clamping for <100 values, normal passthrough, and _apply_max_chars truncation.