### PR TITLE
fix(sandbox): grade every delete verb in its own flag dialect

### DIFF
--- a/docs/approvals-and-permissions.md
+++ b/docs/approvals-and-permissions.md
@@ -93,10 +93,15 @@ capabilities are independent — they are not a single ladder:
 
 | Capability | Meaning | Granted by |
 |---|---|---|
-| *(none)* | delete this one path | `rm X`, `os.remove`, `os.unlink`, `os.rmdir`, `Path(X).unlink()`, `Path(X).rmdir()` |
-| `recursive` | delete the whole tree below it | `rm -r`/`-R`/`--recursive`, `shutil.rmtree(X)` |
-| `parents` | may also delete empty *ancestors* | `os.removedirs(X)` |
-| `force` | `rm`'s `-f`/`--force` | `rm -f`/`--force` |
+| *(none)* | delete this one path | `rm X`, `unlink X`, `rmdir X`, `del X`, `erase X`, `Remove-Item X`, `os.remove`, `os.unlink`, `os.rmdir`, `Path(X).unlink()`, `Path(X).rmdir()` |
+| `recursive` | delete the whole tree below it | `rm -r`/`-R`/`--recursive`, cmd.exe `/s`, PowerShell `-Recurse`, `shutil.rmtree(X)` |
+| `parents` | may also delete empty *ancestors* | `os.removedirs(X)`, `rmdir -p`/`--parents` |
+| `force` | ignore missing files and read-only flags | `rm -f`/`--force`, cmd.exe `/f`, PowerShell `-Force` |
+
+The same verb is graded in whichever dialect it is written: `rmdir /s /q X` is a
+Windows recursive delete, while `rmdir -p X` is the POSIX ancestor-pruning one.
+Switches never count as targets, so `rmdir /s /q /` is a recursive delete of `/`
+and not of three paths named `/s`, `/q` and `/`.
 
 So a `delete:recursive` approval covers a plain `rm X`, but a `delete:force`
 approval does **not** cover `shutil.rmtree(X)` — `force` says nothing about

--- a/src/agentos/application/intent_cache.py
+++ b/src/agentos/application/intent_cache.py
@@ -135,15 +135,77 @@ _RM_LONG_CAPABILITIES: dict[str, str] = {
     "--force": _FORCE,
 }
 
