### PR TITLE
fix(tools): clamp hunk old_start to 0 in _apply_hunk for prepending hunks (#1166)

### DIFF
--- a/src/agentos/tools/builtin/patch.py
+++ b/src/agentos/tools/builtin/patch.py
@@ -455,8 +455,10 @@ def _apply_hunk(file_lines: list[str], hunk: Hunk) -> list[str]:
 
     Returns the new list of lines.
     """
-    # old_start is 1-indexed; convert to 0-indexed
-    pos = hunk.old_start - 1
+    # old_start is 1-indexed; convert to 0-indexed.
+    # old_start=0 means prepend to the beginning of the file
+    # (indices 0, not -1 — issue #1166).
+    pos = max(0, hunk.old_start - 1)
     result = list(file_lines)
 
     # Verify context and deleted lines match

--- a/tests/test_tools/test_apply_patch_gates.py
+++ b/tests/test_tools/test_apply_patch_gates.py
@@ -574,3 +574,37 @@ def test_parse_hunk_header_rejects_malformed_input(header: str) -> None:
 
     with pytest.raises(ValueError, match="Invalid hunk header"):
         _parse_hunk_header(header)
+
+
+def test_apply_hunk_prepending_new_file_from_empty() -> None:
+    """A hunk with old_start=0 should prepend to an empty file (#1166)."""
+    from agentos.tools.builtin.patch import Hunk, _apply_hunk
+
+    hunk = Hunk(
+        old_start=0,
+        old_count=0,
+        new_start=1,
+        new_count=2,
+        lines=[
+            "+#!/usr/bin/env python3\n",
+            "+# new file\n",
+        ],
+    )
+    result = _apply_hunk([], hunk)
+    assert result == ["#!/usr/bin/env python3\n", "# new file\n"], f"Got: {result}"
+
+
+def test_apply_hunk_prepending_to_existing_content() -> None:
+    """A hunk with old_start=0 prepends, does not corrupt, existing lines."""
+    from agentos.tools.builtin.patch import Hunk, _apply_hunk
+
+    existing = ["existing = True\n"]
+    hunk = Hunk(
+        old_start=0,
+        old_count=0,
+        new_start=1,
+        new_count=1,
+        lines=["+line_before\n"],
+    )
+    result = _apply_hunk(existing, hunk)
+    assert result == ["line_before\n", "existing = True\n"], f"Got: {result}"


### PR DESCRIPTION
When old_start=0 (prepending hunk), pos = -1. result[:-1] removes the last line of the file instead of prepending. Content is silently corrupted.

**Vulnerability:** Any apply_patch call with a prepending hunk silently drops the last file line.

**Fix:** pos = max(0, hunk.old_start - 1).

**Verification:** Added 2 tests (prepending to empty file, prepending to existing content). 34 patch gate tests pass.