### PR TITLE
fix(gateway): validate RPC params without an assert (#1194)

### DIFF
--- a/src/agentos/gateway/rpc/__init__.py
+++ b/src/agentos/gateway/rpc/__init__.py
@@ -27,6 +27,7 @@ from agentos.gateway.rpc.registry import (
     RpcUnavailableError,
     get_dispatcher,
     get_registry,
+    require_params_dict,
     validate_classification,
 )
 
@@ -41,6 +42,7 @@ __all__ = [
     "RpcUnavailableError",
     "get_dispatcher",
     "get_registry",
+    "require_params_dict",
     "validate_classification",
 ]
 

--- a/src/agentos/gateway/rpc/registry.py
+++ b/src/agentos/gateway/rpc/registry.py
@@ -78,6 +78,24 @@ class RpcMethodEntry:
     audiences: frozenset[ConnectionSurface]
 
 
+def require_params_dict(params: Any) -> dict[str, Any]:
+    """Return ``params`` as a mapping, or raise ``ValueError``.
+
+    Handlers used to narrow ``params: dict | None`` with
+    ``assert isinstance(params, dict)``. ``python -O`` and ``PYTHONOPTIMIZE``
+    strip assertions, so under an optimized interpreter that narrowing is a
+    comment: a non-mapping payload reaches the subscripts below it and leaves
+    the handler as an unhandled ``TypeError`` — reported as ``INTERNAL_ERROR``
+    rather than the ``INVALID_REQUEST`` the protocol promises for a malformed
+    request. A plain ``raise`` holds in every interpreter mode, and
+    :meth:`RpcRegistry.dispatch` already maps ``ValueError`` to
+    ``INVALID_REQUEST``.
+    """
+    if not isinstance(params, dict):
+        raise ValueError("params must be an object")
+    return params
+
+
 class RpcUnavailableError(RuntimeError):
     """Raised when a method exists but its backing capability is not wired."""
 

--- a/src/agentos/gateway/rpc_env.py
+++ b/src/agentos/gateway/rpc_env.py
@@ -26,7 +26,7 @@ import structlog
 
 from agentos import credential_sources, env_catalog, env_policy, env_store
 from agentos.gateway.access import CONTROL_ONLY
-from agentos.gateway.rpc import RpcContext, get_dispatcher
+from agentos.gateway.rpc import RpcContext, get_dispatcher, require_params_dict
 
 log = structlog.get_logger(__name__)
 
@@ -124,7 +124,7 @@ async def _handle_env_list(params: dict | None, ctx: RpcContext) -> dict[str, An
 async def _handle_env_set(params: dict | None, ctx: RpcContext) -> dict[str, Any]:
     """Write one variable. Returns its new state, without echoing the value."""
     name = _require_name(params)
-    assert isinstance(params, dict)
+    params = require_params_dict(params)
     if "value" not in params:
         raise ValueError("params.value is required")
     value = params["value"]
@@ -169,7 +169,7 @@ async def _handle_env_import(params: dict | None, ctx: RpcContext) -> dict[str, 
     get. The value goes source → store; it is not returned here.
     """
     name = _require_name(params)
-    assert isinstance(params, dict)
+    params = require_params_dict(params)
     source_id = str(params.get("sourceId") or "").strip()
     if not source_id:
         raise ValueError("params.sourceId is required")

--- a/src/agentos/gateway/rpc_sessions.py
+++ b/src/agentos/gateway/rpc_sessions.py
@@ -21,7 +21,13 @@ from agentos.gateway.input_normalization import (
     materialize_generated_text_attachments,
     normalize_incoming_text,
 )
-from agentos.gateway.rpc import RpcContext, RpcHandlerError, RpcUnavailableError, get_dispatcher
+from agentos.gateway.rpc import (
+    RpcContext,
+    RpcHandlerError,
+    RpcUnavailableError,
+    get_dispatcher,
+    require_params_dict,
+)
 from agentos.gateway.session_events import build_sessions_changed_payload
 from agentos.gateway.session_services import (
     get_session_epoch,
@@ -1522,7 +1528,7 @@ async def _handle_sessions_patch(params: dict | None, ctx: RpcContext) -> dict:
         raise KeyError(f"Session not found: {key}")
 
     update_values: dict[str, Any] = {}
-    assert isinstance(params, dict)
+    params = require_params_dict(params)
     field_map = {
         "displayName": "display_name",
         "model": "model",
@@ -1602,7 +1608,7 @@ async def _handle_sessions_rename(params: dict | None, ctx: RpcContext) -> dict:
     custom name and lets ``derived_title`` fall back to the short session id.
     """
     key = _require_key(params)
-    assert isinstance(params, dict)
+    params = require_params_dict(params)
     if "name" not in params and "displayName" not in params:
         raise ValueError("sessions.rename requires a 'name'")
     name = normalize_session_name(params.get("name", params.get("displayName")))

--- a/tests/test_gateway/test_rpc_params_validation.py
+++ b/tests/test_gateway/test_rpc_params_validation.py
@@ -1,0 +1,86 @@
+"""Malformed ``params`` must fail as INVALID_REQUEST in every interpreter mode.
+
+Several handlers narrowed ``params: dict | None`` with
+``assert isinstance(params, dict)``. Assertions are stripped under ``python -O``
+and ``PYTHONOPTIMIZE``, so on an optimized interpreter that line is a comment
+and a non-mapping payload reaches the subscripts below it — surfacing as an
+unhandled ``TypeError`` (``INTERNAL_ERROR``) instead of the ``INVALID_REQUEST``
+the protocol promises. ``require_params_dict`` raises unconditionally, so the
+guard survives ``-O``.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+import agentos.gateway  # noqa: F401  - ensure handler modules are imported
+from agentos.gateway.access import ConnectionSurface
+from agentos.gateway.auth import AccessContext
+from agentos.gateway.rpc import RpcContext, get_dispatcher, require_params_dict
+
+GATEWAY_SRC = Path(agentos.gateway.__file__).parent
+
+
+def _ctx() -> RpcContext:
+    return RpcContext(
+        conn_id="conn-1",
+        access=AccessContext(
+            surface=ConnectionSurface.CONTROL, admitted=True, credential_verified=True
+        ),
+    )
+
+
+class TestRequireParamsDict:
+    def test_returns_the_mapping_unchanged(self) -> None:
+        params = {"key": "agent:main:abc"}
+        assert require_params_dict(params) is params
+
+    @pytest.mark.parametrize("params", [None, [], ["key"], "key", 7, object()])
+    def test_rejects_every_non_mapping(self, params: object) -> None:
+        # ValueError is what RpcRegistry.dispatch maps to INVALID_REQUEST.
+        with pytest.raises(ValueError, match="params must be an object"):
+            require_params_dict(params)
+
+
+class TestNoStrippableParamGuards:
+    """No gateway handler may rely on an ``assert`` to validate ``params``."""
+
+    def test_no_assert_isinstance_params_in_gateway_sources(self) -> None:
+        offenders: list[str] = []
+        for path in sorted(GATEWAY_SRC.rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Assert):
+                    continue
+                test = node.test
+                if (
+                    isinstance(test, ast.Call)
+                    and isinstance(test.func, ast.Name)
+                    and test.func.id == "isinstance"
+                    and test.args
+                    and isinstance(test.args[0], ast.Name)
+                    and test.args[0].id == "params"
+                ):
+                    rel = path.relative_to(GATEWAY_SRC.parent.parent)
+                    offenders.append(f"{rel}:{node.lineno}")
+        assert offenders == [], (
+            "assert-based params validation is stripped by python -O; "
+            f"use require_params_dict instead: {offenders}"
+        )
+
+
+class TestDispatcherRejectsNonMappingParams:
+    @pytest.mark.parametrize(
+        "method",
+        ["sessions.patch", "sessions.rename", "env.set", "env.import"],
+    )
+    @pytest.mark.parametrize("params", [None, [], "key"])
+    async def test_invalid_request_instead_of_internal_error(
+        self, method: str, params: object
+    ) -> None:
+        res = await get_dispatcher().dispatch("r1", method, params, _ctx())
+        assert res.error is not None, res
+        assert res.error.code == "INVALID_REQUEST", res.error


### PR DESCRIPTION
Closes #1194

## The problem

Four handlers narrowed `params: dict | None` with a bare assertion:

```python
name = _require_name(params)
assert isinstance(params, dict)
if "value" not in params:
    ...
```

`python -O` and `PYTHONOPTIMIZE=1` strip assertions, so on an optimized interpreter that line is a comment. The narrowing it promises mypy is not the narrowing the runtime gets.

**Honest scoping:** in all four handlers the assert is preceded by `_require_key(params)` or `_require_name(params)`, both of which already raise `ValueError` on a non-mapping. So today the assert is not reachable as a live failure and I could not produce the `TypeError` the issue predicts. The defect is that the `INVALID_REQUEST` guarantee rests on that call ordering *plus* an interpreter flag rather than on the guard itself — remove or reorder one `_require_*` call and an `-O` deployment starts answering `INTERNAL_ERROR` to a malformed request, silently and only in production.

## The fix

`require_params_dict` in `agentos.gateway.rpc.registry`:

```python
def require_params_dict(params: Any) -> dict[str, Any]:
    if not isinstance(params, dict):
        raise ValueError("params must be an object")
    return params
```

It lives next to the dispatcher because the dispatcher owns the `ValueError` → `INVALID_REQUEST` mapping it depends on. Each `assert isinstance(params, dict)` becomes `params = require_params_dict(params)` — same line, same mypy narrowing, no interpreter dependency.

Call sites: `sessions.patch`, `sessions.rename`, `env.set`, `env.import`.

## Tests

`tests/test_gateway/test_rpc_params_validation.py`:

- `require_params_dict` returns the mapping unchanged and rejects `None`, `[]`, `"key"`, `7`, `object()`.
- An AST scan of `agentos/gateway/**` fails if an `assert isinstance(params, ...)` guard is reintroduced anywhere. This is the test that fails on `main`.
- All four methods dispatched with `None` / `[]` / `"key"` return `INVALID_REQUEST`, pinning the contract that holds whichever guard fires first.

## Verification

- `uv run ruff check src tests` — clean
- `uv run mypy src/agentos --show-error-codes` — clean
- `uv run pytest -q` — full suite green

## Merge independence

Part of a five-PR batch (#1192, #1194, #1198, #1201, #1203). All 120 merge orderings of the five were replayed against `main`: zero conflicts. The fully merged tree passes ruff, mypy and the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URXG1hX8EqgNcMgdqb3epi