-# Shell command separators that terminate a single ``rm`` invocation.
+# ``rmdir -p a/b/c`` removes the leaf and then prunes empty ancestors, reaching
+# *above* the path it was handed. That is exactly ``os.removedirs`` above, so it
+# carries the same grade and the two spellings cover each other.
+_RMDIR_SHORT_CAPABILITIES: dict[str, frozenset[str]] = {"p": frozenset({_RECURSIVE, _PARENTS})}
+_RMDIR_LONG_CAPABILITIES: dict[str, frozenset[str]] = {
+    "--parents": frozenset({_RECURSIVE, _PARENTS})
+}
+
+# cmd.exe switches. ``/s`` recurses into subdirectories and ``/f`` forces
+# read-only files; ``/q`` (quiet) and ``/p`` (prompt) change only what the user
+# is shown, so neither is graded — the same reasoning that leaves ``rm -i``
+# ungraded above.
+_CMD_SWITCH_CAPABILITIES: dict[str, str] = {"s": _RECURSIVE, "f": _FORCE}
+
+# PowerShell parameters are matched by prefix: the parser accepts any
+# unambiguous abbreviation, so ``-Recu`` is ``-Recurse``. Names are compared
+# case-insensitively because PowerShell itself is.
+_PWSH_PARAM_CAPABILITIES: dict[str, str] = {"-recurse": _RECURSIVE, "-force": _FORCE}
+# These take the target as their *next* token rather than positionally.
+_PWSH_PATH_PARAMS: tuple[str, ...] = ("-path", "-literalpath")
+
+# A cmd.exe switch is a slash plus one letter, optionally ``:value`` (``/a:h``).
+# Anything longer is a POSIX path, which keeps ``/``, ``/tmp/x`` and
+# ``/etc/passwd`` as delete *targets* rather than swallowing them as flags.
+_CMD_SWITCH_RE = re.compile(r"^/[A-Za-z](?::[^\s/]*)?$")
+
+# Deletion verbs, each mapped to the flag dialects it may be speaking. A verb
+# can speak more than one: ``rmdir`` takes ``-p`` on POSIX and ``/s /q`` on
+# Windows, and a command the model writes may target either host. Matching is
+# case-insensitive because cmd.exe and PowerShell both are.
+#
+# The PowerShell alias ``ri`` is deliberately absent: two letters collide with
+# too many unrelated binaries to be worth the false positives.
+_POSIX, _CMD, _PWSH = "posix", "cmd", "pwsh"
+_DELETE_VERBS: dict[str, tuple[str, ...]] = {
+    "rm": (_POSIX,),
+    "unlink": (_POSIX,),
+    "rmdir": (_POSIX, _CMD),
+    "rd": (_CMD,),
+    "del": (_CMD,),
+    "erase": (_CMD,),
+    "remove-item": (_PWSH,),
+}
+
+# Longest-first so ``rmdir`` is not consumed as ``rm`` followed by ``dir``.
+#
+# The verb must start a word that is not an attribute access and must be
+# followed by whitespace, end-of-string, or an attached cmd.exe switch
+# (``del/f``). That keeps the Python spellings — ``os.rmdir(...)``,
+# ``Path(x).unlink()`` — with the ``_PY_DELETE_PATTERNS`` above that grade them
+# properly, instead of double-matching them here as shell verbs, and stops
+# ``docker run --rm image`` from reading as a delete of ``image``.
+_DELETE_VERB_RE = re.compile(
+    r"(?<![.\w-])("
+    + "|".join(sorted((re.escape(v) for v in _DELETE_VERBS), key=len, reverse=True))
+    + r")\b(?=\s|$|/[A-Za-z](?:[\s:]|$))([^;\n&|]*)",
+    re.IGNORECASE,
+)
+
+# Shell command separators that terminate a single delete invocation.
 _SHELL_SEPARATORS = (";", "&&", "||", "|", "&")
 
 
-def _rm_invocation_capabilities(tokens: list[str]) -> frozenset[str]:
-    """Grade one ``rm`` argument list by the escalating flags it carries.
+def _rm_invocation_capabilities(
+    tokens: list[str], *, allow_parents: bool = False
+) -> frozenset[str]:
+    """Grade one POSIX argument list by the escalating flags it carries.
 
     Stops flag parsing at ``--`` so ``rm -- -rf`` treats ``-rf`` as a filename,
-    the way ``rm`` itself does.
+    the way ``rm`` itself does. ``allow_parents`` enables the ``rmdir``-only
+    ``-p``/``--parents`` grade.
     """
     capabilities: set[str] = set()
     for token in tokens:
@@ -151,21 +213,27 @@ def _rm_invocation_capabilities(tokens: list[str]) -> frozenset[str]:
             break
         if token.startswith("--"):
             name = token.partition("=")[0]
+            if len(name) <= 2:
+                continue
             capabilities.update(
-                cap
-                for option, cap in _RM_LONG_CAPABILITIES.items()
-                if len(name) > 2 and option.startswith(name)
+                cap for option, cap in _RM_LONG_CAPABILITIES.items() if option.startswith(name)
             )
+            if allow_parents:
+                for option, caps in _RMDIR_LONG_CAPABILITIES.items():
+                    if option.startswith(name):
+                        capabilities.update(caps)
         elif token.startswith("-") and len(token) > 1:
             for char in token[1:]:
                 cap = _RM_SHORT_CAPABILITIES.get(char)
                 if cap is not None:
                     capabilities.add(cap)
+                if allow_parents:
+                    capabilities.update(_RMDIR_SHORT_CAPABILITIES.get(char, ()))
     return frozenset(capabilities)
 
 
 def _rm_invocation_targets(tokens: list[str]) -> list[str]:
-    """Non-flag arguments of one ``rm`` invocation, honouring ``--``."""
+    """Non-flag arguments of one POSIX invocation, honouring ``--``."""
     targets: list[str] = []
     end_of_flags = False
     for token in tokens:
@@ -183,21 +251,117 @@ def _rm_invocation_targets(tokens: list[str]) -> list[str]:
     return targets
 
 
-def _extract_rm_targets(command: str) -> list[tuple[str, frozenset[str]]]:
-    """Pull every ``rm`` argument out, tagged with that invocation's flags.
+def _cmd_invocation(tokens: list[str]) -> tuple[frozenset[str], list[str]]:
+    """Split one cmd.exe argument list into (capabilities, targets).
 
-    Handles ``rm a b c``, ``rm -rf /a /b``, quoted paths, and stops at shell
-    separators. Uses ``finditer`` so ``rm foo; rm -rf /bar`` yields targets
-    from both invocations independently — and each keeps its own capability
-    set, so the ``-rf`` on the second does not leak onto the first. Does not
-    try to be a full shell parser — falls back to whitespace split on shlex
-    errors (unbalanced quotes).
+    Only slash-plus-one-letter tokens are switches, so ``rmdir /s /q /`` grades
+    as a recursive delete of ``/`` rather than deleting three paths named
+    ``/s``, ``/q`` and ``/``.
+
+    Dash-prefixed tokens are read as PowerShell parameters, because ``del``,
+    ``rd`` and ``erase`` are also PowerShell aliases for ``Remove-Item`` and
+    take ``-Recurse``/``-Force`` there.
     """
