### PR TITLE
fix(sandbox): add ~/.git-credentials, ~/.pgpass, and other host credential file denylists

### DIFF
--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -21,9 +21,12 @@ from pathlib import Path, PurePosixPath
 # the entire sensitive-path block layer. ONLY for trusted single-operator
 # environments / E2E testing where sandbox=false + sensitive_path checks
 # block valid agent commands like ``ls /etc/...``. Default off.
-_DISABLED = os.environ.get(
-    "AGENTOS_SENSITIVE_PATHS_DISABLED", ""
-).lower() in ("1", "true", "yes", "on")
+_DISABLED = os.environ.get("AGENTOS_SENSITIVE_PATHS_DISABLED", "").lower() in (
+    "1",
+    "true",
+    "yes",
+    "on",
+)
 
 
 # Path prefixes whose contents must not be read/written/deleted by the agent
@@ -47,6 +50,10 @@ _SENSITIVE_PREFIXES: tuple[str, ...] = (
     "~/.npmrc",
     "~/.pypirc",
     "~/.netrc",
+    "~/.git-credentials",
+    "~/.pgpass",
+    "~/.dockercfg",
+    "~/.htpasswd",
     "~/.gnupg",
     "~/.password-store",
     # A file, not a directory — the entries above all name directories, but the
@@ -89,6 +96,13 @@ _SENSITIVE_SUFFIXES: tuple[str, ...] = (
     # token written outside home. The leading dot is part of the match, so a
     # file merely named ``vault-token`` is left alone.
     "/.vault-token",
+    "/.git-credentials",
+    "/.pgpass",
+    "/.dockercfg",
+    "/.htpasswd",
+    "/.netrc",
+    "/.npmrc",
+    "/.pypirc",
 )
 
 _WORKSPACE_PARENT_EXCEPTION_MARKERS: tuple[str, ...] = ("/root",)
@@ -181,9 +195,7 @@ def _path_contains(path: str, root: str) -> bool:
         return False
     normalized_path = path.rstrip("/")
     normalized_root = root.rstrip("/")
-    return normalized_path == normalized_root or normalized_path.startswith(
-        normalized_root + "/"
-    )
+    return normalized_path == normalized_root or normalized_path.startswith(normalized_root + "/")
 
 
 def _segment_sweeps_its_parent(segment: str) -> bool:
@@ -270,9 +282,7 @@ def _workspace_contains(path: str, workspace: str | Path | None) -> bool:
     candidate_paths = _comparison_path_candidates(str(path))
     workspace_paths = _comparison_path_candidates(str(workspace))
     return any(
-        _path_contains(candidate, root)
-        for candidate in candidate_paths
-        for root in workspace_paths
+        _path_contains(candidate, root) for candidate in candidate_paths for root in workspace_paths
     )
 
 
@@ -290,9 +300,7 @@ def _workspace_nested_under_marker(workspace: str | Path | None, marker: str) ->
         pass
     for workspace_text in _comparison_path_candidates(str(workspace)):
         for marker_text in _comparison_path_candidates(marker):
-            if workspace_text != marker_text and _path_contains(
-                workspace_text, marker_text
-            ):
+            if workspace_text != marker_text and _path_contains(workspace_text, marker_text):
                 return True
     return False
 
@@ -340,9 +348,7 @@ def sensitive_path_marker(
     marker = is_sensitive_path(text)
     if marker is None:
         return None
-    if _workspace_contains(text, workspace) and _workspace_nested_under_marker(
-        workspace, marker
-    ):
+    if _workspace_contains(text, workspace) and _workspace_nested_under_marker(workspace, marker):
         leaf_marker = _sensitive_leaf_marker(text)
         return leaf_marker
     return marker
@@ -364,8 +370,7 @@ def _scan_text_for_marker(
         (match.group(0), match.start()) for match in _ABSOLUTE_OR_TILDE_PATH_RE.finditer(text)
     )
     with_context.extend(
-        (match.group("path"), match.start("path"))
-        for match in _DOTENV_LITERAL_RE.finditer(text)
+        (match.group("path"), match.start("path")) for match in _DOTENV_LITERAL_RE.finditer(text)
     )
 
     for raw in candidates:

--- a/tests/test_sandbox/test_sensitive_paths.py
+++ b/tests/test_sandbox/test_sensitive_paths.py
@@ -51,13 +51,10 @@ def test_active_workspace_exception_keeps_leaf_secret_blocks() -> None:
         "/.env*",
     }
     assert sensitive_path_marker(str(workspace / "id_rsa"), workspace=workspace) == "/id_rsa"
-    assert (
-        sensitive_path_in_text(
-            f"cat {workspace / '.env.local'}",
-            workspace=workspace,
-        )
-        in {"/.env.local", "/.env*"}
-    )
+    assert sensitive_path_in_text(
+        f"cat {workspace / '.env.local'}",
+        workspace=workspace,
+    ) in {"/.env.local", "/.env*"}
 
 
 def test_sensitive_command_targets_honor_active_workspace_exception() -> None:
@@ -70,13 +67,10 @@ def test_sensitive_command_targets_honor_active_workspace_exception() -> None:
         )
         is None
     )
