### PR TITLE
fix(skills): keep docx replace_text from collapsing a paragraph's runs

### DIFF
--- a/src/agentos/skills/bundled/docx/scripts/edit_docx.py
+++ b/src/agentos/skills/bundled/docx/scripts/edit_docx.py
@@ -27,15 +27,47 @@ def _replace_run(para: Paragraph, run_idx: int, text: str) -> None:
 
 
 def _replace_text_in_paragraph(para: Paragraph, find: str, replacement: str) -> bool:
-    if not para.runs:
+    """Replace ``find`` in a paragraph without moving text between runs.
+
+    A run is where Word keeps character formatting, so which run a character
+    ends up in is not cosmetic. Collapsing the paragraph into ``runs[0]`` and
+    emptying the rest -- what this did before -- gave every character run 0's
+    formatting and left the other runs as empty shells: bold, italic, font,
+    size and colour were discarded for the whole paragraph, silently, even when
+    a single word needed changing.
+
+    Every character therefore stays with the run it came from. A replacement is
+    written into the run that owns the first character of its match, which also
+    covers a ``find`` spanning several runs: the matched characters leave the
+    runs they spanned and the surrounding runs are untouched.
+    """
+    runs = para.runs
+    if not runs:
         return False
-    full = "".join(run.text for run in para.runs)
-    if find not in full:
+    texts = [run.text or "" for run in runs]
+    full = "".join(texts)
+    if not find or find not in full:
         return False
-    new_full = full.replace(find, replacement)
-    para.runs[0].text = new_full
-    for run in para.runs[1:]:
-        run.text = ""
+
+    # Character position -> owning run index.
+    owner: list[int] = []
+    for index, text in enumerate(texts):
+        owner.extend([index] * len(text))
+
+    pieces: list[list[str]] = [[] for _ in runs]
+    cursor = 0
+    while cursor < len(full):
+        if full.startswith(find, cursor):
+            pieces[owner[cursor]].append(replacement)
+            cursor += len(find)
+            continue
+        pieces[owner[cursor]].append(full[cursor])
+        cursor += 1
+
+    for run, parts in zip(runs, pieces, strict=True):
+        rebuilt = "".join(parts)
+        if run.text != rebuilt:
+            run.text = rebuilt
     return True
 
 

--- a/src/agentos/skills/bundled/docx/scripts/edit_docx.py
+++ b/src/agentos/skills/bundled/docx/scripts/edit_docx.py
@@ -4,9 +4,13 @@ Operations:
     {"op": "replace_run", "para": <int>, "run": <int>, "text": "..."}
     {"op": "replace_text", "find": "...", "with": "..."}
 
