### PR TITLE
fix(mcp): serialize stdio client requests with asyncio lock

### DIFF
--- a/src/agentos/mcp/stdio.py
+++ b/src/agentos/mcp/stdio.py
@@ -30,6 +30,7 @@ class MCPStdioClient(MCPClient):
         super().__init__(config)
         self._process: asyncio.subprocess.Process | None = None
         self._request_id = 0
+        self._lock = asyncio.Lock()
 
     @staticmethod
     def _encode_message(message: dict[str, Any]) -> bytes:
@@ -155,24 +156,26 @@ class MCPStdioClient(MCPClient):
         assert self._process.stdin is not None
         assert self._process.stdout is not None
 
-        req_id = self._next_id()
-        request: dict[str, Any] = {"jsonrpc": "2.0", "id": req_id, "method": method}
-        if params is not None:
-            request["params"] = params
+        async with self._lock:
+            req_id = self._next_id()
+            request: dict[str, Any] = {"jsonrpc": "2.0", "id": req_id, "method": method}
+            if params is not None:
+                request["params"] = params
 
-        self._process.stdin.write(self._encode_message(request))
-        await self._process.stdin.drain()
+            self._process.stdin.write(self._encode_message(request))
+            await self._process.stdin.drain()
 
-        return await self._read_response(req_id)
+            return await self._read_response(req_id)
 
     async def _send_notification(self, method: str) -> None:
         """Send a JSON-RPC notification (no response expected)."""
         assert self._process is not None
         assert self._process.stdin is not None
 
-        notification = {"jsonrpc": "2.0", "method": method}
-        self._process.stdin.write(self._encode_message(notification))
-        await self._process.stdin.drain()
+        async with self._lock:
+            notification = {"jsonrpc": "2.0", "method": method}
+            self._process.stdin.write(self._encode_message(notification))
+            await self._process.stdin.drain()
 
     async def _read_response(self, req_id: int) -> dict[str, Any]:
         """Read newline-delimited messages until the reply to ``req_id`` arrives.

--- a/tests/test_mcp/test_stdio_client.py
+++ b/tests/test_mcp/test_stdio_client.py
@@ -393,3 +393,26 @@ async def test_connects_to_a_spec_compliant_newline_delimited_server(tmp_path: P
     assert [t.name for t in tools] == ["echo"]
     assert result.content == "multi\nline"
     assert result.is_error is False
+
+
+@pytest.mark.asyncio
+async def test_concurrent_tool_calls_serialized_safely(tmp_path: Path) -> None:
+    """Concurrent tool calls on the same stdio client must be safely serialized."""
+    server = tmp_path / "server.py"
+    server.write_text(_SPEC_COMPLIANT_SERVER)
+    client = MCPStdioClient(
+        MCPServerConfig(name="demo", transport="stdio", command=sys.executable, args=[str(server)])
+    )
+
+    try:
+        await client.connect()
+        # Fire 10 concurrent tool calls
+        results = await asyncio.gather(
+            *[client.call_tool("echo", {"text": f"msg-{i}"}) for i in range(10)]
+        )
+    finally:
+        await client.close()
+
+    assert len(results) == 10
+    assert [r.content for r in results] == [f"msg-{i}" for i in range(10)]
+    assert all(not r.is_error for r in results)


### PR DESCRIPTION
### Summary
Fixes a race condition in `MCPStdioClient` where concurrent tool calls on the same stdio server attempt to read from `self._process.stdout` (`asyncio.StreamReader`) concurrently, throwing:
`RuntimeError: readuntil() called while another coroutine is already waiting for incoming data`

### Key Changes
- **[`src/agentos/mcp/stdio.py`](file:///c:/Users/Administrator/.antigravity-ide/agent-os/src/agentos/mcp/stdio.py)**: Added `self._lock = asyncio.Lock()` to `MCPStdioClient` and wrapped `_send_request` and `_send_notification` in `async with self._lock:`.
- **[`tests/test_mcp/test_stdio_client.py`](file:///c:/Users/Administrator/.antigravity-ide/agent-os/tests/test_mcp/test_stdio_client.py)**: Added regression test `test_concurrent_tool_calls_serialized_safely` executing 10 parallel tool calls via `asyncio.gather()`.

### Verification
- `uv run pytest tests/test_mcp/test_stdio_client.py -v` (23/23 tests passed)
- `uv run ruff check src/agentos/mcp/stdio.py tests/test_mcp/test_stdio_client.py`
- `uv run mypy src/agentos/mcp/stdio.py --show-error-codes`
closes #1462 