### PR TITLE
fix(tools): clamp web_fetch max_chars below the documented minimum (#…

### DIFF
--- a/src/agentos/tools/builtin/web_fetch.py
+++ b/src/agentos/tools/builtin/web_fetch.py
@@ -162,9 +162,13 @@ def _resolve_effective_max_chars(max_chars: int | None) -> int | None:
     """Resolve explicit max_chars or the default cap for omitted values."""
     max_allowed = _active_run_budget_policy().max_single_fetch_chars
     if max_chars is not None:
-        if max_chars < 100:
-            return None
-        return min(max_chars, max_allowed) if max_allowed is not None else max_chars
+        # A request below the documented 100-char floor must be clamped up
+        # to it, not treated as "no cap" -- returning None here disabled
+        # truncation entirely and let a sub-100 request bypass
+        # max_single_fetch_chars, so it returned *more* than a well-formed
+        # request for a higher max_chars (#1400).
+        clamped = max(max_chars, 100)
+        return min(clamped, max_allowed) if max_allowed is not None else clamped
     default = _resolve_default_max_chars()
     return min(default, max_allowed) if max_allowed is not None else default
 

--- a/tests/test_tools/test_web_fetch.py
+++ b/tests/test_tools/test_web_fetch.py
@@ -69,3 +69,31 @@ def test_resolve_effective_max_chars_allows_uncapped_run_policy() -> None:
         assert _resolve_effective_max_chars(999_999) == 999_999
     finally:
         current_tool_context.reset(token)
+
+
+def test_resolve_effective_max_chars_clamps_below_minimum_instead_of_disabling_cap() -> None:
+    """A request below the documented 100-char floor must be clamped up to
+    it, not treated as "no cap" -- the old behaviour returned None here,
+    which made _apply_max_chars skip truncation entirely (#1400)."""
+    assert _resolve_effective_max_chars(50) == 100
+
+
+def test_a_below_minimum_request_never_returns_more_than_a_higher_one() -> None:
+    """Pins the issue's exact inversion: requesting fewer characters must
+    never come back with more of them than a well-formed higher request."""
+    below_minimum = _resolve_effective_max_chars(50)
+    higher = _resolve_effective_max_chars(1000)
+    assert below_minimum is not None
+    assert higher is not None
+    assert below_minimum <= higher
+
+
+def test_resolve_effective_max_chars_run_budget_still_caps_a_clamped_request() -> None:
+    """Clamping a sub-100 request up to the floor must not let it escape a
+    run budget ceiling that sits below that floor."""
+    ctx = ToolContext(tool_run_budget_policy=ToolRunBudgetPolicy(max_single_fetch_chars=40))
+    token = current_tool_context.set(ctx)
+    try:
+        assert _resolve_effective_max_chars(10) == 40
+    finally:
+        current_tool_context.reset(token)


### PR DESCRIPTION
Issue #1400 — web_fetch with max_chars < 100 disables all truncation and bypasses budget limits

Problem: _resolve_effective_max_chars() returned None whenever the caller passed a max_chars value under the documented 100-character minimum. _apply_max_chars() treats None as "no cap," so a sub-100 request skipped truncation entirely and bypassed the active run's max_single_fetch_chars budget policy. The guard inverted its own intent: max_chars=50 returned strictly more data than max_chars=1000.

Fix: _resolve_effective_max_chars() now clamps a sub-100 request up to the 100-char floor instead of bailing out to None, and the clamped value still passes through the existing min(..., max_allowed) budget ceiling — so a run policy capping below 100 still applies correctly.

Tests: Added three regression tests to tests/test_tools/test_web_fetch.py, each confirmed failing before the fix and passing after:

test_resolve_effective_max_chars_clamps_below_minimum_instead_of_disabling_cap — a 50-char request now resolves to 100, not None.
test_a_below_minimum_request_never_returns_more_than_a_higher_one — pins the issue's exact inversion (a lower request can never yield more characters than a higher one).
test_resolve_effective_max_chars_run_budget_still_caps_a_clamped_request — a run budget below 100 (e.g. 40) still wins over the clamped floor.
Also verified clean: ruff check, ruff format --check, mypy src/agentos/tools/builtin/web_fetch.py, and the full tests/test_tools/ suite (1028 passed, 17 skipped). closes #1400 