-    # Match each ``rm`` invocation, stopping at shell separators.
-    # ``[^;\n&|]*`` captures everything from ``rm`` up to the next separator
-    # or end-of-expression, so each ``rm`` is tokenized independently.
-    pattern = re.compile(r"\brm\b([^;\n&|]*)")
-    matches = list(pattern.finditer(command))
+    capabilities: set[str] = set()
+    targets: list[str] = []
+    for token in tokens:
+        if not token:
+            continue
+        if _CMD_SWITCH_RE.match(token):
+            cap = _CMD_SWITCH_CAPABILITIES.get(token[1].lower())
+            if cap is not None:
+                capabilities.add(cap)
+            continue
+        if token.startswith("-") and len(token) > 1:
+            name = token.partition(":")[0].lower()
+            capabilities.update(
+                cap for param, cap in _PWSH_PARAM_CAPABILITIES.items() if param.startswith(name)
+            )
+            continue
+        targets.append(token)
+    return frozenset(capabilities), targets
+
+
+def _select_dialect(verb: str, tokens: list[str]) -> str:
+    """Pick the one dialect an invocation is actually speaking.
+
+    Only ``rmdir`` is ambiguous — POSIX ``rmdir -p`` and cmd.exe ``rmdir /s /q``
+    share the name. A switch-shaped token settles it. Applying both dialects
+    instead would emit the cmd switches as extra bogus targets.
+    """
+    dialects = _DELETE_VERBS[verb]
+    if len(dialects) == 1:
+        return dialects[0]
+    if _CMD in dialects and any(_CMD_SWITCH_RE.match(token) for token in tokens):
+        return _CMD
+    return dialects[0]
+
+
+def _pwsh_invocation(tokens: list[str]) -> tuple[frozenset[str], list[str]]:
+    """Split one PowerShell argument list into (capabilities, targets).
+
+    ``-Recurse``/``-Force`` are matched as whole parameter names by prefix, not
+    by scanning characters: a character scan reads the ``r`` in ``-Force`` and
+    grades a forced delete as a recursive one, which would let an approval for
+    ``-Force`` silently cover ``-Recurse``.
+    """
+    capabilities: set[str] = set()
+    targets: list[str] = []
+    want_path = False
+    for token in tokens:
+        if not token:
+            continue
+        if want_path and not token.startswith("-"):
+            targets.append(token)
+            want_path = False
+            continue
+        if token.startswith("-"):
+            name = token.partition(":")[0].lower()
+            capabilities.update(
+                cap for param, cap in _PWSH_PARAM_CAPABILITIES.items() if param.startswith(name)
+            )
+            want_path = any(param.startswith(name) for param in _PWSH_PATH_PARAMS)
+            continue
+        targets.append(token)
+    return frozenset(capabilities), targets
+
+
+def _tokenize_tail(tail: str) -> list[list[str]]:
+    """Every plausible tokenization of one invocation's argument text.
+
+    Windows paths are also read with ``posix=False`` so ``C:\\Users\\me\\.ssh``
+    survives instead of collapsing to ``C:Usersme.ssh``.
+    """
+    token_sets: list[list[str]] = []
+    try:
+        token_sets.append(shlex.split(tail))
+    except ValueError:
+        token_sets.append(tail.split())
+    windows_path = re.search(r"(?:^|\s)\\[^\s]", tail) or re.search(r"[A-Za-z]:\\", tail)
+    if "\\" in tail and (os.name == "nt" or windows_path):
+        try:
+            token_sets.append(shlex.split(tail, posix=False))
+        except ValueError:
+            token_sets.append(tail.split())
+    return token_sets
+
+
+def _extract_rm_targets(command: str) -> list[tuple[str, frozenset[str]]]:
+    """Pull every delete target out, tagged with that invocation's flags.
+
+    Recognises ``rm``, ``unlink``, ``rmdir``, ``rd``, ``del``, ``erase`` and
+    PowerShell ``Remove-Item``, each parsed in the flag dialect(s) it speaks, so
+    ``rmdir /s /q /`` and ``Remove-Item -Recurse -Force /`` reach the
+    sensitive-path hard block the same way ``rm -rf /`` does.
+
+    Uses ``finditer`` so ``rm foo; rm -rf /bar`` yields targets from both
+    invocations independently, each keeping its own capability set. The verb is
+    matched wherever it appears rather than only at a command boundary: this
+    feeds a security hard block, and ``find . -exec rm -rf / {} +`` or
+    ``xargs rm -rf /`` must still be caught. Does not try to be a full shell
+    parser — falls back to whitespace split on shlex errors (unbalanced quotes).
+    """
+    matches = list(_DELETE_VERB_RE.finditer(command))
     if not matches:
         return []
 