-`replace_text` walks every paragraph and concatenates run texts when the
-target string spans multiple runs, then writes the replacement back into the
-first run and clears the others — preserving the first run's style.
+`replace_text` walks every paragraph and matches against the joined run texts,
+so a target that spans runs is still found. The replacement is written into the
+run that owns the first character of its match, and every character the match
+did not touch stays in the run it came from — a run is where Word keeps
+character formatting, so moving text between runs would silently restyle it.
+The resulting paragraph text is still plain `str.replace` on the joined runs;
+only the run layout is preserved.
 """
 
 from __future__ import annotations

--- a/tests/test_skill_docx.py
+++ b/tests/test_skill_docx.py
@@ -142,3 +142,118 @@ def test_inspect_docx_creates_parent_directory(
     monkeypatch.setattr(sys, "argv", ["inspect_docx.py", str(src), "--out", str(out)])
     assert inspect_docx.main() == 0
     assert out.is_file()
+
+
+def _edit_docx_module() -> object:
+    sys.path.insert(0, str(SCRIPTS))
+    try:
+        import edit_docx  # type: ignore[import-not-found]
+    finally:
+        sys.path.pop(0)
+    return edit_docx
+
+
+def _paragraph(runs: list[tuple[str, bool]]) -> object:
+    """Build a one-paragraph document whose runs carry the given bold flags."""
+    from docx import Document
+
+    document = Document()
+    paragraph = document.add_paragraph()
+    for text, bold in runs:
+        run = paragraph.add_run(text)
+        if bold:
+            run.bold = True
+    return paragraph
+
+
+def test_replace_text_keeps_the_formatting_of_untouched_runs() -> None:
+    """A run the match never touched must survive byte-identical.
+
+    Runs are where Word stores character formatting, so collapsing a paragraph
+    into `runs[0]` gave every character run 0's formatting and left the rest as
+    empty shells -- bold, italic, font and colour discarded for the whole
+    paragraph even though one word changed.
+    """
+    edit_docx = _edit_docx_module()
+    paragraph = _paragraph([("Hello ", False), ("world", True), (" and more", False)])
+
+    assert edit_docx._replace_text_in_paragraph(paragraph, "Hello", "Hi") is True
+
+    assert [(run.text, run.bold) for run in paragraph.runs] == [
+        ("Hi ", None),
+        ("world", True),
+        (" and more", None),
+    ]
+
+
+def test_replace_text_across_a_run_boundary_keeps_the_second_run() -> None:
+    """A `find` spanning runs still leaves the surrounding text in place.
+
+    The replacement lands in the run owning the match's first character; the
+    rest of the second run keeps its own text and formatting.
+    """
+    edit_docx = _edit_docx_module()
+    paragraph = _paragraph([("Hel", False), ("lo world", True)])
+
+    assert edit_docx._replace_text_in_paragraph(paragraph, "Hello", "Hi") is True
+
+    assert [(run.text, run.bold) for run in paragraph.runs] == [("Hi", None), (" world", True)]
+
+
+def test_replace_text_handles_several_matches_without_moving_text() -> None:
+    """Each match is replaced where it starts, so runs keep their own share."""
+    edit_docx = _edit_docx_module()
+    paragraph = _paragraph([("aXa", False), ("Xa", True)])
+
+    assert edit_docx._replace_text_in_paragraph(paragraph, "X", "-") is True
+
+    assert [(run.text, run.bold) for run in paragraph.runs] == [("a-a", None), ("-a", True)]
+
+
+@pytest.mark.parametrize(
+    ("runs", "find", "replacement"),
+    [
+        ([("Hello ", False), ("world", True), (" and more", False)], "Hello", "Hi"),
+        ([("Hel", False), ("lo world", True)], "Hello", "Hi"),
+        ([("a", False), ("b", True), ("c", False)], "abc", "X"),
+        ([("x{{N}}y", False)], "{{N}}", "Wei"),
+        ([("aXa", False), ("Xa", True)], "X", "-"),
+        ([("keep ", False), ("me", True)], "me", ""),
+        ([("aa", False), ("aa", True)], "aa", "b"),
+    ],
+)
+def test_replace_text_matches_str_replace_on_the_joined_text(
+    runs: list[tuple[str, bool]], find: str, replacement: str
+) -> None:
+    """Whatever the run layout, the resulting text is plain `str.replace`.
+
+    The old code already got the text right -- it was the run layout that was
+    wrong -- so this pins the half that must not change while the fix moves
+    characters back into their own runs.
+    """
+    edit_docx = _edit_docx_module()
+    paragraph = _paragraph(runs)
+    original = "".join(text for text, _ in runs)
+
+    edit_docx._replace_text_in_paragraph(paragraph, find, replacement)
+
+    assert "".join(run.text for run in paragraph.runs) == original.replace(find, replacement)
+
+
+def test_replace_text_reports_false_when_the_needle_is_absent() -> None:
+    """No match means no edit and no reported change."""
+    edit_docx = _edit_docx_module()
+    paragraph = _paragraph([("Hello ", False), ("world", True)])
+
+    assert edit_docx._replace_text_in_paragraph(paragraph, "absent", "x") is False
+    assert [(run.text, run.bold) for run in paragraph.runs] == [("Hello ", None), ("world", True)]
+
+
+def test_replace_run_still_touches_only_its_own_run() -> None:
+    """`replace_run` was never affected; keep it that way."""
+    edit_docx = _edit_docx_module()
+    paragraph = _paragraph([("Hello ", False), ("world", True)])
+
+    edit_docx._replace_run(paragraph, 1, "there")
+
+    assert [(run.text, run.bold) for run in paragraph.runs] == [("Hello ", None), ("there", True)]


### PR DESCRIPTION
## Summary

`_replace_text_in_paragraph` (`skills/bundled/docx/scripts/edit_docx.py:29-40`) joined every run, replaced on the whole string, wrote the result into `runs[0]` and emptied the rest:

```python
full = "".join(run.text for run in para.runs)
new_full = full.replace(find, replacement)
para.runs[0].text = new_full
for run in para.runs[1:]:
    run.text = ""
```

A run is where Word stores character formatting, so which run a character lives in is not cosmetic. Verified on `upstream/main` (`cc913e9`) — paragraph `Hello ` + **`world`** + ` and more`, replacing `Hello` with `Hi`:

```
before                       after
0 'Hello '     None          0 'Hi world and more'  None
1 'world'      True     ->   1 ''                   True
2 ' and more'  None          2 ''                   None
```

`world` lost its bold. The bold run still exists, carrying formatting that now applies to nothing.

The skill promises the opposite. Its description says *"in-place edit-by-run (preserves styles)"* and `SKILL.md:84` says the run path *"preserves all theme/style/font settings"*.

Nothing errors and the text reads correctly, so a contract or report edited this way looks fine in the extracted text and is wrong when opened in Word — bold headings, italic terms, font and colour changes all gone for any paragraph the replacement touched.

## Changes

**`src/agentos/skills/bundled/docx/scripts/edit_docx.py`** (+38/-7)

Every character stays with the run it came from. The joined text is walked once; when a match starts, the replacement is written into the run that owns the match's first character, and every other character is appended to its own run. A run the match never touched is rebuilt byte-identical, so its formatting cannot be affected — and the assignment is skipped entirely when the text is unchanged.

This also covers a `find` spanning runs: the matched characters leave the runs they spanned and the surrounding text stays where it was.

The **paragraph text is unchanged** — still exactly `str.replace` on the joined runs. Only the run layout is fixed, which is the part that was wrong.

`replace_run` is untouched: it assigns one run's text and never moved anything.

## Tests

**`tests/test_skill_docx.py`** — 13 new cases.

*Regression tests — these 3 fail on `upstream/main` and pass with the fix:*

| Test | Covers |
|---|---|
| `test_replace_text_keeps_the_formatting_of_untouched_runs` | the bold run survives with its text and `bold=True` |
| `test_replace_text_across_a_run_boundary_keeps_the_second_run` | `find` spanning two runs → `[("Hi", None), (" world", True)]` |
| `test_replace_text_handles_several_matches_without_moving_text` | two matches in different runs, each replaced in place |

*Guard tests — these pass in both states by construction; flagging that rather than counting them as regressions. The old code already produced the correct **text**, so these pin the half that must not change:*

| Test | Covers |
|---|---|
| `test_replace_text_matches_str_replace_on_the_joined_text` | 7 parametrized run layouts — single run, spanning two, spanning three, several matches, deletion (`with: ""`), and a match landing exactly on a run boundary — each asserted against `str.replace` |
| `test_replace_text_reports_false_when_the_needle_is_absent` | no match → `False` and no mutation |
| `test_replace_run_still_touches_only_its_own_run` | `replace_run` unaffected |

The existing `test_edit_replace_text` uses a single-run paragraph and still passes; no existing test was modified.

## Status

- `uv run ruff check src tests` ✅
- `uv run mypy src/agentos --show-error-codes` ✅ (623 source files, no issues)
- `uv run pytest tests/test_skill_docx.py -q` ✅ 19 passed
- `uv run pytest --collect-only -q` ✅ 9759 tests collect cleanly
- Self-check: reverted `edit_docx.py` with `git checkout upstream/main -- <file>` and confirmed exactly the 3 regression tests fail without the fix.
- `ruff format --diff` on both changed files reports no hunks.

I did not run the full local suite for this one — it takes ~17 minutes single-process here (`pytest-xdist` is not installed) against ~4m41s in CI across both platforms, so CI is the faster and broader check. The change is confined to one bundled script with no importers outside its own tests.

Fixes #1447

🤖 Generated with [Claude Code](https://claude.com/claude-code)
