### PR TITLE
fix(skills): handle individual entry errors with return_exceptions in skill hubs

### DIFF
--- a/src/agentos/skills/hub/bankr.py
+++ b/src/agentos/skills/hub/bankr.py
@@ -321,12 +321,13 @@ class BankrSource(SkillSource):
                 loaded = await asyncio.gather(
                     *(_load_one(s) for s in self._allowlist),
                     *(_load_user(r) for r in self._user_refs),
+                    return_exceptions=True,
                 )
         except Exception as exc:
             log.warning("bankr.fetch_failed", error=str(exc))
             return None
 
-        metas = [m for m in loaded if m is not None]
+        metas = [m for m in loaded if m is not None and not isinstance(m, BaseException)]
         if not metas:
             # Every allowlisted skill failed to load (outage / rate limit) —
             # treat as a fetch failure so we retry rather than cache empty.

--- a/src/agentos/skills/hub/capminal.py
+++ b/src/agentos/skills/hub/capminal.py
@@ -150,12 +150,15 @@ class CapminalSource(SkillSource):
                     async with sem:
                         return await self._load_catalog_entry(client, slug)
 
-                loaded = await asyncio.gather(*(_load_one(s) for s in self._allowlist))
+                loaded = await asyncio.gather(
+                    *(_load_one(s) for s in self._allowlist),
+                    return_exceptions=True,
+                )
         except Exception as exc:
             log.warning("capminal.fetch_failed", error=str(exc))
             return None
 
-        metas = [m for m in loaded if m is not None]
+        metas = [m for m in loaded if m is not None and not isinstance(m, BaseException)]
         if not metas:
             return None
         metas.sort(key=lambda m: m.name)

--- a/tests/test_skills_hub_bankr.py
+++ b/tests/test_skills_hub_bankr.py
@@ -662,3 +662,26 @@ def test_default_router_exposes_bankr_source(monkeypatch) -> None:
         assert "bankr" in router.source_ids
     finally:
         defaults._default_router = None
+
+
+@pytest.mark.asyncio
+async def test_search_partial_failure_returns_surviving_skills(monkeypatch) -> None:
+    """If one skill raises an unhandled exception during catalog load,
+    surviving skills are returned rather than failing the whole catalog fetch.
+    """
+    import httpx
+
+    class _FailingAsyncClient(_AsyncClient):
+        async def get(self, url: str, **kwargs: Any) -> _Response:
+            if "alchemy" in url:
+                raise ConnectionResetError("Network reset during fetch")
+            return await super().get(url, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _FailingAsyncClient)
+
+    src = BankrSource(allowlist=_FIXTURE_SLUGS)
+    results = await src.search("")
+    names = {r.name for r in results}
+    assert "bankr" in names
+    assert "alchemy" not in names
+

--- a/tests/test_skills_hub_capminal.py
+++ b/tests/test_skills_hub_capminal.py
@@ -215,3 +215,26 @@ async def test_inspect_and_fetch_enforce_allowlist(monkeypatch) -> None:
 
     assert await src.fetch(disallowed_slug) is None
     assert fetched_id is None
+
+
+@pytest.mark.asyncio
+async def test_search_partial_failure_returns_surviving_skills(monkeypatch) -> None:
+    """If one skill in the allowlist raises an unhandled exception during load,
+    the remaining skills must still load and not fail the entire catalog.
+    """
+    import httpx
+
+    class _FailingAsyncClient(_AsyncClient):
+        async def get(self, url: str, **kwargs: Any) -> _Response:
+            if "morse-launch-b20" in url:
+                raise ConnectionResetError("Connection dropped by peer")
+            return await super().get(url, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _FailingAsyncClient)
+
+    results = await _source().search("")
+    names = {r.name for r in results}
+    assert "capminal" in names
+    assert "contract-interaction" in names
+    assert "morse-launch-b20" not in names
+


### PR DESCRIPTION
## Description
Fixes a cascading catalog failure bug in `CapminalSource` and `BankrSource` where an unhandled exception (e.g., connection reset, network timeout) during the fetch of a single allowlisted skill caused `asyncio.gather` to abort the entire catalog load and discard all other successfully retrieved skills.

## Changes Made
- Added `return_exceptions=True` to `asyncio.gather` in `CapminalSource._fetch_catalog()` and `BankrSource._fetch_catalog()`.
- Filtered out `BaseException` instances from the resolved skill metadata list (`metas = [m for m in loaded if m is not None and not isinstance(m, BaseException)]`).
- Added regression tests in `tests/test_skills_hub_capminal.py` and `tests/test_skills_hub_bankr.py` verifying catalog resilience when individual skills fail.

## Testing & Validation
- `uv run pytest tests/test_skills_hub_capminal.py tests/test_skills_hub_bankr.py -v` (40 passed)
- `uv run pytest tests/test_skills_*.py -q` (120 passed)
- `uv run ruff check` & `uv run mypy` on all modified files (All passed, 0 errors)
closes #1468 