@@ -205,24 +369,21 @@ def _extract_rm_targets(command: str) -> list[tuple[str, frozenset[str]]]:
     seen: set[tuple[str, frozenset[str]]] = set()
 
     for match in matches:
-        tail = match.group(1).strip()
+        verb = match.group(1).lower()
+        tail = match.group(2).strip()
         if not tail:
             continue
 
-        token_sets: list[list[str]] = []
-        try:
-            token_sets.append(shlex.split(tail))
-        except ValueError:
-            token_sets.append(tail.split())
-        if "\\" in tail and (os.name == "nt" or re.search(r"(?:^|\s)\\[^\s]", tail)):
-            try:
-                token_sets.append(shlex.split(tail, posix=False))
-            except ValueError:
-                token_sets.append(tail.split())
-
-        for tokens in token_sets:
-            capabilities = _rm_invocation_capabilities(tokens)
-            for token in _rm_invocation_targets(tokens):
+        for tokens in _tokenize_tail(tail):
+            dialect = _select_dialect(verb, tokens)
+            if dialect == _POSIX:
+                capabilities = _rm_invocation_capabilities(tokens, allow_parents=verb == "rmdir")
+                invocation_targets = _rm_invocation_targets(tokens)
+            elif dialect == _CMD:
+                capabilities, invocation_targets = _cmd_invocation(tokens)
+            else:
+                capabilities, invocation_targets = _pwsh_invocation(tokens)
+            for token in invocation_targets:
                 entry = (token, capabilities)
                 if entry in seen:
                     continue

--- a/tests/test_application/test_intent_cache.py
+++ b/tests/test_application/test_intent_cache.py
@@ -12,7 +12,11 @@ from __future__ import annotations
 
 import pytest
 
-from agentos.application.intent_cache import IntentApprovalCache, _extract_intents
+from agentos.application.intent_cache import (
+    IntentApprovalCache,
+    _extract_intents,
+    _norm_path,
+)
 
 
 class TestCompoundCommandSeparatorBypass:
