### PR TITLE
fix(gateway): bound the transcript read behind sessions.preview

### DIFF
--- a/src/agentos/gateway/rpc_sessions.py
+++ b/src/agentos/gateway/rpc_sessions.py
@@ -2370,6 +2370,35 @@ async def _handle_sessions_messages_unsubscribe(params: dict | None, ctx: RpcCon
     return None
 
 
+# A preview is 120 characters of the last message, so it reads a bounded tail
+# instead of deserializing the whole history of every listed session. The
+# second window is the fallback for a tail that is all tool traffic.
+_PREVIEW_TRANSCRIPT_WINDOWS = (10, 50)
+
+
+def _preview_snippet(transcript: list[Any]) -> str:
+    """Return the last user/assistant message text, truncated for display."""
+
+    for entry in reversed(transcript):
+        if entry.role in ("user", "assistant") and entry.content:
+            return str(entry.content)[:120]
+    return ""
+
+
+async def _preview_last_message(storage: Any, session_id: str) -> str:
+    get_recent = getattr(storage, "get_recent_transcript", None)
+    if not callable(get_recent):
+        # Storage without a tail query keeps the old full read rather than
+        # losing the preview entirely.
+        return _preview_snippet(await storage.get_transcript(session_id, limit=-1))
+    for window in _PREVIEW_TRANSCRIPT_WINDOWS:
+        transcript = await get_recent(session_id, window)
+        snippet = _preview_snippet(transcript)
+        if snippet or len(transcript) < window:
+            return snippet
+    return ""
+
+
 @_d.method("sessions.preview")
 async def _handle_sessions_preview(params: dict | None, ctx: RpcContext) -> dict:
     keys = (params or {}).get("keys")
@@ -2401,13 +2430,7 @@ async def _handle_sessions_preview(params: dict | None, ctx: RpcContext) -> dict
         )
         last_msg = ""
         try:
