### PR TITLE
fix(tools): keep .xlsx row numbers aligned when a sheet has empty rows

### DIFF
--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -48,6 +48,7 @@ _BINARY_EXTENSIONS = {
     *_OFFICE_BINARY_EXTENSIONS,
 }
 _XLSX_MAIN_NS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+_XLSX_MAX_ROWS = 1_048_576  # OpenXML worksheet row ceiling
 _XLSX_PACKAGE_REL_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
 _XLSX_OFFICE_REL_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
 _BOOTSTRAP_SOURCE_FILENAMES = frozenset(BOOTSTRAP_FILENAMES)
@@ -673,8 +674,31 @@ def _read_xlsx_worksheet(raw_xml: bytes, shared_strings: list[str]) -> list[list
             row.append(_xlsx_cell_value(cell_el, shared_strings))
         while row and row[-1] == "":
             row.pop()
+        # OpenXML omits empty rows from <sheetData>, so the sheet is sparse in
+        # the same way a row is sparse in its cells. Pad to the declared row
+        # number or every later row shifts up, which both mislabels the row an
+        # agent is told it read and puts real data past the end of `offset`.
+        row_number = _xlsx_row_index(row_el.attrib.get("r", ""))
+        if row_number is not None:
+            while len(rows) < row_number - 1:
+                rows.append([])
         rows.append(row)
     return rows
+
+
+def _xlsx_row_index(row_ref: str) -> int | None:
+    """Return the 1-based row number from a ``<row r=...>`` attribute.
+
+    ``None`` for a missing, malformed, or out-of-range reference — those fall
+    back to positional append rather than padding a sheet to an absurd height.
+    """
+
+    if not row_ref.isdigit():
+        return None
+    number = int(row_ref)
+    if number < 1 or number > _XLSX_MAX_ROWS:
+        return None
+    return number
 
 
 def _xlsx_column_index(cell_ref: str) -> int:

--- a/tests/test_tools/test_xlsx_sparse_rows.py
+++ b/tests/test_tools/test_xlsx_sparse_rows.py
@@ -1,0 +1,151 @@
+"""Regression tests for issue #1149: sparse .xlsx rows keep their row numbers."""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from agentos.tools.builtin import filesystem as fs
+from agentos.tools.builtin.filesystem import (
+    _format_spreadsheet,
+    _read_xlsx_sheets,
+    _read_xlsx_worksheet,
+    _xlsx_row_index,
+)
+
+_SHEET_HEAD = (
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+    '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+    "<sheetData>"
+)
+_SHEET_TAIL = "</sheetData></worksheet>"
+
+
+def _row(number: str, column: str, text: str) -> str:
+    return (
+        f'<row r="{number}"><c r="{column}{number}" t="inlineStr"><is><t>{text}</t></is></c></row>'
+    )
+
+
+def _worksheet(*rows: str) -> bytes:
+    return (_SHEET_HEAD + "".join(rows) + _SHEET_TAIL).encode("utf-8")
+
+
+def _write_workbook(path: Path, worksheet: bytes) -> Path:
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr(
+            "xl/workbook.xml",
+            '<?xml version="1.0"?>'
+            '<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"'
+            ' xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">'
+            '<sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets>'
+            "</workbook>",
+        )
+        zf.writestr(
+            "xl/_rels/workbook.xml.rels",
+            '<?xml version="1.0"?>'
+            '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+            '<Relationship Id="rId1" Target="worksheets/sheet1.xml"'
+            ' Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>'
+            "</Relationships>",
+        )
+        zf.writestr("xl/worksheets/sheet1.xml", worksheet)
+    return path
+
+
+# ── Row padding ─────────────────────────────────────────────────────────
+
+
+def test_omitted_rows_are_padded_to_their_declared_row_number() -> None:
+    rows = _read_xlsx_worksheet(_worksheet(_row("1", "A", "Header"), _row("5", "A", "Data")), [])
+
+    assert rows == [["Header"], [], [], [], ["Data"]]
+
+
+def test_dense_sheet_is_unchanged() -> None:
+    rows = _read_xlsx_worksheet(
+        _worksheet(_row("1", "A", "a"), _row("2", "A", "b"), _row("3", "A", "c")), []
+    )
+
+    assert rows == [["a"], ["b"], ["c"]]
+
+
+def test_leading_gap_before_the_first_populated_row_is_padded() -> None:
+    rows = _read_xlsx_worksheet(_worksheet(_row("3", "A", "Data")), [])
+
+    assert rows == [[], [], ["Data"]]
+
+
+def test_rows_without_a_usable_reference_fall_back_to_positional_append() -> None:
+    worksheet = _worksheet(
+        '<row><c r="A1" t="inlineStr"><is><t>first</t></is></c></row>',
+        '<row r="not-a-number"><c r="A2" t="inlineStr"><is><t>second</t></is></c></row>',
+    )
+
+    assert _read_xlsx_worksheet(worksheet, []) == [["first"], ["second"]]
+
+
+def test_out_of_range_row_reference_does_not_inflate_the_sheet() -> None:
+    """A tiny file must not be able to allocate an absurd number of rows."""
+    worksheet = _worksheet(
+        _row("1", "A", "Header"),
+        '<row r="99999999999"><c r="A2" t="inlineStr"><is><t>Data</t></is></c></row>',
+    )
+
+    assert _read_xlsx_worksheet(worksheet, []) == [["Header"], ["Data"]]
+
+
+def test_row_index_bounds() -> None:
+    assert _xlsx_row_index("1") == 1
+    assert _xlsx_row_index("1048576") == 1_048_576
+    assert _xlsx_row_index("1048577") is None
+    assert _xlsx_row_index("0") is None
+    assert _xlsx_row_index("-2") is None
+    assert _xlsx_row_index("") is None
+    assert _xlsx_row_index(" 3 ") is None
+
+
+# ── Reported row numbers and pagination ─────────────────────────────────
+
+
+def test_formatted_output_reports_the_real_row_numbers(tmp_path: Path) -> None:
+    rows = _read_xlsx_worksheet(_worksheet(_row("1", "A", "Header"), _row("5", "A", "Data")), [])
+
+    output = _format_spreadsheet(
+        path=tmp_path / "test.xlsx", sheets=[("Sheet1", rows)], offset=1, limit=10
+    )
+
+    assert "Sheet: Sheet1 (5 rows x 1 columns)" in output
+    assert "1\tHeader" in output
+    assert "5\tData" in output
+    assert "2\tData" not in output
+
+
+def test_offset_reaches_a_row_past_a_gap(tmp_path: Path) -> None:
+    rows = _read_xlsx_worksheet(_worksheet(_row("1", "A", "Header"), _row("5", "A", "Data")), [])
+
+    output = _format_spreadsheet(
+        path=tmp_path / "test.xlsx", sheets=[("Sheet1", rows)], offset=5, limit=10
+    )
+
+    assert "5\tData" in output
+
+
+# ── End to end through the workbook reader ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_read_spreadsheet_keeps_row_numbers_for_a_sparse_workbook(tmp_path: Path) -> None:
+    workbook = _write_workbook(
+        tmp_path / "sparse.xlsx",
+        _worksheet(_row("1", "A", "Header"), _row("5", "A", "Data")),
+    )
+
+    [(name, rows)] = _read_xlsx_sheets(workbook)
+    assert name == "Sheet1"
+    assert rows == [["Header"], [], [], [], ["Data"]]
+
+    output = await fs.read_spreadsheet(str(workbook), offset=5)
+    assert "5\tData" in output


### PR DESCRIPTION
## Problem

OpenXML omits empty rows from `<sheetData>`, so a workbook with a header in
row 1 and data in row 5 arrives as two `<row>` elements.
`_read_xlsx_worksheet` appended them positionally, which compressed the
sheet:

- the agent was told row 5 was row 2 — a wrong row number reported as fact;
- `read_spreadsheet(path, offset=5)` sliced `rows[4:104]` out of a two-row
  list and reported the sheet as empty, so data past a gap was unreachable
  through pagination.

Sparse *columns* were already handled through `_xlsx_column_index`; rows
never got the same treatment.

## Fix

Rows are padded to the row number in the `<row r=...>` attribute, so the
reported numbers match the workbook and `offset` reaches the row it names.

`_xlsx_row_index` returns `None` for a missing, malformed, or out-of-range
reference and those rows fall back to positional append — a crafted
`r="99999999999"` cannot make a tiny file allocate an absurd number of rows.
The ceiling is the OpenXML worksheet limit, 1,048,576.

CSV/TSV reading, `_format_spreadsheet`, and dense workbooks are unchanged.

## Tests

`tests/test_tools/test_xlsx_sparse_rows.py` (new, 9 cases): padding for a
mid-sheet gap and for a leading gap, dense sheets unchanged, the fallback
for an unusable `r`, the out-of-range guard, `_xlsx_row_index` bounds,
row numbers in the formatted output, `offset` reaching a row past a gap, and
an end-to-end read of a real `.xlsx` through `read_spreadsheet`.

> Prior art: #1152 pads rows too. This one adds the guard for a missing,
> malformed, or out-of-range `r` — without it a crafted `r="99999999999"`
> in a tiny file pads the sheet to an absurd height — plus coverage of the
> reported row numbers, `offset` past a gap, and an end-to-end `.xlsx` read.

## Verification

- `uv run ruff check src tests` — passed
- `uv run mypy src/agentos --show-error-codes` — passed
- `uv run pytest -q` — full suite passed

Fixes #1149


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3B1CPvWx1QbC5jtoVCQFX