@@ -330,3 +334,104 @@ class TestDocumentedAsymmetries:
         cache.record("rm /tmp/d")
         assert cache.check("rm -d /tmp/d") is True
         assert cache.check('os.rmdir("/tmp/d")') is True
+
+
+class TestNonRmDeleteVerbs:
+    """Issue #1015: every deletion verb must reach the hard block, not just ``rm``.
+
+    ``_extract_intents`` feeds ``sensitive_target_in_command``, which is the
+    last line of defence before a shell command runs (ordinary approval cannot
+    override it). A verb it does not recognise is a silent bypass.
+    """
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "rmdir /s /q /",
+            "rd /s /q /",
+            "del /f /q /",
+            "erase /f /q /",
+            "unlink /",
+            "Remove-Item -Recurse -Force /",
+            "RMDIR /S /Q /",
+            "remove-item -recurse -force /",
+            "del/f /q /",
+        ],
+        ids=lambda c: c.replace(" ", "_"),
+    )
+    def test_root_target_is_extracted(self, command: str) -> None:
+        assert [target for _kind, target in _extract_intents(command)] == [_norm_path("/")]
+
+    @pytest.mark.parametrize(
+        ("command", "kind"),
+        [
+            ("rmdir /s /q /tmp/x", "delete:recursive"),
+            ("rmdir /q /tmp/x", "delete"),
+            ("rmdir -p /tmp/a/b", "delete:recursive+parents"),
+            ("del /f /tmp/x", "delete:force"),
+            ("del /s /tmp/x", "delete:recursive"),
+            ("Remove-Item -Force /tmp/x", "delete:force"),
+            ("Remove-Item -Recurse /tmp/x", "delete:recursive"),
+            ("Remove-Item -Path /tmp/x -Recurse", "delete:recursive"),
+            ("unlink /tmp/x", "delete"),
+        ],
+    )
+    def test_capability_grading_per_dialect(self, command: str, kind: str) -> None:
+        assert [k for k, _target in _extract_intents(command)] == [kind]
+
+    def test_force_approval_does_not_cover_recursive(self) -> None:
+        """``-Force`` must not grade as ``recursive``.
+
+        Reading the ``r`` out of ``-Force`` with a character scan grades a
+        forced delete as a recursive one, so approving ``-Force`` would
+        silently authorise ``-Recurse``.
+        """
+        cache = IntentApprovalCache()
+        cache.record("Remove-Item -Force /tmp/x")
+        assert cache.check("Remove-Item -Force /tmp/x") is True
+        assert cache.check("Remove-Item -Recurse /tmp/x") is False
+
+    def test_plain_windows_delete_does_not_cover_recursive(self) -> None:
+        """Approving ``rmdir /q X`` must not authorise ``rmdir /s /q X``."""
+        cache = IntentApprovalCache()
+        cache.record("rmdir /q /tmp/x")
+        assert cache.check("rmdir /s /q /tmp/x") is False
+
+    def test_cmd_switches_are_not_targets(self) -> None:
+        """``/s`` and ``/q`` are switches, not paths to delete."""
+        assert [t for _k, t in _extract_intents("rmdir /s /q /tmp/x")] == [_norm_path("/tmp/x")]
+
+    def test_posix_rmdir_target_survives(self) -> None:
+        """A POSIX ``rmdir`` with no switches keeps its path."""
+        assert [t for _k, t in _extract_intents("rmdir /tmp/empty")] == [_norm_path("/tmp/empty")]
+
+
+class TestDeleteVerbFalsePositives:
+    """Verbs must not fire on look-alikes that delete nothing."""
+
+    @pytest.mark.parametrize(
+        "command",
+        ["docker run --rm image", "echo delete", "cat notes.rd"],
+    )
+    def test_no_intent_extracted(self, command: str) -> None:
+        assert _extract_intents(command) == []
+
+    def test_verb_as_an_argument_still_over_detects(self) -> None:
+        """A verb passed as data is still read as a delete, and that is deliberate.
+
+        This detector feeds a security hard block, so it fails closed: matching
+        a verb anywhere is what keeps ``find . -exec rm -rf / {} +`` and
+        ``xargs rm -rf /`` caught. ``main`` already behaves this way for ``rm``
+        (``grep -r rm src``); the added verbs inherit the same trade-off, whose
+        usability side is tracked in #1349. Over-detection costs one approval
+        prompt, under-detection costs the host.
+        """
+        assert [k for k, _t in _extract_intents("grep -r rmdir src")] == ["delete"]
+
+    @pytest.mark.parametrize(
+        "command",
+        ['os.rmdir("/tmp/d")', 'Path("/tmp/x").unlink()', 'os.unlink("/tmp/x")'],
+    )
+    def test_python_spellings_stay_plain_deletes(self, command: str) -> None:
+        """The Python patterns own these; the shell verbs must not double-match."""
+        assert [k for k, _t in _extract_intents(command)] == ["delete"]