-    assert (
-        sensitive_target_in_command(
-            f"rm {workspace / '.env'}",
-            workspace=workspace,
-        )
-        in {"/.env", "/.env*"}
-    )
+    assert sensitive_target_in_command(
+        f"rm {workspace / '.env'}",
+        workspace=workspace,
+    ) in {"/.env", "/.env*"}
 
 
 def test_windows_rooted_workspace_targets_keep_leaf_secret_blocks() -> None:
@@ -89,23 +83,17 @@ def test_windows_rooted_workspace_targets_keep_leaf_secret_blocks() -> None:
         )
         is None
     )
-    assert (
-        sensitive_target_in_command(
-            r"rm \root\.agentos\workspace\.env",
-            workspace=workspace,
-        )
-        in {"/.env", "/.env*"}
-    )
+    assert sensitive_target_in_command(
+        r"rm \root\.agentos\workspace\.env",
+        workspace=workspace,
+    ) in {"/.env", "/.env*"}
 
 
 def test_posix_sensitive_paths_stay_blocked_on_windows_runners() -> None:
     workspace = Path("/root/.agentos/workspace")
 
     assert sensitive_path_in_text("cat /dev/sda 2>/dev/null") == "/dev"
-    assert (
-        sensitive_path_in_text("cat /root/.ssh/id_rsa", workspace=workspace)
-        == "~/.ssh"
-    )
+    assert sensitive_path_in_text("cat /root/.ssh/id_rsa", workspace=workspace) == "~/.ssh"
 
 
 def test_every_rm_in_a_compound_command_is_checked() -> None:
@@ -349,6 +337,63 @@ def test_a_file_merely_named_vault_token_is_not_sensitive(path: str) -> None:
         return
 
     assert is_sensitive_path(path) is None
+
+
+@pytest.mark.parametrize(
+    ("relative", "marker"),
+    [
+        (".git-credentials", "~/.git-credentials"),
+        (".pgpass", "~/.pgpass"),
+        (".dockercfg", "~/.dockercfg"),
+        (".htpasswd", "~/.htpasswd"),
+    ],
+)
+def test_home_credential_files_missing_from_issue_981_are_sensitive(
+    relative: str,
+    marker: str,
+) -> None:
+    """Issue #981: files the host uses to store plaintext credentials that
+    were missing from _SENSITIVE_PREFIXES. git-credentials holds GitHub
+    tokens in plaintext, pgpass holds PostgreSQL passwords, dockercfg holds
+    Docker registry credentials, and htpasswd holds basic auth secrets."""
+    target = Path.home()
+    for part in relative.split("/"):
+        target = target / part
+    assert is_sensitive_path(str(target)) == marker
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/var/deploy/.git-credentials",
+        "/opt/db/.pgpass",
+        "/tmp/.dockercfg",
+        "/home/deploy/.htpasswd",
+    ],
+)
+def test_credential_files_outside_home_match_suffix_entries(path: str) -> None:
+    """Issue #981: when credential files land outside home, the suffix
+    entries catch them. Backslash-normalized spellings also match on all
+    platforms."""
+    # Extract suffix from the expected pattern
+    name = path.rsplit("/", 1)[-1]
+    assert is_sensitive_path(path) == f"/{name}"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/tmp/.netrc",
+        "/tmp/.npmrc",
+        "/tmp/.pypirc",
+    ],
+)
+def test_suffix_only_credential_files_are_sensitive_everywhere(path: str) -> None:
+    """Issue #981: .netrc, .npmrc, and .pypirc had entry-suffix protection
+    through their home prefix already, but the suffix entries were also
+    missing so copies anywhere on the filesystem were unprotected."""
+    name = path.rsplit("/", 1)[-1]
+    assert is_sensitive_path(path) == f"/{name}"
 
 
 def test_new_credential_paths_are_caught_in_free_form_text() -> None:

--- a/tests/test_sandbox/test_sensitive_paths_env_vars.py
+++ b/tests/test_sandbox/test_sensitive_paths_env_vars.py
@@ -51,7 +51,13 @@ def test_env_var_home_reads_are_blocked_like_tilde(
     home: Path, suffix: str, marker: str, spelling: str
 ) -> None:
     assert sensitive_path_in_text(f"cat ~/{suffix}") == marker
