### PR TITLE
fix(gateway): count cancelled channel replies and label them apart from errors

### DIFF
--- a/src/agentos/gateway/channel_dispatch.py
+++ b/src/agentos/gateway/channel_dispatch.py
@@ -208,6 +208,54 @@ class _ChannelInFlightSet:
         self._tasks.clear()
 
 
+def _make_reply_done_callback(
+    in_flight: _ChannelInFlightSet,
+    session_key: str,
+) -> Callable[[asyncio.Task[Any]], None]:
+    """Build the done callback that retires a finished reply delivery task.
+
+    Both terminal outcomes are worth a counter, and they are different
+    outcomes: a cancelled reply is a turn that was interrupted, an exception
+    is a delivery that broke. They carry distinct ``reason`` labels so an
+    operator reading ``turn_cancellations_total`` can tell them apart.
+    """
+
+    def _reply_done(t: asyncio.Task[Any]) -> None:
+        in_flight.discard(t)
+        if t.cancelled():
+            # ``t.exception()`` raises CancelledError on a cancelled task, so
+            # the guard that avoided that used to skip the metric as well —
+            # real cancellations were the one outcome recorded nowhere.
+            log.info(
+                "channel_dispatch.reply_task_cancelled",
+                session_key=session_key,
+            )
+            _emit_metric(
+                "turn_cancellations_total",
+                value=1,
+                reason="reply_task_cancelled",
+                session_key=session_key,
+            )
+            return
+        exc = t.exception()
+        if exc is not None:
+            log.error(
+                "channel_dispatch.reply_task_error",
+                session_key=session_key,
+                error_type=type(exc).__name__,
+                error=str(exc),
+                exc_info=exc,
+            )
+            _emit_metric(
+                "turn_cancellations_total",
+                value=1,
+                reason="reply_task_error",
+                session_key=session_key,
+            )
+
+    return _reply_done
+
+
 def _compute_channel_cap(config: Any) -> int:
     """Compute the effective per-channel in-flight cap.
 
@@ -629,25 +677,7 @@ async def run_channel_dispatch(
                 )
                 _in_flight.add(reply_task)
 
-                def _reply_done(t: asyncio.Task[Any], _sk: str = session_key) -> None:
-                    _in_flight.discard(t)
-                    exc = t.exception() if not t.cancelled() else None
-                    if exc is not None:
-                        log.error(
-                            "channel_dispatch.reply_task_error",
-                            session_key=_sk,
-                            error_type=type(exc).__name__,
-                            error=str(exc),
-                            exc_info=exc,
-                        )
-                        _emit_metric(
-                            "turn_cancellations_total",
-                            value=1,
-                            reason="reply_task_error",
-                            session_key=_sk,
-                        )
-
-                reply_task.add_done_callback(_reply_done)
+                reply_task.add_done_callback(_make_reply_done_callback(_in_flight, session_key))
             continue
 
         # Gap 3: Start typing indicator (background task). On a streaming

--- a/tests/test_gateway/test_channel_concurrent_dispatch.py
+++ b/tests/test_gateway/test_channel_concurrent_dispatch.py
@@ -18,6 +18,7 @@ from agentos.gateway.channel_dispatch import (
     _ChannelInFlightSet,
     _compute_channel_cap,
     _deliver_runtime_channel_reply,
+    _make_reply_done_callback,
     _resolve_channel_overflow_policy,
 )
 
@@ -212,55 +213,103 @@ async def test_relay_close_on_success() -> None:
 # ── done_callback surfaces exceptions ────────────────────────────────────────
 
 
-@pytest.mark.asyncio
-async def test_ac2_3_done_callback_logs_error_and_counter() -> None:
-    """done_callback on a failing reply task logs error + turn_cancellations_total."""
-    metric_calls: list[str] = []
+async def _run_reply_done(coro: Any, *, session_key: str = "s:cb-test") -> tuple[Any, Any, Any]:
+    """Drive one reply task through the real done callback.
 