### PR DESCRIPTION
## Linked issue

Fixes #1015

- [x] This pull request fully resolves the linked issue, or the description
      says what remains.

## Summary

`_extract_intents` matched the literal verb `rm` and nothing else, so every
other deletion verb produced zero targets. `sensitive_target_in_command`
iterates those targets, so with none extracted it returned `None` and the
root-wipe and sensitive-path hard blocks never fired.

That block is the last line of defence. `shell.py` calls it before running any
command and only `/elevated full` bypasses it, so ordinary approval cannot
override it. On `main`:

```
/        rm -rf /                        <- blocked
None     rmdir /s /q /                   <- NOT blocked
None     rd /s /q /
None     del /f /q ~/.ssh/id_rsa
None     erase /f /q ~/.aws/credentials
None     unlink ~/.ssh/id_rsa
None     Remove-Item -Recurse -Force /
```

### Why not just add the verbs to the regex

Adding names to the pattern routes Windows and PowerShell commands into a
POSIX-only flag parser, which gets two things wrong.

**Switches become targets.** `_rm_invocation_targets` treats a token as a flag
only when it starts with `-`. cmd.exe switches start with `/`, so
`rmdir /s /q /` extracts three targets, `/s`, `/q` and `/`, instead of one.

**Grading silently breaks.** `rmdir /s /q X` grades as a plain `delete` because
no `-` flag is present. Approving `rmdir /q X` then covers `rmdir /s /q X`,
which reopens exactly the escalation that aa56af4 closed. The same happens in
PowerShell for a different reason: `_rm_invocation_capabilities` scans
individual characters, reads the `r` in `-Force`, and grades a forced delete as
a recursive one, so an approval for `-Force` covers `-Recurse`.

### What this change does

Each verb is parsed in the flag dialect it actually speaks.

| Verb | Dialect |
|---|---|
| `rm`, `unlink` | POSIX |
| `rmdir` | POSIX and cmd.exe, chosen per invocation |
| `rd`, `del`, `erase` | cmd.exe, plus PowerShell parameters since they are aliases for `Remove-Item` |
| `Remove-Item` | PowerShell |

- A cmd.exe switch is a slash plus one letter, optionally `:value`. Anything
  longer stays a path, so `/`, `/tmp/x` and `/etc/passwd` remain targets while
  `/s` and `/q` do not.
- `rmdir` is the only ambiguous name. A switch-shaped token picks the cmd.exe
  reading, otherwise POSIX. Applying both dialects would emit the switches as
  extra bogus targets.
- PowerShell parameters are matched as whole names by prefix, since the parser
  accepts unambiguous abbreviations. `-Force` grades `force`, `-Recurse` grades
  `recursive`.
- `rmdir -p` grades `recursive+parents`, matching `os.removedirs`, since both
  prune empty ancestors above the path they were handed.

**Verb matching stays unanchored on purpose.** This feeds a security hard block,
so it fails closed. Anchoring verbs to a command boundary would stop
`find . -exec rm -rf / {} +`, `xargs rm -rf /`, `env FOO=1 rm -rf /`,
`nohup rm -rf /` and `time rm -rf /` from being caught, all of which `main`
blocks today. The verb boundary does now exclude attribute access, which keeps
`os.rmdir(...)` and `Path(x).unlink()` with the `_PY_DELETE_PATTERNS` that
already grade them, and stops `docker run --rm image` reading as a delete of
`image`.