-    assert sensitive_path_in_text(f"cat {spelling}/{suffix}") == marker
+    result = sensitive_path_in_text(f"cat {spelling}/{suffix}")
+    # The path may be caught by prefix (~/.netrc) or suffix (/.netrc) —
+    # both correctly block, so accept either.
+    suffix_name = suffix.rsplit("/", 1)[-1]
+    expected_alternatives = {marker, f"/{suffix_name}"}
+    alternatives = expected_alternatives
+    assert result in alternatives, f"Got {result!r}, expected one of {alternatives}"
 
 
 def test_env_var_home_exfiltration_is_blocked(home: Path) -> None:


### PR DESCRIPTION
## Summary
`_SENSITIVE_PREFIXES` and `_SENSITIVE_SUFFIXES` in `agentos.sandbox.sensitive_paths` omitted several well-known host credential files despite `agentos.redact._CREDENTIAL_FILE_NAMES` already listing them for redaction. This created a security gap where agent shell commands could read, overwrite, or delete critical plaintext credential files without triggering the sensitive-path hard block.

## Vulnerability
An agent executing arbitrary shell commands could:
- `cat ~/.git-credentials` → exfiltrate plaintext GitHub personal access tokens
- `cat ~/.pgpass` → leak PostgreSQL database passwords
- `cat ~/.dockercfg` → steal Docker registry credentials (often with push access)
- `cat ~/.htpasswd` → leak HTTP basic auth password hashes
- `rm /tmp/.git-credentials` / `rm /tmp/.pgpass` → destroy credential copies placed anywhere on the filesystem

None of these would trigger a sensitive-path hard block. The redaction layer would mask them in output, but the file could still be read and exfiltrated through side channels (e.g. writing to a network location, encoding in filenames, or using timing side channels).

Additionally, `.netrc`, `.npmrc`, and `.pypirc` had only home-directory coverage through `_SENSITIVE_PREFIXES` but no suffix coverage, leaving copies outside home (e.g. `/tmp/.netrc`) unprotected.

## Root Cause
The sandbox-sensitive-path denylist had not been updated to match the redaction credential file list. `agentos.redact._CREDENTIAL_FILE_NAMES` already defined:
- `.git-credentials` — GitHub credential store with plaintext tokens/passwords
- `.pgpass` — PostgreSQL plaintext password file
- `.dockercfg` — Docker registry authentication
- `.htpasswd` — Apache-style basic auth credential file

But neither `_SENSITIVE_PREFIXES` (guards files at home paths like `~/.git-credentials`) nor `_SENSITIVE_SUFFIXES` (guards the same filenames anywhere on the filesystem) included them.

## Fix
### `_SENSITIVE_PREFIXES` additions (home-directory coverage):
- `"~/.git-credentials"` — GitHub tokens
- `"~/.pgpass"` — PostgreSQL passwords
- `"~/.dockercfg"` — Docker registry auth
- `"~/.htpasswd"` — Basic auth credentials

### `_SENSITIVE_SUFFIXES` additions (any-directory coverage):
- `"/.git-credentials"` — catch copies anywhere
- `"/.pgpass"` — catch copies anywhere
- `"/.dockercfg"` — catch copies anywhere
- `"/.htpasswd"` — catch copies anywhere
- `"/.netrc"` — was prefix-only, now suffix-protected
- `"/.npmrc"` — was prefix-only, now suffix-protected
- `"/.pypirc"` — was prefix-only, now suffix-protected

## Verification
Added 11 new parameterized test cases across three groups:
1. **Home-directory prefix matches**: `test_home_credential_files_missing_from_issue_981_are_sensitive` — verifies `~/.git-credentials`, `~/.pgpass`, `~/.dockercfg`, `~/.htpasswd` all return their prefix marker.
2. **Out-of-home suffix matches**: `test_credential_files_outside_home_match_suffix_entries` — verifies `/var/deploy/.git-credentials`, `/opt/db/.pgpass`, `/tmp/.dockercfg`, `/home/deploy/.htpasswd` all return their suffix marker.
3. **Pre-existing suffix-only files**: `test_suffix_only_credential_files_are_sensitive_everywhere` — verifies `/tmp/.netrc`, `/tmp/.npmrc`, `/tmp/.pypirc` (these were only prefix-protected before).

All 48 tests pass (37 existing + 11 new). Confirmed `is_sensitive_path("~/.git-credentials")` returns `"~/.git-credentials"` and `is_sensitive_path("/tmp/.pgpass")` returns `"/.pgpass"`.

### CI Fix
Updated `test_env_var_home_reads_are_blocked_like_tilde` to accept both `~/.netrc` and `/.netrc` markers, since the new suffix entries catch `$HOME/.netrc` before the prefix entry. Both correctly block the path — the marker string changed, not the security outcome.
