### PR TITLE
fix(tools): treat git_commit(files=[]) as "stage nothing" (#1203)

### DIFF
--- a/src/agentos/tools/builtin/git.py
+++ b/src/agentos/tools/builtin/git.py
@@ -181,7 +181,11 @@ async def git_diff(
         "files": {
             "type": "array",
             "items": {"type": "string"},
-            "description": "Files to stage. If omitted, stages all changes (git add -A).",
+            "description": (
+                "Files to stage. If omitted, stages all changes (git add -A). "
+                "Pass an empty array to stage nothing and commit only what is "
+                "already staged."
+            ),
         },
         "workdir": {"type": "string", "description": "Git repository directory (default: cwd)."},
     },
@@ -204,12 +208,16 @@ async def git_commit(
     workdir: str | None = None,
 ) -> str:
     cwd = _effective_workdir(workdir)
-    if files:
+    # ``files`` omitted (None) means "stage everything"; an explicitly empty
+    # list means "stage nothing" and commit what the caller already staged.
+    # Collapsing the two with ``if files:`` swept untracked files the caller
+    # never named into the commit.
+    if files is None:
+        await _run_git("add", "-A", cwd=cwd)
+    elif files:
         for file_path in files:
             _reject_foreign_git_path(file_path)
         await _run_git("add", "--", *files, cwd=cwd)
-    else:
-        await _run_git("add", "-A", cwd=cwd)
     return await _run_git("commit", "-m", message, cwd=cwd)
 
 

--- a/tests/test_tools/test_git_workdir_policy.py
+++ b/tests/test_tools/test_git_workdir_policy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -79,3 +80,65 @@ def test_git_diff_argv_staged_with_path() -> None:
         "--",
         "src/main.py",
     )
+
+
+def _git_commit_impl() -> Any:
+    """``git_commit`` with the ``@tool``/``@sandboxed`` wrappers peeled off.
+
+    The staging decision under test lives in the plain coroutine; the sandbox
+    wrapper denies fail-closed when no runtime is configured.
+    """
+    return git.git_commit.__wrapped__.__wrapped__  # type: ignore[attr-defined]
+
+
+class _RecordingRunGit:
+    """Stand-in for ``git._run_git`` that records argv instead of running git."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, ...]] = []
+
+    async def __call__(self, *args: str, cwd: str | None = None) -> str:
+        self.calls.append(args)
+        return ""
+
+
+async def test_git_commit_with_empty_files_stages_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``files=[]`` is an explicit "stage nothing", not "stage everything".
+
+    Regression for the ``if files:`` fall-through that ran ``git add -A`` and
+    swept untracked files the caller never named into the commit.
+    """
+    recorder = _RecordingRunGit()
+    monkeypatch.setattr(git, "_run_git", recorder)
+
+    await _git_commit_impl()(message="commit staged", files=[])
+
+    assert recorder.calls == [("commit", "-m", "commit staged")]
+
+
+async def test_git_commit_without_files_stages_everything(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Omitting ``files`` keeps the documented ``git add -A`` behavior."""
+    recorder = _RecordingRunGit()
+    monkeypatch.setattr(git, "_run_git", recorder)
+
+    await _git_commit_impl()(message="commit all")
+
+    assert recorder.calls == [("add", "-A"), ("commit", "-m", "commit all")]
+
+
+async def test_git_commit_with_named_files_stages_only_those(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorder = _RecordingRunGit()
+    monkeypatch.setattr(git, "_run_git", recorder)
+
+    await _git_commit_impl()(message="commit one", files=["file1.txt"])
+
+    assert recorder.calls == [
+        ("add", "--", "file1.txt"),
+        ("commit", "-m", "commit one"),
+    ]


### PR DESCRIPTION
Closes #1203

## The problem

```python
if files:
    ...
    await _run_git("add", "--", *files, cwd=cwd)
else:
    await _run_git("add", "-A", cwd=cwd)
```

`bool([])` is `False`, so an explicitly empty list took the same branch as an omitted argument and ran `git add -A`. A caller asking to commit only what it had already staged got the entire working tree instead — including untracked files it never named. The reproduction in the issue is the sharp end of it: an untracked `secret.txt` sitting beside the staged change lands in the commit.

Two different intents were collapsed into one branch by a truthiness test.

## The fix

```python
if files is None:
    await _run_git("add", "-A", cwd=cwd)
elif files:
    for file_path in files:
        _reject_foreign_git_path(file_path)
    await _run_git("add", "--", *files, cwd=cwd)
return await _run_git("commit", "-m", message, cwd=cwd)
```

- `files` omitted → unchanged `git add -A`.
- `files=[]` → no `add` runs at all; the commit takes whatever the caller already staged.
- `files=[...]` → unchanged, path policy still applied per file.

An empty list is skipped rather than passed to `git add --` so nothing depends on how git treats an empty pathspec.

The tool schema description says so too — the agent picks this argument from that text, so leaving it reading "If omitted, stages all changes" would keep the empty-list case undiscoverable.

## Tests

`tests/test_tools/test_git_workdir_policy.py`, recording the argv `_run_git` receives:

- `files=[]` → exactly `["commit", "-m", ...]`, no `add`. **Fails on `main`** (it gets `add -A` first).
- omitted → `add -A` then `commit`.
- `files=["file1.txt"]` → `add -- file1.txt` then `commit`.

The last two are regression guards and pass either way. Tests call the undecorated coroutine (`__wrapped__.__wrapped__`), matching `test_apply_patch_atomicity.py`, since `@sandboxed` denies fail-closed with no runtime configured.

## Verification

- `uv run ruff check src tests` — clean
- `uv run mypy src/agentos --show-error-codes` — clean
- `uv run pytest -q` — full suite green

## Merge independence

Part of a five-PR batch (#1192, #1194, #1198, #1201, #1203). All 120 merge orderings of the five were replayed against `main`: zero conflicts. The fully merged tree passes ruff, mypy and the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URXG1hX8EqgNcMgdqb3epi