`docs/approvals-and-permissions.md` lists which spellings grant each capability,
so that table is updated in the same change.

### Not covered

`rd /s /q C:\` stays unblocked on a POSIX host, because `_norm_path` resolves
`C:\` against the working directory. `rm -rf C:\` behaves identically on `main`,
so this is a pre-existing `_norm_path` limitation rather than something this
change introduces. On Windows `_is_root_target("C:\\")` is already `True` and
the block fires.

A verb passed as data, such as `grep -r rmdir src`, is still read as a delete.
`main` already does this for `rm` (`grep -r rm src`), and #1349 tracks the
usability side. Over-detection costs one approval prompt, under-detection costs
the host. There is a test asserting this behaviour so it is not mistaken for an
oversight.

### Relationship to the other open PRs

#1015 has three. Flagging this so a maintainer does not have to diff them.

- **#1019** and **#1215** branch from blob `d27f0e841`; `main` is `7a8916872`.
  Commits aa56af4 and 95e1d72 landed in between. Neither PR contains any
  occurrence of `_graded_kind`, so merging either reverts destructiveness
  grading.
- **#1016** is current, but anchors verbs to command position. Running its head
  commit, `find . -exec rm -rf / {} +`, `xargs rm -rf /`, `env FOO=1 rm -rf /`,
  `nohup rm -rf /` and `time rm -rf /` all go from blocked on `main` to not
  blocked, and `rd /s /q C:\` is still missed.

## Tests

Rebased onto `origin/main` at e1e7a60 and re-verified there, since the branch
moves quickly. `intent_cache.py` is untouched upstream, and the bypass still
reproduces on that commit:

```
/        rm -rf /                        <- blocked
None     rmdir /s /q /                   <- still NOT blocked on e1e7a60
None     Remove-Item -Recurse -Force /
```

23 new tests in `tests/test_application/test_intent_cache.py` covering target
extraction per verb, capability grading per dialect, the two escalation guards,
and the false-positive boundaries.

The tests fail with the source change reverted, so they prove the fix rather
than describe it. Restoring `intent_cache.py` from `origin/main` and keeping the
new tests:

```
$ uv run pytest tests/test_application/test_intent_cache.py -q
23 failed, 58 passed

$ # with the fix applied
$ uv run pytest tests/test_application/test_intent_cache.py -q
81 passed
```

With the change:

```
$ uv run pytest tests/test_application tests/test_sandbox tests/test_security tests/test_tools -q
1435 passed, 5 skipped

$ uv run pytest -q          # full suite
9709 passed, 3 failed, 28 skipped

$ uv run ruff check src tests
All checks passed!

$ uv run mypy src/agentos --show-error-codes
Success: no issues found in 624 source files
```

The 3 failures are pre-existing and fail identically with this change reverted:
`test_cli/test_env_cmd.py::test_json_stdout_is_not_polluted_by_startup_logs`,
`test_cli/test_gateway_rpc_skew.py::test_gateway_older_warns_but_runs`, and
`test_gateway/test_status_version_provider.py::test_package_version_tracks_metadata_not_stale_literal`.

Every hunk in the diff sits inside a function this change reworks, or is the new
test class. No unrelated reformatting.

### Full CI

This repository holds workflow runs for first-time contributors, so the checks
on this PR sit in `action_required` until a maintainer approves them. The same
commit was run through this workflow on a fork in the meantime. Because
`workflow_dispatch` writes the `.ci/run-all` sentinel, every job ran rather than
the reduced set a `pull_request` event selects:

https://github.com/dxfareed/agent-os/actions/runs/34210227673

```
success   Classify changed files
success   Validate GitHub Actions workflows
success   Lint, test, and build (ubuntu-latest, 3.12)    9884 passed, 33 skipped
success   Lint, test, and build (windows-latest, 3.12)   9836 passed, 81 skipped
success   Release packaging contracts                    100 passed, 1 skipped
success   CI result
```

Frontend checks passed in the same run (99 files, 2041 tests).

The Windows job matters here: the reporter hit this on Windows 11, and the
cmd.exe and PowerShell dialects are most of this change.