-    def _fake_emit(name: str, value: int = 1, **labels: Any) -> None:
-        metric_calls.append(name)
+    Returns the in-flight set, the recorded ``_emit_metric`` calls, and the
+    patched module logger.
+    """
+    metric_calls: list[tuple[str, dict[str, Any]]] = []
 
-    # Build a reply task that raises
-    async def _failing_reply() -> None:
-        raise ValueError("reply boom")
+    def _fake_emit(name: str, **labels: Any) -> None:
+        metric_calls.append((name, labels))
 
     ifs = _ChannelInFlightSet(cap=8)
 
-    session_key = "s:cb-test"
-
     with patch("agentos.gateway.channel_dispatch._emit_metric", side_effect=_fake_emit):
         with patch("agentos.gateway.channel_dispatch.log") as mock_log:
-            task = asyncio.create_task(_failing_reply())
+            task = asyncio.create_task(coro)
             ifs.add(task)
-
-            def _reply_done(t: asyncio.Task[Any], _sk: str = session_key) -> None:
-                ifs.discard(t)
-                exc = t.exception() if not t.cancelled() else None
-                if exc is not None:
-                    mock_log.error(
-                        "channel_dispatch.reply_task_error",
-                        session_key=_sk,
-                        error_type=type(exc).__name__,
-                        error=str(exc),
-                        exc_info=exc,
-                    )
-                    _fake_emit(
-                        "turn_cancellations_total",
-                        value=1,
-                        reason="reply_task_error",
-                        session_key=_sk,
-                    )
-
-            task.add_done_callback(_reply_done)
-            # Wait for task to complete
+            task.add_done_callback(_make_reply_done_callback(ifs, session_key))
+            # Let the task reach its first await point before cancelling it.
+            await asyncio.sleep(0)
+            if not task.done():
+                task.cancel()
             await asyncio.gather(task, return_exceptions=True)
-            # Give callbacks a chance to fire
+            # Give the done callback a chance to fire.
             await asyncio.sleep(0)
 
+    return ifs, metric_calls, mock_log
+
+
+@pytest.mark.asyncio
+async def test_ac2_3_done_callback_logs_error_and_counter() -> None:
+    """done_callback on a failing reply task logs error + turn_cancellations_total."""
+
+    async def _failing_reply() -> None:
+        raise ValueError("reply boom")
+
+    ifs, metric_calls, mock_log = await _run_reply_done(_failing_reply())
+
     assert mock_log.error.called, "log.error must be called on reply task exception"
-    assert "turn_cancellations_total" in metric_calls, (
-        "turn_cancellations_total counter must be incremented"
-    )
+    assert metric_calls == [
+        (
+            "turn_cancellations_total",
+            {"value": 1, "reason": "reply_task_error", "session_key": "s:cb-test"},
+        )
+    ]
+    assert not ifs._tasks
+
+
+@pytest.mark.asyncio
+async def test_done_callback_counts_a_cancelled_reply_task() -> None:
+    """A cancelled reply is a cancellation — issue #1190 recorded nothing at all."""
+
+    async def _long_reply() -> None:
+        await asyncio.sleep(60)
+
+    ifs, metric_calls, mock_log = await _run_reply_done(_long_reply())
+
+    assert metric_calls == [
+        (
+            "turn_cancellations_total",
+            {"value": 1, "reason": "reply_task_cancelled", "session_key": "s:cb-test"},
+        )
+    ]
+    assert not mock_log.error.called, "a cancellation is not a delivery error"
+    assert mock_log.info.called
+    assert not ifs._tasks
+
+
+@pytest.mark.asyncio
+async def test_done_callback_separates_cancellation_from_delivery_error() -> None:
+    """The two outcomes carry different reason labels on the same counter."""
+
+    async def _failing_reply() -> None:
+        raise ValueError("reply boom")
+
+    async def _long_reply() -> None:
+        await asyncio.sleep(60)
+
+    _ifs, error_calls, _log = await _run_reply_done(_failing_reply())
+    _ifs2, cancel_calls, _log2 = await _run_reply_done(_long_reply())
+
+    assert error_calls[0][1]["reason"] == "reply_task_error"
+    assert cancel_calls[0][1]["reason"] == "reply_task_cancelled"
+
+
+@pytest.mark.asyncio
+async def test_done_callback_is_silent_for_a_successful_reply() -> None:
+    """A delivered reply is retired from the in-flight set without a counter."""
+
+    async def _ok_reply() -> None:
+        return None
+
+    ifs, metric_calls, mock_log = await _run_reply_done(_ok_reply())
+
+    assert metric_calls == []
+    assert not mock_log.error.called
+    assert not ifs._tasks
 
 
 # ── stop_channel cancels all in-flight tasks ────────────────────────────────


### PR DESCRIPTION
## Problem

`_reply_done` extracted the outcome as
`exc = t.exception() if not t.cancelled() else None`. The guard is needed —
`exception()` raises on a cancelled task — but it also meant a real
cancellation took the `exc is None` path and emitted nothing. So
`turn_cancellations_total` never counted an actual cancelled reply, while
delivery exceptions were the only thing it did count.

## Fix

Both terminal outcomes are recorded, with distinct `reason` labels on the
same counter:

- cancelled → `reason="reply_task_cancelled"`, logged at info;
- exception → `reason="reply_task_error"`, logged at error with `exc_info`
  (unchanged).

An operator reading the counter can now tell an interrupted turn from a
broken delivery, and cancellations stop being invisible. The metric name is
unchanged, so the CI counter-name check and existing dashboards hold.

The callback moves out of `run_channel_dispatch` into
`_make_reply_done_callback` so the real code is reachable from a test: the
existing coverage re-implemented the closure inline in the test file and
asserted against its own copy, which is why the missing branch went
unnoticed. In-flight retirement (`_in_flight.discard`) is unchanged.

## Tests

`tests/test_gateway/test_channel_concurrent_dispatch.py`: the existing
`test_ac2_3_done_callback_logs_error_and_counter` now drives the real
callback instead of a copy, plus three new cases — a cancelled reply
counted with `reply_task_cancelled` and no error log, the two reasons
distinguished on the same counter, and a successful reply retired with no
counter at all. The new cases fail against the old callback body.

> Prior art: #1191 emits the cancellation metric too. This one also makes
> the callback reachable from a test: the existing coverage asserted against
> an inline copy of the closure, so a fix landing in the real code path
> would not have been proven by it.

## Verification

- `uv run ruff check src tests` — passed
- `uv run mypy src/agentos --show-error-codes` — passed
- `uv run pytest -q` — full suite passed

Fixes #1190


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3B1CPvWx1QbC5jtoVCQFX
