### PR TITLE
feat(cli): print the installed version with 'agentos --version'

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -6,9 +6,14 @@ automate AgentOS.
 Run:
 
 ```sh
+agentos --version
 agentos --help
 agentos <command> --help
 ```
+
+`agentos --version` (short form `-V`) prints the installed version on its own
+line and exits 0 — the same value `agentos gateway status` reports as
+`cliVersion`.
 
 ## Main Commands
 

--- a/src/agentos/cli/main.py
+++ b/src/agentos/cli/main.py
@@ -91,6 +91,38 @@ app = typer.Typer(
     pretty_exceptions_enable=False,
 )
 
+
+def _version_callback(value: bool) -> None:
+    """Print the installed version and exit before any command runs.
+
+    Eager so ``agentos --version`` answers on its own, without a subcommand
+    and without ``no_args_is_help`` turning it into a help dump. The bare
+    version string is what a script wants; the same value is reported as
+    ``cliVersion`` by ``agentos gateway status``.
+    """
+
+    if not value:
+        return
+    from agentos import __version__
+
+    typer.echo(__version__)
+    raise typer.Exit(0)
+
+
+@app.callback()
+def main_callback(
+    version: bool = typer.Option(
+        False,
+        "--version",
+        "-V",
+        help="Print the installed AgentOS version and exit.",
+        callback=_version_callback,
+        is_eager=True,
+    ),
+) -> None:
+    """AgentOS - Python agent runtime with multi-channel support."""
+
+
 # ── Sub-apps ─────────────────────────────────────────────────────────────────
 
 app.add_typer(auth_app, name="auth")

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -119,7 +119,9 @@ non-TTY contexts fall back automatically.
 ## CLI map
 
 Top-level: `init`, `onboard`, `configure`, `doctor`, `upgrade`, `chat`,
-`agent`, `reset`, plus these groups (each supports `--help`):
+`agent`, `reset`, plus these groups (each supports `--help`).
+`agentos --version` (`-V`) prints the installed version on stdout and exits 0 —
+use it instead of `uv tool list` / `pip show` to answer "which version is this?":
 
 | Group | Subcommands |
 | --- | --- |

--- a/tests/test_cli/test_cli_version_flag.py
+++ b/tests/test_cli/test_cli_version_flag.py
@@ -1,0 +1,46 @@
+"""``agentos --version`` prints the installed version and exits 0.
+
+Before this existed the only way to read the running version was
+``uv tool list`` (issue #1364).
+"""
+
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+
+from agentos import __version__
+from agentos.cli.main import app
+
+runner = CliRunner()
+
+
+@pytest.mark.parametrize("flag", ["--version", "-V"])
+def test_version_flag_prints_version_and_exits_zero(flag: str) -> None:
+    result = runner.invoke(app, [flag])
+
+    assert result.exit_code == 0
+    assert __version__ in result.stdout.splitlines()
+
+
+def test_version_flag_is_listed_in_help() -> None:
+    result = runner.invoke(app, ["--help"], terminal_width=100)
+
+    assert result.exit_code == 0
+    assert "--version" in result.stdout
+
+
+def test_version_flag_wins_over_a_subcommand() -> None:
+    """Eager, so it answers before ``doctor`` (or anything else) can run."""
+
+    result = runner.invoke(app, ["--version", "doctor"])
+
+    assert result.exit_code == 0
+    assert __version__ in result.stdout.splitlines()
+
+
+def test_bare_invocation_still_shows_help() -> None:
+    result = runner.invoke(app, [])
+
+    assert result.exit_code == 2
+    assert "Usage:" in result.stdout


### PR DESCRIPTION
`agentos --version` did not exist, so the only way to read the running version
was `uv tool list` / `pip show` — and on Windows that is exactly what the
reporter had to do after `agentos upgrade` left the CLI in an unclear state.

## Change

A root Typer callback adds an eager `--version` / `-V` option that prints the
installed version on stdout and exits 0. Eager so it answers on its own, before
`no_args_is_help` turns a bare invocation into a help dump and before any
subcommand runs.

The output is the bare version string on its own line — the same value
`agentos gateway status` reports as `cliVersion`, so `v=$(agentos --version)`
works. It resolves through `agentos.__version__`, which already reads the
installed distribution metadata for both `use-agent-os` and the pre-rename
`agentos`.

## Verification

- `agentos --version` and `agentos -V` print the version and exit 0.
- `agentos --version doctor` still answers with the version (eager).
- `agentos` with no arguments still exits 2 with the usage help; `agentos --help`
  is byte-identical to before apart from the new option row.
- New: `tests/test_cli/test_cli_version_flag.py` (5 tests).
- `ruff check src tests`, `mypy src/agentos`, and the full `pytest` suite pass.

Docs: `docs/cli.md` and `src/agentos/skills/bundled/agentos/SKILL.md` both
mention the flag, per the CLI-surface rule in AGENTS.md.

Fixes #1364

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0133si2sRrGEeYCzaiQuyKcb
