### PR TITLE
fix(gateway): log the metric recording failures _emit_metric swallowed

### DIFF
--- a/src/agentos/gateway/task_runtime.py
+++ b/src/agentos/gateway/task_runtime.py
@@ -66,8 +66,17 @@ def _emit_metric(name: str, value: int = 1, **labels: Any) -> None:
             k: v for k, v in labels.items() if k not in {"session_key", "session_id", "turn_id"}
         }
         record_metric(name, value, **metric_labels)
-    except Exception:
-        pass
+    except Exception as exc:
+        # record_metric() swallows its own registry errors, so what lands here
+        # is the import or the label build failing — a metric that never
+        # reaches Prometheus while the log line above says it was emitted.
+        # Debug level: an observability gap must not add noise to a good turn.
+        log.debug(
+            "metric_record_failed",
+            metric=name,
+            error_type=type(exc).__name__,
+            error=str(exc),
+        )
 
 
 TERMINAL_STATUSES = frozenset(

--- a/tests/test_gateway/test_task_runtime_metric_errors.py
+++ b/tests/test_gateway/test_task_runtime_metric_errors.py
@@ -1,0 +1,100 @@
+"""Regression tests for issue #1188: a failed metric record leaves a trace.
+
+``_emit_metric`` used to swallow every failure with a bare ``pass``, so a
+metric that never reached Prometheus looked identical to one that did.
+
+The module logger is patched rather than captured with
+``structlog.testing.capture_logs``: structlog is configured globally, and a
+cached bound logger makes the capture context a no-op depending on what ran
+earlier in the session.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from agentos.gateway import task_runtime
+from agentos.observability import metrics as metrics_mod
+
+
+def _boom(name: str, value: float = 1.0, **labels: object) -> None:
+    raise RuntimeError("registry exploded")
+
+
+def test_record_failure_is_logged_at_debug_with_the_metric_name(monkeypatch) -> None:
+    monkeypatch.setattr(metrics_mod, "record_metric", _boom)
+
+    with patch.object(task_runtime, "log") as mock_log:
+        task_runtime._emit_metric("turn_cancellations_total", value=1, reason="timeout")
+
+    mock_log.debug.assert_called_once_with(
+        "metric_record_failed",
+        metric="turn_cancellations_total",
+        error_type="RuntimeError",
+        error="registry exploded",
+    )
+
+
+def test_an_unimportable_metrics_module_is_logged_too(monkeypatch) -> None:
+    monkeypatch.setitem(sys.modules, "agentos.observability.metrics", None)
+
+    with patch.object(task_runtime, "log") as mock_log:
+        task_runtime._emit_metric("queue_full_errors_total", value=1)
+
+    assert mock_log.debug.call_count == 1
+    assert mock_log.debug.call_args.kwargs["metric"] == "queue_full_errors_total"
+
+
+def test_a_record_failure_does_not_break_the_caller(monkeypatch) -> None:
+    monkeypatch.setattr(metrics_mod, "record_metric", _boom)
+
+    with patch.object(task_runtime, "log") as mock_log:
+        task_runtime._emit_metric("in_flight_turns_total", value=1, session_key="agent:main:s1")
+
+    # The metric log line the CI grep asserts on is still emitted.
+    mock_log.info.assert_called_once_with(
+        "in_flight_turns_total",
+        metric="in_flight_turns_total",
+        value=1,
+        session_key="agent:main:s1",
+    )
+
+
+def test_a_successful_record_logs_no_failure(monkeypatch) -> None:
+    recorded: list[tuple[str, float, dict]] = []
+
+    def ok(name: str, value: float = 1.0, **labels: object) -> None:
+        recorded.append((name, value, dict(labels)))
+
+    monkeypatch.setattr(metrics_mod, "record_metric", ok)
+
+    with patch.object(task_runtime, "log") as mock_log:
+        task_runtime._emit_metric(
+            "turn_cancellations_total",
+            value=1,
+            reason="timeout",
+            session_key="agent:main:s1",
+        )
+
+    assert not mock_log.debug.called
+    # session_key stays out of the exported labels; reason stays in.
+    assert recorded == [("turn_cancellations_total", 1, {"reason": "timeout"})]
+
+
+@pytest.mark.parametrize("label", ["session_key", "session_id", "turn_id"])
+def test_unbounded_identifiers_are_still_dropped_from_exported_labels(
+    monkeypatch, label: str
+) -> None:
+    recorded: list[dict] = []
+
+    def ok(name: str, value: float = 1.0, **labels: object) -> None:
+        recorded.append(dict(labels))
+
+    monkeypatch.setattr(metrics_mod, "record_metric", ok)
+
+    task_runtime._emit_metric("turn_cancellations_total", value=1, **{label: "x"})
+
+    assert recorded == [{}]


### PR DESCRIPTION
## Problem

`_emit_metric` logs the metric line, then records it to Prometheus inside a
`try` whose `except Exception` was a bare `pass`. A metric that never
reached the registry looked exactly like one that did — the log line above
says it was emitted either way — so an operator chasing a counter that
stopped moving had nothing to go on.

## Fix

The failure is logged at debug with the metric name and the exception type
and message.

Debug rather than warning: this is an observability gap, not a turn failure,
and it must not add noise to a working turn. Worth being precise about what
this catches — `record_metric` already swallows and debug-logs its own
registry errors, so what actually reaches this handler is the deferred
import or the label build failing. That is exactly the case where the
counter silently stops and nothing says why.

Metric names and the emitted log line are unchanged, so the CI counter-name
grep and every existing metric assertion still hold.

## Tests

`tests/test_gateway/test_task_runtime_metric_errors.py` (new, 7 cases): a
raising `record_metric` producing exactly one debug `metric_record_failed`
with the metric name and exception detail, an unimportable metrics module
logged the same way, the caller surviving a failure with its metric log line
intact, a successful record logging no failure, and `session_key` /
`session_id` / `turn_id` still dropped from exported labels.

> Prior art: #1189 logs the same failure. This one adds the exception type
> alongside the message, and coverage for the unimportable-module path, the
> caller surviving, and the label filtering.

## Verification

- `uv run ruff check src tests` — passed
- `uv run mypy src/agentos --show-error-codes` — passed
- `uv run pytest -q` — full suite passed

Fixes #1188


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3B1CPvWx1QbC5jtoVCQFX
