### PR TITLE
fix(gateway): filter _ChannelInFlightSet.cancel_all to asyncio.Task only (#1399)

### DIFF
--- a/src/agentos/gateway/channel_dispatch.py
+++ b/src/agentos/gateway/channel_dispatch.py
@@ -188,8 +188,14 @@ class _ChannelInFlightSet:
         self._tasks.discard(token)  # type: ignore[arg-type]
 
     async def cancel_all(self) -> None:
-        """Cancel every in-flight task and await completion (for shutdown)."""
-        tasks = list(self._tasks)
+        """Cancel every in-flight task and await completion (for shutdown).
+
+        Reservation tokens (inserted by try_acquire) are opaque ``object()``
+        instances that lack a ``.cancel()`` method — filter to only
+        ``asyncio.Task`` instances so shutdown does not crash with
+        ``AttributeError`` (issue #1399).
+        """
+        tasks = [t for t in self._tasks if isinstance(t, asyncio.Task)]
         for t in tasks:
             t.cancel()
         if tasks:

--- a/tests/test_gateway/test_channel_concurrent_dispatch.py
+++ b/tests/test_gateway/test_channel_concurrent_dispatch.py
@@ -942,3 +942,26 @@ async def test_apply_overflow_policy_not_invoked_without_channel_override() -> N
             pass
 
     task_runtime.apply_overflow_policy.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_gracefully_handles_reservation_tokens() -> None:
+    """cancel_all() must not crash when the set contains opaque tokens (#1399).
+
+    Reservation tokens inserted by try_acquire() are object() instances
+    with no .cancel() method — the fix filters to asyncio.Task only.
+    """
+    ifs = _ChannelInFlightSet(cap=8)
+
+    # Insert a reservation token (as done in channel_dispatch.py line 850)
+    assert ifs.try_acquire(object())
+
+    # Also add a real task
+    t = asyncio.create_task(asyncio.sleep(60))
+    ifs.add(t)
+
+    # cancel_all must not raise AttributeError
+    await ifs.cancel_all()
+
+    # The real task should be cancelled
+    assert t.done()


### PR DESCRIPTION
cancel_all() calls .cancel() on every element in self._tasks. Reservation tokens (opaque object() instances from try_acquire) lack .cancel(), crashing shutdown with AttributeError.

**Fix:** Filter: tasks = [t for t in self._tasks if isinstance(t, asyncio.Task)]

**Verification:** Added test_cancel_all_gracefully_handles_reservation_tokens. 23 concurrent dispatch tests pass.