### PR TITLE
fix(gateway): report a missing session manager as UNAVAILABLE (#1192)

### DIFF
--- a/src/agentos/gateway/rpc/registry.py
+++ b/src/agentos/gateway/rpc/registry.py
@@ -296,10 +296,10 @@ async def _config_get(params: Any, ctx: RpcContext) -> Any:
 
 async def _sessions_get(params: Any, ctx: RpcContext) -> dict[str, Any]:
     if ctx.session_manager is None:
-        raise KeyError("No session manager available")
+        raise RpcUnavailableError("No session manager available")
     storage = get_session_storage(ctx.session_manager)
     if storage is None:
-        raise KeyError("No session storage available")
+        raise RpcUnavailableError("No session storage available")
     if not isinstance(params, dict) or "key" not in params:
         raise ValueError("params.key is required")
     session = await storage.get_session(params["key"])

--- a/src/agentos/gateway/rpc_chat.py
+++ b/src/agentos/gateway/rpc_chat.py
@@ -581,7 +581,7 @@ async def _handle_chat_inject(params: dict | None, ctx: RpcContext) -> dict:
     session_key = _canonical_webchat_session_key(params["sessionKey"])
 
     if ctx.session_manager is None:
-        raise KeyError("No session manager available")
+        raise RpcUnavailableError("No session manager available")
 
     storage = getattr(ctx.session_manager, "_storage", None)
     if storage is not None:

--- a/src/agentos/gateway/rpc_sessions.py
+++ b/src/agentos/gateway/rpc_sessions.py
@@ -959,11 +959,11 @@ async def _handle_sessions_send(params: dict | None, ctx: RpcContext) -> dict:
         raise ValueError(f"Invalid session intent: {params.get('intent')}") from exc
 
     if ctx.session_manager is None:
-        raise KeyError("No session manager available")
+        raise RpcUnavailableError("No session manager available")
 
     storage = get_session_storage(ctx.session_manager)
     if storage is None:
-        raise KeyError("No session storage available")
+        raise RpcUnavailableError("No session storage available")
 
     session = await storage.get_session(key)
     if session is None and session_intent is SessionIntent.CONTINUE:
@@ -1511,11 +1511,11 @@ async def _handle_sessions_patch(params: dict | None, ctx: RpcContext) -> dict:
     key = _require_key(params)
 
     if ctx.session_manager is None:
-        raise KeyError("No session manager available")
+        raise RpcUnavailableError("No session manager available")
 
     storage = get_session_storage(ctx.session_manager)
     if storage is None:
-        raise KeyError("No session storage available")
+        raise RpcUnavailableError("No session storage available")
 
     session = await storage.get_session(key)
     if session is None:
@@ -1608,11 +1608,11 @@ async def _handle_sessions_rename(params: dict | None, ctx: RpcContext) -> dict:
     name = normalize_session_name(params.get("name", params.get("displayName")))
 
     if ctx.session_manager is None:
-        raise KeyError("No session manager available")
+        raise RpcUnavailableError("No session manager available")
 
     storage = get_session_storage(ctx.session_manager)
     if storage is None:
-        raise KeyError("No session storage available")
+        raise RpcUnavailableError("No session storage available")
 
     session = await _resolve_session_node(storage, key)
     resolved_key = str(getattr(session, "session_key", "") or key)
@@ -1710,11 +1710,11 @@ async def _handle_sessions_reset(params: dict | None, ctx: RpcContext) -> dict[s
     key = _require_key(params)
 
     if ctx.session_manager is None:
-        raise KeyError("No session manager available")
+        raise RpcUnavailableError("No session manager available")
 
     storage = get_session_storage(ctx.session_manager)
     if storage is None:
-        raise KeyError("No session storage available")
+        raise RpcUnavailableError("No session storage available")
 
     task_runtime = getattr(ctx, "task_runtime", None)
     # Drain MUST run before any branch that clears session state — including the
@@ -1953,11 +1953,11 @@ def _reset_response(
 async def _handle_sessions_delete(params: dict | None, ctx: RpcContext) -> dict:
     """Delete one or more sessions. Accepts {key} for single or {keys} for bulk."""
     if ctx.session_manager is None:
-        raise KeyError("No session manager available")
+        raise RpcUnavailableError("No session manager available")
 
     storage = get_session_storage(ctx.session_manager)
     if storage is None:
-        raise KeyError("No session storage available")
+        raise RpcUnavailableError("No session storage available")
 
     # Support both single key and bulk keys
     keys: list[str] = []
@@ -2009,7 +2009,7 @@ async def _handle_sessions_delete(params: dict | None, ctx: RpcContext) -> dict:
 async def _handle_sessions_context_compact(params: dict | None, ctx: RpcContext) -> dict:
     key = _require_key(params)
     if ctx.session_manager is None:
-        raise KeyError("No session manager available")
+        raise RpcUnavailableError("No session manager available")
 
     context_window_tokens = _context_window_tokens(params, ctx)
     custom_instructions = (params or {}).get("instructions")
@@ -2249,7 +2249,7 @@ async def _handle_sessions_truncate(params: dict | None, ctx: RpcContext) -> dic
 
     key = _require_key(params)
     if ctx.session_manager is None:
-        raise KeyError("No session manager available")
+        raise RpcUnavailableError("No session manager available")
 
     max_messages = (params or {}).get("maxMessages", 20)
     force = bool((params or {}).get("force", False))
@@ -2427,11 +2427,11 @@ async def _handle_sessions_resolve(params: dict | None, ctx: RpcContext) -> dict
     key = _require_key(params)
 
     if ctx.session_manager is None:
-        raise KeyError("No session manager available")
+        raise RpcUnavailableError("No session manager available")
 
     storage = get_session_storage(ctx.session_manager)
     if storage is None:
-        raise KeyError("No session storage available")
+        raise RpcUnavailableError("No session storage available")
 
     session = await _resolve_session_node(storage, key)
 

--- a/tests/test_gateway/test_rpc_session_manager_unavailable.py
+++ b/tests/test_gateway/test_rpc_session_manager_unavailable.py
@@ -1,0 +1,79 @@
+"""An unwired session manager is UNAVAILABLE, never NOT_FOUND.
+
+The session handlers used to raise ``KeyError("No session manager available")``
+for a missing manager or storage. ``RpcRegistry.dispatch`` maps ``KeyError`` to
+``NOT_FOUND``, so a gateway with no session backend answered as though the
+caller had asked for a session key that does not exist — a permanent,
+non-retryable verdict for a condition that is neither. It also made the
+capability failure indistinguishable from a real lookup miss for any caller
+whose ``except KeyError:`` was meant to catch only the latter.
+
+``RpcUnavailableError`` is the shape the rest of the gateway already uses for
+this (``rpc_chat._require_chat_session_manager``, ``rpc_memory``,
+``sessions.create(message=...)``), and it dispatches as a retryable
+``UNAVAILABLE``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import agentos.gateway  # noqa: F401  - ensure handler modules are imported
+from agentos.gateway.access import ConnectionSurface
+from agentos.gateway.auth import AccessContext
+from agentos.gateway.protocol import ERROR_UNAVAILABLE
+from agentos.gateway.rpc import RpcContext, get_dispatcher
+
+SESSION_KEY = "agent:main:abc123"
+
+# Every session RPC that guards on ``ctx.session_manager``, with the smallest
+# params each one accepts before reaching that guard.
+UNAVAILABLE_CASES = [
+    ("sessions.get", {"key": SESSION_KEY}),
+    ("sessions.send", {"key": SESSION_KEY, "message": "hi"}),
+    ("sessions.patch", {"key": SESSION_KEY, "displayName": "x"}),
+    ("sessions.rename", {"key": SESSION_KEY, "name": "x"}),
+    ("sessions.reset", {"key": SESSION_KEY}),
+    ("sessions.delete", {"key": SESSION_KEY}),
+    ("sessions.contextCompact", {"key": SESSION_KEY}),
+    ("sessions.truncate", {"key": SESSION_KEY, "messageId": "m1"}),
+    ("sessions.resolve", {"key": SESSION_KEY}),
+    ("chat.inject", {"sessionKey": "webchat:main", "role": "user", "content": "hi"}),
+]
+
+
+def _ctx() -> RpcContext:
+    """A control connection on a gateway with no session manager wired."""
+    return RpcContext(
+        conn_id="conn-1",
+        access=AccessContext(
+            surface=ConnectionSurface.CONTROL, admitted=True, credential_verified=True
+        ),
+        session_manager=None,
+    )
+
+
+@pytest.mark.parametrize(
+    ("method", "params"), UNAVAILABLE_CASES, ids=[case[0] for case in UNAVAILABLE_CASES]
+)
+async def test_missing_session_manager_is_retryable_unavailable(
+    method: str, params: dict
+) -> None:
+    res = await get_dispatcher().dispatch("r1", method, params, _ctx())
+
+    assert res.error is not None, res
+    assert res.error.code == ERROR_UNAVAILABLE, res.error
+    assert res.error.retryable is True, res.error
+
+
+@pytest.mark.parametrize(
+    ("method", "params"), UNAVAILABLE_CASES, ids=[case[0] for case in UNAVAILABLE_CASES]
+)
+async def test_missing_session_manager_is_not_reported_as_not_found(
+    method: str, params: dict
+) -> None:
+    """NOT_FOUND is reserved for a session key that genuinely does not exist."""
+    res = await get_dispatcher().dispatch("r1", method, params, _ctx())
+
+    assert res.error is not None, res
+    assert res.error.code != "NOT_FOUND", res.error


### PR DESCRIPTION
Closes #1192

## The problem

Every session handler guards on `ctx.session_manager` (and its storage) with

```python
if ctx.session_manager is None:
    raise KeyError("No session manager available")
```

`RpcRegistry.dispatch` maps `KeyError` to `NOT_FOUND`. So a gateway with no session backend answers as though the caller asked for a session key that does not exist — a permanent, non-retryable verdict for a condition that is neither permanent nor about the key. It also makes the capability failure indistinguishable from a real lookup miss for any caller whose `except KeyError:` was written to catch only the latter.

## The fix

`RpcUnavailableError` is already what the rest of the gateway raises for exactly this shape — `rpc_chat._require_chat_session_manager`, `rpc_memory` ("Session manager is not configured"), and `rpc_sessions` itself at `sessions.create(message=...)` — and `dispatch` renders it as a retryable `UNAVAILABLE`.

This swaps the exception type at all 17 guards and changes nothing else:

| Method | Guards |
| --- | --- |
| `sessions.get` (registry built-in) | manager + storage |
| `sessions.send`, `.patch`, `.rename`, `.reset`, `.delete`, `.resolve` | manager + storage |
| `sessions.contextCompact`, `.truncate` | manager |
| `chat.inject` | manager |

`chat.inject` is included deliberately: it is the same guard with the same message in a module that already has `_require_chat_session_manager` raising `RpcUnavailableError` two hundred lines above it. Leaving it would have been the only surviving instance.

Every `raise KeyError(f"Session not found: {key}")` is untouched — that one really is `NOT_FOUND`.

## Behavior note for downstream

`agentos.cli.gateway_rpc.rpc_error_exit_code` maps `NOT_FOUND` to exit code 2 (the usage-error slot) and everything unrecognized to 1. A CLI command run against a gateway with no session backend therefore now exits 1 rather than 2 — a runtime failure rather than a usage error, which is the accurate reading.

## Tests

`tests/test_gateway/test_rpc_session_manager_unavailable.py` dispatches all ten methods against an `RpcContext` with `session_manager=None` and asserts `UNAVAILABLE` + `retryable=True`, plus a second pass asserting the code is not `NOT_FOUND`. All 20 fail on `main` and pass here.

## Verification

- `uv run ruff check src tests` — clean
- `uv run mypy src/agentos --show-error-codes` — clean
- `uv run pytest -q` — full suite green

## Merge independence

Part of a five-PR batch (#1192, #1194, #1198, #1201, #1203). All 120 merge orderings of the five were replayed against `main`: zero conflicts. The fully merged tree passes ruff, mypy and the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URXG1hX8EqgNcMgdqb3epi