-            transcript = await storage.get_transcript(s.session_id, limit=-1)
-            if transcript:
-                # Find the last user or assistant message for preview
-                for entry in reversed(transcript):
-                    if entry.role in ("user", "assistant") and entry.content:
-                        last_msg = entry.content[:120]
-                        break
+            last_msg = await _preview_last_message(storage, s.session_id)
         except Exception:
             pass
         previews.append(

--- a/tests/test_gateway/test_rpc_sessions_preview_bounded.py
+++ b/tests/test_gateway/test_rpc_sessions_preview_bounded.py
@@ -1,0 +1,154 @@
+"""Regression tests for issue #1186: sessions.preview reads a bounded tail.
+
+The preview is 120 characters of the last message, so the handler must not
+pull an entire session history into memory to produce it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from agentos.gateway.config import GatewayConfig
+from agentos.gateway.rpc import RpcContext
+from agentos.gateway.rpc_sessions import (
+    _PREVIEW_TRANSCRIPT_WINDOWS,
+    _handle_sessions_preview,
+    _preview_last_message,
+    _preview_snippet,
+)
+
+
+@dataclass
+class _Entry:
+    role: str
+    content: str
+
+
+class _Storage:
+    """Transcript storage that records how it was queried."""
+
+    def __init__(self, entries: list[_Entry]) -> None:
+        self.entries = entries
+        self.full_reads: list[Any] = []
+        self.windows: list[int] = []
+
+    async def get_transcript(self, session_id: str, limit: int | None = None) -> list[_Entry]:
+        self.full_reads.append(limit)
+        return list(self.entries)
+
+    async def get_recent_transcript(self, session_id: str, n: int) -> list[_Entry]:
+        self.windows.append(n)
+        return list(self.entries[-n:])
+
+
+class _LegacyStorage(_Storage):
+    """Storage predating ``get_recent_transcript`` — full read is all it has."""
+
+    get_recent_transcript = None  # type: ignore[assignment]
+
+
+def _transcript(count: int, *, tail_role: str = "assistant") -> list[_Entry]:
+    entries = [_Entry(role="user", content=f"msg {i}") for i in range(count - 1)]
+    entries.append(_Entry(role=tail_role, content="the last thing said"))
+    return entries
+
+
+# ── Bounded reads ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_preview_reads_only_the_recent_window() -> None:
+    storage = _Storage(_transcript(5_000))
+
+    assert await _preview_last_message(storage, "s1") == "the last thing said"
+    assert storage.windows == [_PREVIEW_TRANSCRIPT_WINDOWS[0]]
+    assert storage.full_reads == []
+
+
+@pytest.mark.asyncio
+async def test_preview_widens_once_when_the_tail_has_no_displayable_message() -> None:
+    entries = [_Entry(role="user", content="the only thing said")]
+    entries += [_Entry(role="tool", content=f"tool {i}") for i in range(30)]
+    storage = _Storage(entries)
+
+    assert await _preview_last_message(storage, "s1") == "the only thing said"
+    assert storage.windows == list(_PREVIEW_TRANSCRIPT_WINDOWS)
+    assert storage.full_reads == []
+
+
+@pytest.mark.asyncio
+async def test_preview_stops_widening_once_the_whole_session_is_in_the_window() -> None:
+    storage = _Storage([_Entry(role="tool", content="only tool output")])
+
+    assert await _preview_last_message(storage, "s1") == ""
+    assert storage.windows == [_PREVIEW_TRANSCRIPT_WINDOWS[0]]
+
+
+@pytest.mark.asyncio
+async def test_preview_never_widens_past_the_last_window() -> None:
+    storage = _Storage([_Entry(role="tool", content=f"tool {i}") for i in range(500)])
+
+    assert await _preview_last_message(storage, "s1") == ""
+    assert storage.windows == list(_PREVIEW_TRANSCRIPT_WINDOWS)
+    assert max(storage.windows) == _PREVIEW_TRANSCRIPT_WINDOWS[-1]
+
+
+@pytest.mark.asyncio
+async def test_storage_without_a_tail_query_still_produces_a_preview() -> None:
+    storage = _LegacyStorage(_transcript(20))
+
+    assert await _preview_last_message(storage, "s1") == "the last thing said"
+    assert storage.full_reads == [-1]
+
+
+# ── Snippet extraction ──────────────────────────────────────────────────
+
+
+def test_snippet_truncates_to_120_characters() -> None:
+    assert _preview_snippet([_Entry(role="user", content="x" * 500)]) == "x" * 120
+
+
+def test_snippet_skips_empty_and_non_conversational_entries() -> None:
+    entries = [
+        _Entry(role="user", content="kept"),
+        _Entry(role="assistant", content=""),
+        _Entry(role="tool", content="tool output"),
+        _Entry(role="system", content="system note"),
+    ]
+
+    assert _preview_snippet(entries) == "kept"
+
+
+def test_snippet_is_empty_for_an_empty_transcript() -> None:
+    assert _preview_snippet([]) == ""
+
+
+# ── Handler wiring ──────────────────────────────────────────────────────
+
+
+class _Session:
+    session_id = "sid-1"
+    session_key = "agent:main:sid-1"
+    display_name = "Sess"
+    updated_at = 42
+
+
+class _ListingStorage(_Storage):
+    async def list_sessions(self, limit: int = 50) -> list[_Session]:
+        return [_Session()]
+
+
+@pytest.mark.asyncio
+async def test_handler_previews_without_a_full_transcript_read() -> None:
+    storage = _ListingStorage(_transcript(5_000))
+    ctx = RpcContext(conn_id="c1", config=GatewayConfig())
+    ctx.session_manager = type("_Manager", (), {"storage": storage})()
+
+    payload = await _handle_sessions_preview(None, ctx)
+
+    assert payload["previews"][0]["lastMessage"] == "the last thing said"
+    assert storage.full_reads == []
+    assert storage.windows == [_PREVIEW_TRANSCRIPT_WINDOWS[0]]


### PR DESCRIPTION
## Problem

`sessions.preview` builds a 120-character snippet of the last message, and
it did that by calling `get_transcript(s.session_id, limit=-1)` for every
session in the list — reading and deserializing an entire history to look at
its tail. Previewing 50 long-running sessions pulled 50 full transcripts
into memory.

## Fix

The preview reads a bounded window through `get_recent_transcript` instead:

- 10 entries first, which is what the snippet actually needs;
- widened once to 50 when the tail is all tool traffic and holds no
  user/assistant message to show, so a tool-heavy session still gets its
  preview instead of a blank one;
- stops early once the window already covers the whole session.

Storage without a `get_recent_transcript` keeps the old full read rather
than losing the preview entirely. The snippet itself is unchanged: last
user/assistant message with content, first 120 characters. Memory is now
bounded by the window, not by session length.

## Tests

`tests/test_gateway/test_rpc_sessions_preview_bounded.py` (new, 9 cases):
a 5,000-entry session previewed from one 10-entry window with no full read,
the single widening when the tail is tool-only, the early stop, the cap at
the last window, the fallback for storage without a tail query, snippet
truncation and role/empty filtering, and the handler itself producing the
preview without a full transcript read.

> Prior art: #1187 bounds the same read by adding methods to
> `session/manager.py` and `session/storage.py`. This one stays inside
> `rpc_sessions.py` using the `get_recent_transcript` that storage already
> has, and handles the tool-only tail (a bounded widening) and storage
> without a tail query.

## Verification

- `uv run ruff check src tests` — passed
- `uv run mypy src/agentos --show-error-codes` — passed
- `uv run pytest -q` — full suite passed

Fixes #1186


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3B1CPvWx1QbC5jtoVCQFX
