### PR TITLE
refactor: unify signature probing and compaction provider resolution (#1201)

### DIFF
--- a/src/agentos/cli/tui/adapters/slash_standalone.py
+++ b/src/agentos/cli/tui/adapters/slash_standalone.py
@@ -25,6 +25,7 @@ from agentos.engine.commands import Surface
 from agentos.session.compaction import (
     build_compaction_config_from_provider,
     call_compact_with_optional_config,
+    resolve_compaction_provider,
 )
 from agentos.session.naming import normalize_session_name
 
@@ -207,33 +208,9 @@ async def handle_image_command_turnrunner(
     raise RuntimeError("standalone image dependency was not configured")
 
 
-def _resolve_compaction_provider(
-    provider_selector: Any,
-    model_override: str | None = None,
-) -> Any | None:
-    if provider_selector is None:
-        return None
-    selector = provider_selector
-    clone = getattr(provider_selector, "clone", None)
-    if callable(clone):
-        try:
-            selector = clone()
-        except Exception:  # noqa: BLE001
-            selector = provider_selector
-    if model_override and selector is not provider_selector:
-        override = getattr(selector, "override_model", None)
-        if callable(override):
-            try:
-                override(model_override)
-            except Exception:  # noqa: BLE001
-                pass
-    resolver = getattr(selector, "resolve", None)
-    if not callable(resolver):
-        return None
-    try:
-        return resolver()
-    except Exception:  # noqa: BLE001
-        return None
+#: Retained as a module attribute: ``slash_bridge`` and the chat-command
+#: export map address this adapter's helper by name.
+_resolve_compaction_provider = resolve_compaction_provider
 
 
 def _coerce_transcript_result(result: Any) -> list[Any] | None:

--- a/src/agentos/compat/__init__.py
+++ b/src/agentos/compat/__init__.py
@@ -1,6 +1,5 @@
 """Compatibility helpers used by runtime-facing modules."""
 
-from . import aiosqlite, pypi_client, version_utils
+from . import aiosqlite, inspect_utils, pypi_client, version_utils
 
-__all__ = ["aiosqlite", "pypi_client", "version_utils"]
-
+__all__ = ["aiosqlite", "inspect_utils", "pypi_client", "version_utils"]

--- a/src/agentos/compat/inspect_utils.py
+++ b/src/agentos/compat/inspect_utils.py
@@ -1,0 +1,44 @@
+"""Callable-signature introspection shared by the gateway and the engine.
+
+Optional keyword arguments are threaded through a lot of seams here — a
+``compact`` method that may or may not take ``compaction_id``, a channel's
+``send_typing`` that may or may not take ``thread_id``, a ``TurnRunner.run``
+that may or may not take ``attachments``. Every one of those call sites asks
+the same question, and four modules answered it with their own copy of the
+same six lines.
+
+The copies had drifted where it matters most: on a callable whose signature
+cannot be read, ``rpc_sessions`` returned ``True`` (pass the keyword anyway),
+``channel_dispatch`` and ``context_overflow`` returned ``False``, and
+``engine.runtime`` let the exception escape into the caller. This module is
+the single answer.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+__all__ = ["accepts_keyword_arg"]
+
+
+def accepts_keyword_arg(callable_obj: Any, name: str) -> bool:
+    """Return True when *callable_obj* accepts *name* as a keyword argument.
+
+    True when the parameter is declared explicitly, and true when a
+    ``**kwargs`` catch-all would absorb it.
+
+    A callable whose signature cannot be read at all — :func:`inspect.signature`
+    raises ``TypeError`` or ``ValueError`` for some C builtins and for objects
+    with an unusable ``__signature__`` — is reported as *not* accepting the
+    keyword. That is the safe direction for the callers: passing a keyword the
+    target does not take raises ``TypeError`` and fails the turn, while
+    omitting an optional one leaves the target on its own default.
+    """
+    try:
+        params = inspect.signature(callable_obj).parameters
+    except (TypeError, ValueError):
+        return False
+    if name in params:
+        return True
+    return any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())

--- a/src/agentos/engine/runtime.py
+++ b/src/agentos/engine/runtime.py
@@ -35,6 +35,7 @@ from agentos.attachment_refs import (
     transcript_material_path,
 )
 from agentos.bootstrap_types import BootstrapFileReport
+from agentos.compat.inspect_utils import accepts_keyword_arg
 from agentos.contracts.attachments import (
     ALLOWED_MEDIA_TYPES as _ALLOWED_ENGINE_MEDIA_TYPES,
 )
@@ -640,14 +641,6 @@ _SAFETY_MODULES: Final[tuple[Any, ...]] = (
 )
 
 log = structlog.get_logger(__name__)
-
-
-def _accepts_keyword_arg(callable_obj: Any, name: str) -> bool:
-    """Return True when callable accepts `name` explicitly or via `**kwargs`."""
-    params = inspect.signature(callable_obj).parameters
-    if name in params:
-        return True
-    return any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
 
 
 def _strip_context_summary_marker(content: str) -> str:
@@ -5349,13 +5342,13 @@ class TurnRunner:
             if callable(compact_with_result):
                 compact_method = self._session_manager.compact_with_result
                 compact_kwargs: dict[str, Any] = {}
-                if _accepts_keyword_arg(compact_method, "compaction_id"):
+                if accepts_keyword_arg(compact_method, "compaction_id"):
                     compact_kwargs["compaction_id"] = compaction_id
-                if _accepts_keyword_arg(compact_method, "trigger_reason"):
+                if accepts_keyword_arg(compact_method, "trigger_reason"):
                     compact_kwargs["trigger_reason"] = "t3_upgrade"
-                if _accepts_keyword_arg(compact_method, "flush_receipt_status"):
+                if accepts_keyword_arg(compact_method, "flush_receipt_status"):
                     compact_kwargs["flush_receipt_status"] = flush_receipt_status
-                if _accepts_keyword_arg(compact_method, "mutation_context"):
+                if accepts_keyword_arg(compact_method, "mutation_context"):
                     compact_kwargs["mutation_context"] = self._session_write_context_factory(
                         session_key
                     )
@@ -5591,13 +5584,13 @@ class TurnRunner:
             if callable(compact_with_result):
                 compact_method = self._session_manager.compact_with_result
                 compact_kwargs: dict[str, Any] = {}
-                if _accepts_keyword_arg(compact_method, "compaction_id"):
+                if accepts_keyword_arg(compact_method, "compaction_id"):
                     compact_kwargs["compaction_id"] = compaction_id
-                if _accepts_keyword_arg(compact_method, "trigger_reason"):
+                if accepts_keyword_arg(compact_method, "trigger_reason"):
                     compact_kwargs["trigger_reason"] = "preflight"
-                if _accepts_keyword_arg(compact_method, "flush_receipt_status"):
+                if accepts_keyword_arg(compact_method, "flush_receipt_status"):
                     compact_kwargs["flush_receipt_status"] = flush_receipt_status
-                if _accepts_keyword_arg(compact_method, "mutation_context"):
+                if accepts_keyword_arg(compact_method, "mutation_context"):
                     compact_kwargs["mutation_context"] = self._session_write_context_factory(
                         session_key
                     )

--- a/src/agentos/engine/turn_runner/harness.py
+++ b/src/agentos/engine/turn_runner/harness.py
@@ -16,6 +16,7 @@ import asyncio
 import inspect
 from typing import TYPE_CHECKING, Any, cast
 
+from agentos.compat.inspect_utils import accepts_keyword_arg
 from agentos.engine.turn_runner.agent_bootstrap_stage import (
     AgentConfigBuilderPort,
     AgentFactoryPort,
@@ -680,7 +681,7 @@ class _RequestContextPrependAdapter(RequestContextPrependPort):
 class _TurnRunnerAgentRunAdapter(AgentRunPort):
     """Bind ``agent.run_turn(turn_input, extra_messages=..., **kwargs)``.
 
-    Folds the ``_accepts_keyword_arg(agent.run_turn, "semantic_message")``
+    Folds the ``accepts_keyword_arg(agent.run_turn, "semantic_message")``
     introspection inside the adapter so the stage body never imports
     ``inspect``. ``semantic_message`` is forwarded only when the agent
     accepts the keyword; otherwise the call uses the two-arg
@@ -696,10 +697,8 @@ class _TurnRunnerAgentRunAdapter(AgentRunPort):
         extra_messages: list[Any] | None,
         semantic_message: str | None,
     ) -> AsyncIterator[AgentEvent]:
-        from agentos.engine.runtime import _accepts_keyword_arg
-
         kwargs: dict[str, Any] = {}
-        if _accepts_keyword_arg(agent.run_turn, "semantic_message"):
+        if accepts_keyword_arg(agent.run_turn, "semantic_message"):
             kwargs["semantic_message"] = semantic_message
         return agent.run_turn(
             turn_input,
@@ -900,7 +899,7 @@ class _TurnRunnerTranscriptAppendAdapter(TranscriptAppendPort):
     body has no ``inspect`` dependency and no ``session_manager is None``
     conditional:
 
-    1. ``_accepts_keyword_arg(session_manager.append_message, "token_count")``
+    1. ``accepts_keyword_arg(session_manager.append_message, "token_count")``
        introspection: passes ``token_count`` only when the manager
        accepts it.
     2. The ``session_manager is None`` guard: returns ``False`` (no
@@ -925,8 +924,6 @@ class _TurnRunnerTranscriptAppendAdapter(TranscriptAppendPort):
         turn_usage: dict[str, Any] | None,
         token_count: int | None,
     ) -> bool:
-        from agentos.engine.runtime import _accepts_keyword_arg
-
         session_manager = self._runner._session_manager
         if session_manager is None:
             return False
@@ -937,11 +934,11 @@ class _TurnRunnerTranscriptAppendAdapter(TranscriptAppendPort):
         }
         if reasoning_content is not None:
             append_kwargs["reasoning_content"] = reasoning_content
-        if turn_usage is not None and _accepts_keyword_arg(
+        if turn_usage is not None and accepts_keyword_arg(
             session_manager.append_message, "turn_usage"
         ):
             append_kwargs["turn_usage"] = turn_usage
-        if _accepts_keyword_arg(session_manager.append_message, "token_count"):
+        if accepts_keyword_arg(session_manager.append_message, "token_count"):
             append_kwargs["token_count"] = token_count
         await self._runner._append_session_message(session_key, **append_kwargs)
         return True

--- a/src/agentos/engine/turn_runner/prompt_assembler_stage.py
+++ b/src/agentos/engine/turn_runner/prompt_assembler_stage.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 # ---------------------------------------------------------------------------
 # RunPipelineRequest — typed dataclass that folds the 6 inline
-# ``_accepts_keyword_arg(self._run_pipeline, ...)`` introspection calls.
+# ``accepts_keyword_arg(self._run_pipeline, ...)`` introspection calls.
 #
 # All fields are optional because the pre-turn pipeline accepts every one of
 # them as a keyword today; the stage consistently passes the value or
@@ -45,10 +45,10 @@ if TYPE_CHECKING:
 class RunPipelineRequest:
     """Typed input for ``PipelineExecutionPort.run_pipeline``.
 
-    Folds the 6 inline ``_accepts_keyword_arg(self._run_pipeline, name)``
+    Folds the 6 inline ``accepts_keyword_arg(self._run_pipeline, name)``
     introspection branches into a single typed payload. The stage builds
     this once, the port consumes it once. The introspection cleanup is
-    bounded to the prompt-assembler slice — ``_accepts_keyword_arg`` stays
+    bounded to the prompt-assembler slice — ``accepts_keyword_arg`` stays
     in ``runtime.py`` because two other call sites (``agent.run_turn`` and
     ``session_manager.append_message``) still rely on it.
     """
@@ -107,7 +107,7 @@ class PipelineExecutionPort(Protocol):
 
     The port forwards a typed ``RunPipelineRequest`` to the underlying
     helper. The adapter at the harness side unpacks the request into the
-    helper's keyword arguments. The 6 inline ``_accepts_keyword_arg``
+    helper's keyword arguments. The 6 inline ``accepts_keyword_arg``
     introspection branches are eliminated in favor of always passing every
     kwarg — the helper accepts all 6 today; the introspection is dead code.
     """

--- a/src/agentos/engine/turn_runner/stream_consumer_stage.py
+++ b/src/agentos/engine/turn_runner/stream_consumer_stage.py
@@ -67,7 +67,7 @@ class AgentRunPort(Protocol):
     """Wrap ``agent.run_turn(turn_input, extra_messages=..., **kwargs)``.
 
     Returns the async iterator the agent produces; the stage consumes
-    it via ``async for``. The port handles the ``_accepts_keyword_arg``
+    it via ``async for``. The port handles the ``accepts_keyword_arg``
     introspection for ``semantic_message`` so the stage body has no
     ``inspect``-based branching. The agent is supplied per-call so a
     single stage instance can serve every turn.

--- a/src/agentos/engine/turn_runner/turn_finalizer_stage.py
+++ b/src/agentos/engine/turn_runner/turn_finalizer_stage.py
@@ -106,7 +106,7 @@ class TranscriptAppendPort(Protocol):
 
     Wraps the inline ``await self._session_manager.append_message(...)``.
     The adapter folds the
-    ``_accepts_keyword_arg(..., "token_count")`` introspection so the
+    ``accepts_keyword_arg(..., "token_count")`` introspection so the
     stage body has no ``inspect`` dependency, and the
     ``session_manager is None`` guard so the stage body has no
     conditional on manager presence. Returns ``True`` if the append

--- a/src/agentos/gateway/channel_dispatch.py
+++ b/src/agentos/gateway/channel_dispatch.py
@@ -48,6 +48,7 @@ from agentos.channels.artifact_delivery import (
 )
 from agentos.channels.stream_policy import resolve_channel_stream_policy
 from agentos.channels.types import IncomingMessage, OutgoingMessage
+from agentos.compat.inspect_utils import accepts_keyword_arg
 from agentos.engine.start_turn import start_turn_via_runtime
 from agentos.engine.types import (
     ArtifactEvent,
@@ -303,16 +304,6 @@ class _DirectiveTagStreamSanitizer:
         pending = self._pending
         self._pending = ""
         return _strip_internal_compaction_markers(_strip_inline_directive_tags(pending))
-
-
-def _accepts_keyword_arg(callable_obj: Any, name: str) -> bool:
-    try:
-        params = inspect.signature(callable_obj).parameters
-    except (TypeError, ValueError):
-        return False
-    if name in params:
-        return True
-    return any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
 
 
 @contextlib.asynccontextmanager
@@ -1219,9 +1210,9 @@ def _start_typing_keepalive(
 
     typing_kwargs: dict[str, Any] = {}
     if inbound is not None:
-        if _accepts_keyword_arg(send_typing, "channel_id"):
+        if accepts_keyword_arg(send_typing, "channel_id"):
             typing_kwargs["channel_id"] = inbound.channel_id
-        if _accepts_keyword_arg(send_typing, "thread_id"):
+        if accepts_keyword_arg(send_typing, "thread_id"):
             thread_id = next(
                 (
                     inbound.metadata[key]
@@ -1537,7 +1528,7 @@ class _RuntimeChannelStreamRelay:
         if not resolve_channel_stream_policy(channel).relay_stream:
             return None
         enqueue = getattr(task_runtime, "enqueue", None)
-        if not callable(enqueue) or not _accepts_keyword_arg(enqueue, "stream_event_sink"):
+        if not callable(enqueue) or not accepts_keyword_arg(enqueue, "stream_event_sink"):
             return None
         relay = cls(channel, inbound, config)
         relay._task = asyncio.create_task(relay._run())
@@ -2475,11 +2466,11 @@ async def _run_turn_batch_path(
         "agent_id": tool_ctx.agent_id,
     }
     model = resolve_agent_model(tool_ctx.agent_id, config)
-    if model is not None and _accepts_keyword_arg(turn_runner.run, "model"):
+    if model is not None and accepts_keyword_arg(turn_runner.run, "model"):
         run_kwargs["model"] = model
-    if _accepts_keyword_arg(turn_runner.run, "semantic_message"):
+    if accepts_keyword_arg(turn_runner.run, "semantic_message"):
         run_kwargs["semantic_message"] = semantic_message
-    if attachments and _accepts_keyword_arg(turn_runner.run, "attachments"):
+    if attachments and accepts_keyword_arg(turn_runner.run, "attachments"):
         run_kwargs["attachments"] = attachments
     try:
         stream = turn_runner.run(
@@ -2648,11 +2639,11 @@ async def _run_turn_streaming_path(
             "agent_id": tool_ctx.agent_id,
         }
         model = resolve_agent_model(tool_ctx.agent_id, config)
-        if model is not None and _accepts_keyword_arg(turn_runner.run, "model"):
+        if model is not None and accepts_keyword_arg(turn_runner.run, "model"):
             run_kwargs["model"] = model
-        if _accepts_keyword_arg(turn_runner.run, "semantic_message"):
+        if accepts_keyword_arg(turn_runner.run, "semantic_message"):
             run_kwargs["semantic_message"] = semantic_message
-        if attachments and _accepts_keyword_arg(turn_runner.run, "attachments"):
+        if attachments and accepts_keyword_arg(turn_runner.run, "attachments"):
             run_kwargs["attachments"] = attachments
         stream = turn_runner.run(
             msg.content,

--- a/src/agentos/gateway/context_overflow.py
+++ b/src/agentos/gateway/context_overflow.py
@@ -23,12 +23,12 @@ The three policies:
 
 from __future__ import annotations
 
-import inspect
 from dataclasses import dataclass, field
 from typing import Any
 
 import structlog
 
+from agentos.compat.inspect_utils import accepts_keyword_arg
 from agentos.engine.cache_break_monitor import notify_compaction
 from agentos.gateway.config import ContextOverflowPolicy, GatewayConfig
 from agentos.session.compaction import (
@@ -52,19 +52,6 @@ from agentos.session.context_view import build_compaction_context_records
 from agentos.session.tokenizer import estimate_tokens
 
 log = structlog.get_logger(__name__)
-
-
-def _accepts_keyword_arg(func: Any, name: str) -> bool:
-    try:
-        signature = inspect.signature(func)
-    except (TypeError, ValueError):
-        return False
-    if name in signature.parameters:
-        return True
-    return any(
-        param.kind is inspect.Parameter.VAR_KEYWORD
-        for param in signature.parameters.values()
-    )
 
 
 @dataclass
@@ -373,11 +360,11 @@ async def apply_context_overflow_policy(
             compact_with_result = getattr(session_manager, "compact_with_result", None)
             if callable(compact_with_result):
                 compact_kwargs: dict[str, Any] = {}
-                if _accepts_keyword_arg(compact_with_result, "compaction_id"):
+                if accepts_keyword_arg(compact_with_result, "compaction_id"):
                     compact_kwargs["compaction_id"] = compaction_id
-                if _accepts_keyword_arg(compact_with_result, "trigger_reason"):
+                if accepts_keyword_arg(compact_with_result, "trigger_reason"):
                     compact_kwargs["trigger_reason"] = "gateway_auto_summarize"
-                if _accepts_keyword_arg(compact_with_result, "flush_receipt_status"):
+                if accepts_keyword_arg(compact_with_result, "flush_receipt_status"):
                     compact_kwargs["flush_receipt_status"] = flush_status
                 compaction_result = await compact_with_result(
                     session_key,

--- a/src/agentos/gateway/rpc_chat.py
+++ b/src/agentos/gateway/rpc_chat.py
@@ -14,7 +14,11 @@ from agentos.gateway.access import CONTROL_AND_CHANNEL, CONTROL_ONLY
 from agentos.gateway.config import GatewayConfig
 from agentos.gateway.context_overflow import apply_context_overflow_policy
 from agentos.gateway.rpc import RpcContext, RpcUnavailableError, get_dispatcher
-from agentos.session.compaction import build_compaction_config_from_provider
+from agentos.session.compaction import (
+    build_compaction_config_from_provider,
+    effective_compaction_model,
+    resolve_compaction_provider,
+)
 from agentos.session.keys import build_webchat_key, canonicalize_session_key, parse_agent_id
 
 _d = get_dispatcher()
@@ -227,43 +231,6 @@ async def _chat_history_summaries(
     return [_session_summary_to_chat_payload(summary) for summary in summaries or []]
 
 
-def _effective_compaction_model(session: object | None) -> str | None:
-    if session is None:
-        return None
-    return getattr(session, "model_override", None) or getattr(session, "model", None)
-
-
-def _resolve_compaction_provider(ctx: RpcContext, session: object | None) -> object | None:
-    selector = getattr(ctx, "provider_selector", None)
-    if selector is None:
-        return None
-
-    resolved_selector = selector
-    clone = getattr(selector, "clone", None)
-    if callable(clone):
-        try:
-            resolved_selector = clone()
-        except Exception:  # noqa: BLE001
-            resolved_selector = selector
-
-    model = _effective_compaction_model(session)
-    if model and resolved_selector is not selector:
-        override = getattr(resolved_selector, "override_model", None)
-        if callable(override):
-            try:
-                override(model)
-            except Exception:  # noqa: BLE001
-                pass
-
-    resolver = getattr(resolved_selector, "resolve", None)
-    if not callable(resolver):
-        return None
-    try:
-        return cast(object | None, resolver())
-    except Exception:  # noqa: BLE001
-        return None
-
-
 async def _build_context_overflow_compaction_config(ctx: RpcContext, session_key: str):
     session = None
     storage = getattr(getattr(ctx, "session_manager", None), "_storage", None)
@@ -272,9 +239,10 @@ async def _build_context_overflow_compaction_config(ctx: RpcContext, session_key
             session = await storage.get_session(session_key)
         except Exception:  # noqa: BLE001
             session = None
+    model = effective_compaction_model(session)
     return build_compaction_config_from_provider(
-        _resolve_compaction_provider(ctx, session),
-        model_override=_effective_compaction_model(session),
+        resolve_compaction_provider(getattr(ctx, "provider_selector", None), model),
+        model_override=model,
         compaction_config=getattr(getattr(ctx, "config", None), "compaction", None),
     )
 

--- a/src/agentos/gateway/rpc_sessions.py
+++ b/src/agentos/gateway/rpc_sessions.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import inspect
 import time
 import uuid
 from dataclasses import asdict, replace
@@ -11,6 +10,7 @@ from typing import Any, cast
 
 import structlog
 
+from agentos.compat.inspect_utils import accepts_keyword_arg
 from agentos.engine.cache_break_monitor import notify_compaction
 from agentos.engine.start_turn import start_turn_via_runtime
 from agentos.gateway import attachment_ingest as _attachment_ingest
@@ -34,6 +34,8 @@ from agentos.paths import media_root_from_config
 from agentos.session.compaction import (
     build_compaction_config_from_provider,
     call_compact_with_optional_config,
+    effective_compaction_model,
+    resolve_compaction_provider,
 )
 from agentos.session.compaction_lifecycle import (
     COMPACTION_CHUNK_SUMMARIZED_EVENT,
@@ -63,16 +65,6 @@ _MAX_TOTAL_ATTACHMENT_BYTES = _attachment_ingest.MAX_TOTAL_ATTACHMENT_BYTES
 _MAX_ATTACHMENTS = _attachment_ingest.MAX_ATTACHMENTS
 
 
-def _accepts_keyword_arg(func: Any, name: str) -> bool:
-    try:
-        params = inspect.signature(func).parameters
-    except (TypeError, ValueError):
-        return True
-    return name in params or any(
-        param.kind == inspect.Parameter.VAR_KEYWORD for param in params.values()
-    )
-
-
 def _clean_cancel_source(value: Any, default: str) -> str:
     text = str(value or "").strip()
     if not text:
@@ -94,9 +86,9 @@ async def _cancel_task_runtime(
 ) -> int:
     cancel = getattr(task_runtime, "cancel")
     kwargs: dict[str, Any] = {"session_key": session_key}
-    if _accepts_keyword_arg(cancel, "source"):
+    if accepts_keyword_arg(cancel, "source"):
         kwargs["source"] = source
-    if _accepts_keyword_arg(cancel, "reason"):
+    if accepts_keyword_arg(cancel, "reason"):
         kwargs["reason"] = reason
     return int(await cancel(**kwargs))
 
@@ -436,43 +428,6 @@ def _context_window_tokens(params: dict | None, ctx: RpcContext) -> int:
     if value <= 0:
         raise ValueError("contextWindowTokens must be a positive integer")
     return value
-
-
-def _effective_compaction_model(session: Any | None) -> str | None:
-    if session is None:
-        return None
-    return getattr(session, "model_override", None) or getattr(session, "model", None)
-
-
-def _resolve_compaction_provider(ctx: RpcContext, session: Any | None) -> Any | None:
-    selector = getattr(ctx, "provider_selector", None)
-    if selector is None:
-        return None
-
-    resolved_selector = selector
-    clone = getattr(selector, "clone", None)
-    if callable(clone):
-        try:
-            resolved_selector = clone()
-        except Exception:  # noqa: BLE001
-            resolved_selector = selector
-
-    model = _effective_compaction_model(session)
-    if model and resolved_selector is not selector:
-        override = getattr(resolved_selector, "override_model", None)
-        if callable(override):
-            try:
-                override(model)
-            except Exception:  # noqa: BLE001
-                pass
-
-    resolver = getattr(resolved_selector, "resolve", None)
-    if not callable(resolver):
-        return None
-    try:
-        return resolver()
-    except Exception:  # noqa: BLE001
-        return None
 
 
 def _enum_value(value: Any) -> Any:
@@ -2100,9 +2055,12 @@ async def _handle_sessions_context_compact(params: dict | None, ctx: RpcContext)
             **compaction_lifecycle_payload(compaction_id, COMPACTION_TRIGGERED_EVENT),
         )
         try:
+            compaction_model = effective_compaction_model(session)
             compaction_config = build_compaction_config_from_provider(
-                _resolve_compaction_provider(ctx, session),
-                model_override=_effective_compaction_model(session),
+                resolve_compaction_provider(
+                    getattr(ctx, "provider_selector", None), compaction_model
+                ),
+                model_override=compaction_model,
                 compaction_config=getattr(getattr(ctx, "config", None), "compaction", None),
             )
 
@@ -2117,7 +2075,7 @@ async def _handle_sessions_context_compact(params: dict | None, ctx: RpcContext)
                 compact_kwargs: dict[str, Any] = {
                     "custom_instructions": custom_instructions,
                 }
-                if _accepts_keyword_arg(compact_with_result, "flush_receipt_status"):
+                if accepts_keyword_arg(compact_with_result, "flush_receipt_status"):
                     compact_kwargs["flush_receipt_status"] = flush_receipt_status
                 result = await compact_with_result(
                     key,

--- a/src/agentos/session/compaction.py
+++ b/src/agentos/session/compaction.py
@@ -107,6 +107,55 @@ def build_compaction_config_from_provider(
     return cfg
 
 
+def effective_compaction_model(session: Any | None) -> str | None:
+    """Return the model a compaction run for *session* should summarize with.
+
+    A per-session override wins over the session's own model; ``None`` means
+    "no opinion", and the provider's configured default applies.
+    """
+    if session is None:
+        return None
+    return getattr(session, "model_override", None) or getattr(session, "model", None)
+
+
+def resolve_compaction_provider(
+    provider_selector: Any,
+    model_override: str | None = None,
+) -> Any | None:
+    """Resolve the provider a compaction run should use, or ``None``.
+
+    Compaction must not disturb the live selector: when the selector can be
+    cloned, *model_override* is applied to the clone so the turn in flight
+    keeps its own model. Every optional step degrades rather than raises — a
+    selector that cannot clone, cannot override, or cannot resolve leaves the
+    caller with the unmodified selector or with ``None``, and compaction falls
+    back to its configured defaults instead of failing the turn.
+    """
+    if provider_selector is None:
+        return None
+    selector = provider_selector
+    clone = getattr(provider_selector, "clone", None)
+    if callable(clone):
+        try:
+            selector = clone()
+        except Exception:  # noqa: BLE001
+            selector = provider_selector
+    if model_override and selector is not provider_selector:
+        override = getattr(selector, "override_model", None)
+        if callable(override):
+            try:
+                override(model_override)
+            except Exception:  # noqa: BLE001
+                pass
+    resolver = getattr(selector, "resolve", None)
+    if not callable(resolver):
+        return None
+    try:
+        return resolver()
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def compact_accepts_config(compact_fn: Any) -> bool:
     """Return whether a compact callable can accept the optional config arg."""
 

--- a/tests/test_ci/test_architecture_import_contracts.py
+++ b/tests/test_ci/test_architecture_import_contracts.py
@@ -36,6 +36,11 @@ APPROVED_PACKAGE_IMPORTS: frozenset[tuple[str, str]] = frozenset({
     ("cli", "tools"),
     ("engine", "agents"),
     ("engine", "channels"),
+    # agentos.compat is a leaf utility package that depends on no other
+    # agentos subpackage. cli/gateway/memory/scheduler/session already point
+    # at it; the engine joins them for the shared ``accepts_keyword_arg``
+    # signature probe.
+    ("engine", "compat"),
     ("engine", "contracts"),
     ("engine", "gateway"),
     ("engine", "identity"),

--- a/tests/test_compat/test_inspect_utils.py
+++ b/tests/test_compat/test_inspect_utils.py
@@ -1,0 +1,109 @@
+"""Contract for the one shared ``accepts_keyword_arg``.
+
+Four modules used to carry their own copy, and the copies disagreed on the
+failure path: ``rpc_sessions`` returned True for an uninspectable callable,
+``channel_dispatch`` and ``context_overflow`` returned False, and
+``engine.runtime`` let the exception escape. These tests pin the single answer
+so a future edit cannot re-introduce the drift silently.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+import pytest
+
+from agentos.compat.inspect_utils import accepts_keyword_arg
+
+
+def _explicit(a: int, *, token_count: int | None = None) -> None: ...
+
+
+def _var_keyword(a: int, **kwargs: Any) -> None: ...
+
+
+def _neither(a: int, b: int) -> None: ...
+
+
+def _var_positional(*args: Any) -> None: ...
+
+
+class _Callable:
+    def __call__(self, *, thread_id: str | None = None) -> None: ...
+
+    def method(self, *, channel_id: str | None = None) -> None: ...
+
+
+class TestAccepts:
+    def test_explicit_keyword_parameter(self) -> None:
+        assert accepts_keyword_arg(_explicit, "token_count") is True
+
+    def test_var_keyword_absorbs_anything(self) -> None:
+        assert accepts_keyword_arg(_var_keyword, "anything_at_all") is True
+
+    def test_bound_method(self) -> None:
+        assert accepts_keyword_arg(_Callable().method, "channel_id") is True
+
+    def test_callable_instance_uses_dunder_call(self) -> None:
+        assert accepts_keyword_arg(_Callable(), "thread_id") is True
+
+    def test_lambda(self) -> None:
+        assert accepts_keyword_arg(lambda *, source=None: None, "source") is True
+
+
+class TestRejects:
+    def test_parameter_is_absent(self) -> None:
+        assert accepts_keyword_arg(_neither, "token_count") is False
+
+    def test_var_positional_does_not_absorb_a_keyword(self) -> None:
+        assert accepts_keyword_arg(_var_positional, "token_count") is False
+
+    def test_positional_name_still_counts_as_accepted(self) -> None:
+        # ``a`` is positional-or-keyword, so it can be passed by keyword.
+        assert accepts_keyword_arg(_neither, "a") is True
+
+
+class TestUninspectableCallable:
+    """The one behavior the four copies disagreed on."""
+
+    @pytest.mark.parametrize("exc", [TypeError("no signature"), ValueError("no signature")])
+    def test_signature_failure_reports_not_accepted(
+        self, exc: Exception, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _boom(_obj: Any) -> Any:
+            raise exc
+
+        monkeypatch.setattr(inspect, "signature", _boom)
+
+        # False, not True and not a propagated exception: passing a keyword the
+        # target may not take fails the call, while omitting an optional one
+        # leaves the target on its own default.
+        assert accepts_keyword_arg(_explicit, "token_count") is False
+
+
+class TestSingleImplementation:
+    """No module may keep a private copy of this predicate."""
+
+    def test_no_module_redefines_accepts_keyword_arg(self) -> None:
+        import ast
+        from pathlib import Path
+
+        import agentos
+
+        src_root = Path(agentos.__file__).parent
+        canonical = src_root / "compat" / "inspect_utils.py"
+        offenders: list[str] = []
+        for path in sorted(src_root.rglob("*.py")):
+            if path == canonical:
+                continue
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.FunctionDef) and node.name.endswith(
+                    "accepts_keyword_arg"
+                ):
+                    offenders.append(f"{path.relative_to(src_root.parent)}:{node.lineno}")
+        assert offenders == [], (
+            "accepts_keyword_arg has exactly one implementation, in "
+            f"agentos/compat/inspect_utils.py; found copies at {offenders}"
+        )

--- a/tests/test_session/test_compaction_provider_resolution.py
+++ b/tests/test_session/test_compaction_provider_resolution.py
@@ -1,0 +1,166 @@
+"""Contract for the one shared compaction provider/model resolution.
+
+``_effective_compaction_model`` and ``_resolve_compaction_provider`` were
+copy-pasted between ``rpc_chat``, ``rpc_sessions``, and the standalone slash
+adapter. Provider resolution decides which key and which model a compaction
+run bills, so a copy drifting from its siblings is a live-money bug that no
+test would catch. These tests pin the single implementation.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+
+import agentos
+from agentos.session.compaction import (
+    effective_compaction_model,
+    resolve_compaction_provider,
+)
+
+
+class _Selector:
+    """A provider selector that records how compaction used it."""
+
+    def __init__(
+        self,
+        *,
+        clone_raises: bool = False,
+        override_raises: bool = False,
+        resolve_raises: bool = False,
+        resolvable: bool = True,
+    ) -> None:
+        self.overrides: list[str] = []
+        self.clones: list[_Selector] = []
+        self._clone_raises = clone_raises
+        self._override_raises = override_raises
+        self._resolve_raises = resolve_raises
+        self._resolvable = resolvable
+
+    def clone(self) -> _Selector:
+        if self._clone_raises:
+            raise RuntimeError("clone failed")
+        twin = _Selector(
+            override_raises=self._override_raises,
+            resolve_raises=self._resolve_raises,
+            resolvable=self._resolvable,
+        )
+        self.clones.append(twin)
+        return twin
+
+    def override_model(self, model: str) -> None:
+        if self._override_raises:
+            raise RuntimeError("override failed")
+        self.overrides.append(model)
+
+    def resolve(self) -> object:
+        if self._resolve_raises:
+            raise RuntimeError("resolve failed")
+        return SimpleNamespace(provider_name="stub", owner=self)
+
+
+class TestEffectiveCompactionModel:
+    def test_none_session_has_no_opinion(self) -> None:
+        assert effective_compaction_model(None) is None
+
+    def test_override_wins_over_session_model(self) -> None:
+        session = SimpleNamespace(model="base/model", model_override="override/model")
+        assert effective_compaction_model(session) == "override/model"
+
+    def test_falls_back_to_session_model(self) -> None:
+        session = SimpleNamespace(model="base/model", model_override=None)
+        assert effective_compaction_model(session) == "base/model"
+
+    def test_session_without_either_attribute(self) -> None:
+        assert effective_compaction_model(SimpleNamespace()) is None
+
+
+class TestResolveCompactionProvider:
+    def test_no_selector_resolves_to_nothing(self) -> None:
+        assert resolve_compaction_provider(None, "some/model") is None
+
+    def test_override_is_applied_to_the_clone_not_the_live_selector(self) -> None:
+        selector = _Selector()
+
+        provider = resolve_compaction_provider(selector, "override/model")
+
+        assert selector.overrides == [], "the live selector must not be re-pointed"
+        assert [c.overrides for c in selector.clones] == [["override/model"]]
+        assert provider is not None
+        assert provider.owner is selector.clones[0]
+
+    def test_no_model_override_leaves_the_clone_alone(self) -> None:
+        selector = _Selector()
+
+        resolve_compaction_provider(selector, None)
+
+        assert [c.overrides for c in selector.clones] == [[]]
+
+    def test_uncloneable_selector_is_used_directly_without_override(self) -> None:
+        resolved = object()
+        selector = SimpleNamespace(resolve=lambda: resolved)  # no ``clone``
+
+        # No clone to isolate the override into, so the live selector is left
+        # as it is rather than re-pointed under the running turn.
+        assert resolve_compaction_provider(selector, "override/model") is resolved
+
+    def test_clone_failure_falls_back_to_the_live_selector(self) -> None:
+        selector = _Selector(clone_raises=True)
+
+        provider = resolve_compaction_provider(selector, "override/model")
+
+        assert selector.overrides == []
+        assert provider is not None
+        assert provider.owner is selector
+
+    def test_override_failure_still_resolves(self) -> None:
+        selector = _Selector(override_raises=True)
+
+        assert resolve_compaction_provider(selector, "override/model") is not None
+
+    def test_resolve_failure_degrades_to_none(self) -> None:
+        selector = _Selector(resolve_raises=True)
+
+        assert resolve_compaction_provider(selector, "override/model") is None
+
+    def test_selector_without_resolve_degrades_to_none(self) -> None:
+        assert resolve_compaction_provider(SimpleNamespace(), "override/model") is None
+
+
+class TestSingleImplementation:
+    def test_no_module_redefines_the_helpers(self) -> None:
+        src_root = Path(agentos.__file__).parent
+        canonical = src_root / "session" / "compaction.py"
+        names = {"effective_compaction_model", "resolve_compaction_provider"}
+        offenders: list[str] = []
+        for path in sorted(src_root.rglob("*.py")):
+            if path == canonical:
+                continue
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.FunctionDef):
+                    continue
+                if node.name.lstrip("_") not in names:
+                    continue
+                # A one-line delegating shim (``return _bridge.resolve(...)``)
+                # is the adapter layering, not a second implementation.
+                body = [n for n in node.body if not isinstance(n, ast.Expr)]
+                if len(body) == 1 and isinstance(body[0], ast.Return):
+                    continue
+                offenders.append(f"{path.relative_to(src_root.parent)}:{node.lineno}")
+        assert offenders == [], (
+            "compaction provider resolution lives only in agentos/session/compaction.py; "
+            f"found copies at {offenders}"
+        )
+
+
+def test_gateway_and_cli_share_the_canonical_helper() -> None:
+    """The former copy sites now reference the shared implementation."""
+    from agentos.cli.tui.adapters import slash_standalone
+    from agentos.gateway import rpc_chat, rpc_sessions
+
+    assert slash_standalone._resolve_compaction_provider is resolve_compaction_provider
+    for module in (rpc_chat, rpc_sessions):
+        assert module.resolve_compaction_provider is resolve_compaction_provider
+        assert module.effective_compaction_model is effective_compaction_model


### PR DESCRIPTION
Closes #1201

Two helpers had been copy-pasted until the copies disagreed. This gives each one a single home.

## 1. `_accepts_keyword_arg` → `agentos.compat.inspect_utils.accepts_keyword_arg`

Four copies, three different answers for a callable whose signature cannot be read:

| Copy | On `inspect.signature` raising |
| --- | --- |
| `gateway/rpc_sessions.py` | returns `True` — pass the keyword anyway |
| `gateway/channel_dispatch.py` | returns `False` |
| `gateway/context_overflow.py` | returns `False` |
| `engine/runtime.py` | no `try` at all — the exception escapes into the caller |

The canonical version returns **`False`**. That is the safe direction and what three of the four sites already did: passing a keyword the target does not take raises `TypeError` and fails the turn, while omitting an optional one leaves the target on its own default.

**Behavior change, scoped:** it only differs for a callable `inspect.signature` cannot read at all — some C builtins, objects with an unusable `__signature__`. Ordinary functions, bound methods, callables and `MagicMock` are all inspectable and unaffected. The affected call sites are `rpc_sessions._cancel_task_runtime` (`source`/`reason`) and `sessions.contextCompact` (`flush_receipt_status`), which previously passed the keyword blind, and `engine/runtime`'s compaction kwargs, which previously propagated the exception.

`engine/turn_runner/harness.py` imported the helper from `engine.runtime` inside two method bodies; those are now one module-level import, and the docstrings that named the old symbol are updated.

## 2. Compaction provider resolution → `agentos.session.compaction`

`_effective_compaction_model` and `_resolve_compaction_provider` existed in `gateway/rpc_chat.py`, `gateway/rpc_sessions.py` and `cli/tui/adapters/slash_standalone.py`. Provider resolution decides which key and which model a compaction run bills, so a copy drifting from its siblings is a live-money bug that no test would catch.

Both now live in `agentos.session.compaction`, keeping the standalone adapter's `(provider_selector, model_override)` signature — the one that does not need an `RpcContext`, so the CLI and the gateway can share it. Semantics are unchanged: the model override is applied to a *clone* so the turn in flight keeps its own model, and every optional step degrades (to the unmodified selector, or to `None`) rather than raising.

`slash_standalone._resolve_compaction_provider` remains as a module attribute bound to the shared function, because `slash_bridge` and the chat-command export map address it by name.

## Architecture contract

`("engine", "compat")` is added to `APPROVED_PACKAGE_IMPORTS`. `agentos.compat` is a leaf that imports no other agentos subpackage, and `cli`, `gateway`, `memory`, `scheduler` and `session` already depend on it.

## Tests

- `tests/test_compat/test_inspect_utils.py` — explicit params, `**kwargs`, bound methods, callable instances, lambdas; `*args` not absorbing a keyword; and the one behavior the four copies disagreed on, both `TypeError` and `ValueError` from `inspect.signature`. Plus an AST scan asserting no module redefines the predicate.
- `tests/test_session/test_compaction_provider_resolution.py` — model override precedence; that the override lands on the clone and never on the live selector; the uncloneable, clone-failing, override-failing, resolve-failing and no-`resolve` paths; that the three former copy sites now reference the shared function; and an AST scan that ignores one-line delegating shims but fails on a re-implementation.

## Verification

- `uv run ruff check src tests` — clean
- `uv run mypy src/agentos --show-error-codes` — clean
- `uv run pytest -q` — full suite green

## Merge independence

Part of a five-PR batch (#1192, #1194, #1198, #1201, #1203). This one shares `gateway/rpc_sessions.py` with #1192 and #1194 and `gateway/rpc_chat.py` with #1192, so all 120 merge orderings of the five were replayed against `main`: zero conflicts. The fully merged tree passes ruff, mypy and the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URXG1hX8EqgNcMgdqb3epi