### PR TITLE
fix(tools): pad xlsx worksheet row gaps to preserve row numbering (#1149)

### DIFF
--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -665,6 +665,14 @@ def _read_xlsx_worksheet(raw_xml: bytes, shared_strings: list[str]) -> list[list
     root = ET.fromstring(raw_xml)
     rows: list[list[str]] = []
     for row_el in root.findall(f".//{{{_XLSX_MAIN_NS}}}row"):
+        # Use the row's ``r`` attribute (1-indexed actual Excel row number) to
+        # detect gaps left by empty rows that have no <row> element in the XML.
+        # Insert padding for missing rows so row-number alignment is preserved
+        # and pagination (offset/limit) maps correctly (issue #1149).
+        row_num = int(row_el.attrib.get("r", str(len(rows) + 1)))
+        while len(rows) < row_num - 1:
+            rows.append([])  # empty row padding
+
         row: list[str] = []
         for cell_el in row_el.findall(f"{{{_XLSX_MAIN_NS}}}c"):
             column_index = _xlsx_column_index(cell_el.attrib.get("r", ""))

--- a/tests/test_tools/test_filesystem_read_workspace.py
+++ b/tests/test_tools/test_filesystem_read_workspace.py
@@ -410,3 +410,47 @@ async def test_list_dir_broken_symlink_does_not_crash(tmp_path: Path) -> None:
     assert "[file] valid.txt" in output
     assert "broken_link.txt" in output
 
+
+
+def test_read_xlsx_handles_empty_row_gaps() -> None:
+    """Empty rows in xlsx must not skew row numbering (#1149)."""
+    from agentos.tools.builtin.filesystem import _read_xlsx_worksheet
+
+    # Simulate XML with row 1, row 3 (no row 2 element)
+    xml = b'''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData>
+    <row r="1">
+      <c r="A1" t="inlineStr"><is><t>Row1</t></is></c>
+    </row>
+    <row r="3">
+      <c r="A3" t="inlineStr"><is><t>Row3</t></is></c>
+    </row>
+  </sheetData>
+</worksheet>'''
+    rows = _read_xlsx_worksheet(xml, [])
+    assert len(rows) == 3, f"Expected 3 rows, got {len(rows)}"
+    assert rows[0] == ["Row1"]
+    assert rows[1] == [], f"Row 2 should be empty, got {rows[1]}"
+    assert rows[2] == ["Row3"], f"Row 3 should be 'Row3', got {rows[2]}"
+
+
+def test_read_xlsx_with_adjacent_rows_is_unchanged() -> None:
+    """Adjacent rows still work correctly."""
+    from agentos.tools.builtin.filesystem import _read_xlsx_worksheet
+
+    xml = b'''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData>
+    <row r="1">
+      <c r="A1" t="inlineStr"><is><t>A</t></is></c>
+    </row>
+    <row r="2">
+      <c r="A2" t="inlineStr"><is><t>B</t></is></c>
+    </row>
+  </sheetData>
+</worksheet>'''
+    rows = _read_xlsx_worksheet(xml, [])
+    assert len(rows) == 2
+    assert rows[0] == ["A"]
+    assert rows[1] == ["B"]


### PR DESCRIPTION
_read_xlsx_worksheet iterates <row> elements in XML. When Excel omits empty rows, row numbers skip: sheet with row 1 and row 3 produces 2 rows instead of 3, misaligning pagination.

**Fix:** Parse row r attribute; pad with empty rows when gaps exist.

**Verification:** Added 2 tests (gap handling, adjacent rows). 20 filesystem tests pass.