### PR TITLE
fix(router): match C++, C# and .NET as code targets (#1198)

### DIFF
--- a/src/agentos/agentos_router/task_type.py
+++ b/src/agentos/agentos_router/task_type.py
@@ -123,11 +123,20 @@ _TRANSLATE_RES: tuple[tuple[str, re.Pattern[str]], ...] = tuple(
 #: is the only guard — it exists because the task is different, not because the
 #: translation is judged hard. Suppression is the safe direction: it forfeits a
 #: saving and hands the turn back to ordinary model routing.
+#:
+#: Names that begin or end in a non-word character need their own edges: a
+#: blanket ``\b(?:...)\b`` silently never matches them. ``c++`` and ``c#``
+#: end in ``+``/``#``, so a trailing ``\b`` would demand a word character
+#: right after them — which "port this to C++." does not have. ``.net``
+#: starts with ``.``, so a leading ``\b`` would demand a word character right
+#: before the dot, which " .NET" does not have (only "ASP.NET" did).
 _CODE_TARGET_RE = re.compile(
     r"\b(?:python|javascript|typescript|golang|rust|java|kotlin|swift|scala"
     r"|haskell|ruby|php|perl|sql|bash|powershell|matlab|fortran|cobol"
-    r"|c\+\+|c#|\.net|react|vue|svelte|jquery|regex|assembly|solidity"
-    r"|dart|elixir|erlang|clojure|lua|zig)\b",
+    r"|react|vue|svelte|jquery|regex|assembly|solidity"
+    r"|dart|elixir|erlang|clojure|lua|zig)\b"
+    r"|\b(?:c\+\+|c#)(?!\w)"
+    r"|\.net\b",
     re.IGNORECASE,
 )
 

--- a/tests/test_agentos_router/test_task_type.py
+++ b/tests/test_agentos_router/test_task_type.py
@@ -115,6 +115,43 @@ class TestProgrammingLanguageTarget:
         assert verdict.task_type is None
         assert verdict.blocked_by == BLOCK_CODE_TARGET
 
+    @pytest.mark.parametrize(
+        "message",
+        [
+            # Names ending in a non-word character: a trailing ``\b`` used to
+            # demand a word character right after ``+``/``#``, so the guard
+            # never fired at the end of a sentence.
+            "Translate this function to C++.",
+            "Translate this function to C++",
+            "Translate this code to C#.",
+            "Translate this code to C#",
+            "Please translate the parser to c++ and keep the tests.",
+            # Names starting with a non-word character: a leading ``\b`` used
+            # to demand a word character right before the dot.
+            "Translate this service to .NET.",
+            "Translate this service to .NET",
+            "Translate the handler to .net, please.",
+            # Already worked before (a word character precedes the dot) and
+            # must keep working.
+            "Translate this service to ASP.NET.",
+        ],
+    )
+    def test_non_word_edge_language_names_block(self, message: str) -> None:
+        verdict = detect_task_type(message)
+        assert verdict.task_type is None
+        assert verdict.blocked_by == BLOCK_CODE_TARGET
+
+    def test_word_boundary_languages_still_require_a_whole_word(self) -> None:
+        """The relaxed edges must not turn substrings into matches."""
+        verdict = detect_task_type("Translate this scalable rustic javanese text to French.")
+        assert verdict.task_type == TASK_TYPE_TRANSLATE
+        assert verdict.blocked_by is None
+
+    def test_dotnet_prefix_of_a_longer_word_does_not_block(self) -> None:
+        verdict = detect_task_type("Translate this to French, then post it to the .network wiki.")
+        assert verdict.task_type == TASK_TYPE_TRANSLATE
+        assert verdict.blocked_by is None
+
     def test_language_named_only_in_the_body_does_not_block(self) -> None:
         """A document mentioning Python is not a porting request."""
         body = ("The team migrated the Python service last quarter. " * 40) + ("z" * 1500)


### PR DESCRIPTION
Closes #1198

## The problem

`_CODE_TARGET_RE` wrapped every language name in a single `\b(?:...)\b`. That works for `python` and `rust`; it silently never fires for the three names whose edges are not word characters.

- `c++` and `c#` end in `+` / `#`. The trailing `\b` demands a word character immediately after — `"Translate this function to C++."` has a period there, and end-of-string has nothing at all.
- `.net` starts with `.`. The leading `\b` demands a word character immediately before the dot. `"Translate this service to .NET"` has a space, so only the `ASP.NET` spelling ever matched.

Result: a request to port code to C++, C#, or .NET fell straight through the guard, was classified `task_type="translate"`, and was capped to the cheapest model tier — the exact opposite of what a code port needs.

```python
>>> detect_task_type("Translate this function to C++.")
TaskTypeVerdict(task_type='translate', matched_language='en', evidence='Translate', blocked_by=None)
```

## The fix

Each name now carries the edge its spelling actually needs:

```python
r"\b(?:python|...|zig)\b"      # unchanged
r"|\b(?:c\+\+|c#)(?!\w)"       # trailing non-word char
r"|\.net\b"                    # leading non-word char
```

The `.net` alternative deliberately keeps **no** left-hand assertion. The issue proposed `(?<!\w)\.net\b`, but that would trade one miss for another: `ASP.NET` has a word character before the dot and matched on `main`, and a lookbehind would newly reject it. With no left assertion, both `" .NET"` and `"ASP.NET"` match. `\.net\b` still refuses `.network` (the trailing `\b` fails before `w`).

Word-boundary languages are untouched — `scalable`, `rustic`, `javanese` still do not match.

## Tests

`tests/test_agentos_router/test_task_type.py`, in `TestProgrammingLanguageTarget`:

- 9 parametrized phrasings of C++ / C# / .NET at sentence end, before punctuation, and mid-sentence — **8 fail on `main`**, all pass here.
- `ASP.NET` in the same parametrize list as a regression guard: it passed before and must keep passing.
- Two negatives: substring names must not match, and `.network` must not match.

## Verification

- `uv run ruff check src tests` — clean
- `uv run mypy src/agentos --show-error-codes` — clean
- `uv run pytest -q` — full suite green

## Merge independence

Part of a five-PR batch (#1192, #1194, #1198, #1201, #1203). All 120 merge orderings of the five were replayed against `main`: zero conflicts. The fully merged tree passes ruff, mypy and the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URXG1hX8EqgNcMgdqb3epi