### PR TITLE
fix(cli): stop the managed gateway before a Windows upgrade

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -305,6 +305,22 @@ When the current install was built from a local directory (detected via PEP 610
 never prompts, blocks, or changes the exit code. `--json` reports the same as
 `sourceDirectory` (`null` for a release install).
 
+On **Windows** the managed gateway is stopped *before* the installer runs and
+started again afterwards. Windows refuses to replace a file a live process holds
+open, and the managed gateway runs the tool venv's own interpreter — leaving it
+up is what produced `Access is denied` on
+`…\uv\tools\use-agent-os\Scripts`, and a half-replaced directory with
+`agentos` no longer on PATH. `--no-restart` keeps its promise not to touch the
+gateway, so an upgrade with that flag can still hit the lock. POSIX is
+unchanged: files are replaced under the running gateway, which is restarted
+afterwards.
+
+If the installer is refused anyway, the failure names the recovery instead of
+only echoing the installer's error: stop the gateway and close every other
+AgentOS process, re-run the printed command from a fresh terminal, and — if
+`agentos` is then not found — put uv's tool bin directory back on PATH with
+`uv tool update-shell`.
+
 Exit codes: **0** success (upgraded + verified, or `--check`/`--dry-run`);
 **3** this install method needs a manual command (printed); **1** the upgrade
 failed, timed out, or the post-restart version could not be verified.

--- a/src/agentos/cli/upgrade_cmd.py
+++ b/src/agentos/cli/upgrade_cmd.py
@@ -35,6 +35,12 @@ from agentos.cli.ui import console, markup_escape
 
 # Default upgrade-subprocess timeout (seconds). Overridable via --timeout.
 _DEFAULT_TIMEOUT_S = 600.0
+#: Windows will not let anything replace a file a live process holds open.
+#: Read through this rather than ``os.name`` so the Windows-only stop-first
+#: path can be exercised from either platform's test run.
+_ON_WINDOWS = os.name == "nt"
+#: What uv/pipx print when Windows refuses the replacement.
+_FILE_LOCK_MARKERS = ("access is denied", "os error 5", "winerror 5")
 # Bounded wait for the restarted gateway to report the new version.
 _VERIFY_TIMEOUT_S = 30.0
 _VERIFY_POLL_S = 0.5
@@ -163,15 +169,17 @@ def _query_gateway_version(config_path: str | None) -> str | None:
     return gateway_handshake_version(config_path=config_path)
 
 
-def _restart_and_verify(
-    *,
-    config_path: str | None,
-    expected_version: str,
-    json_output: bool,
-) -> bool:
-    """Restart the managed gateway (if running) and verify the new version.
+def _stop_gateway_before_upgrade(config_path: str | None) -> bool:
+    """Stop the managed gateway so Windows can replace the files it holds open.
 
-    Returns True on verified restart (or nothing-to-restart), False on failure.
+    The managed gateway runs the *tool venv's own* interpreter, and Windows
+    refuses to delete or overwrite a file a live process has open. Rebuilding
+    that venv underneath it is what produces "Access is denied" — and, worse, a
+    half-replaced ``Scripts`` directory afterwards with ``agentos`` no longer on
+    PATH. POSIX replaces files under a running process happily, so it keeps the
+    lower-downtime restart-afterwards path.
+
+    Returns True when a managed gateway was stopped and has to be started again.
     """
 
     from agentos.cli.gateway_cmd import _lifecycle_manager
@@ -179,17 +187,102 @@ def _restart_and_verify(
     manager = _lifecycle_manager(port=None, bind=None, listen="", config_path=config_path)
     status = manager.status()
     if not (status.state == "running" and status.managed):
-        console.print(
-            "[dim]Gateway is not running (managed) — nothing to restart. "
-            "It will pick up the new version on next start.[/dim]"
-        )
-        return True
+        return False
 
-    console.print("Restarting managed gateway…")
-    result = manager.restart()
+    console.print("Stopping managed gateway so the installed files can be replaced…")
+    result = manager.stop()
+    if result.exit_code != 0:
+        # Leave it to the normal restart-afterwards path rather than claiming a
+        # stop that did not happen; the upgrade may still fail, and then the
+        # file-lock recovery guidance is what the operator needs.
+        console.print(
+            f"[yellow]Gateway stop failed:[/yellow] {result.message or result.code or result.state}"
+        )
+        return False
+    return True
+
+
+def _start_gateway_after_failed_upgrade(config_path: str | None) -> None:
+    """Bring back the gateway we stopped when the upgrade did not go through."""
+
+    from agentos.cli.gateway_cmd import _lifecycle_manager
+
+    manager = _lifecycle_manager(port=None, bind=None, listen="", config_path=config_path)
+    result = manager.start()
     if result.exit_code != 0:
         console.print(
-            f"[red]Gateway restart failed:[/red] {result.message or result.code or result.state}"
+            "[red]The gateway stopped for the upgrade could not be started again.[/red]\n"
+            "Recovery: run 'agentos gateway start'."
+        )
+        return
+    console.print("Gateway started again on the previous version.")
+
+
+def _looks_like_file_lock(result: UpgradeRunResult) -> bool:
+    """True when the installer failed because a file was held open."""
+
+    blob = f"{result.stdout}\n{result.stderr}".casefold()
+    return any(marker in blob for marker in _FILE_LOCK_MARKERS)
+
+
+def _emit_file_lock_recovery(manual_hint: str) -> None:
+    """Say what actually holds the install open, and how to get ``agentos`` back.
+
+    A failure here can leave the tool directory half-replaced, so the operator
+    needs the PATH step as much as the retry command.
+    """
+
+    console.print(
+        "[red]The installer could not replace the installed files (access denied).[/red]\n"
+        "A running process still has them open — the gateway, an 'agentos chat' "
+        "session, or another AgentOS/Python process.\n"
+        "Recovery:\n"
+        "  1. Run 'agentos gateway stop', then close every other AgentOS process.\n"
+        f"  2. From a fresh terminal run: {markup_escape(manual_hint)}\n"
+        "  3. If 'agentos' is then not found, put uv's tool bin directory back on "
+        "PATH with 'uv tool update-shell' (or add the directory "
+        "'uv tool dir --bin' prints)."
+    )
+
+
+def _restart_and_verify(
+    *,
+    config_path: str | None,
+    expected_version: str,
+    json_output: bool,
+    start_only: bool = False,
+) -> bool:
+    """Restart the managed gateway (if running) and verify the new version.
+
+    ``start_only`` is the Windows path: the gateway was already stopped before
+    the upgrade so its files could be replaced, so there is nothing to restart —
+    it has to be started.
+
+    Returns True on verified restart (or nothing-to-restart), False on failure.
+    """
+
+    from agentos.cli.gateway_cmd import _lifecycle_manager
+
+    manager = _lifecycle_manager(port=None, bind=None, listen="", config_path=config_path)
+    if start_only:
+        console.print("Starting managed gateway…")
+        result = manager.start()
+        action = "start"
+    else:
+        status = manager.status()
+        if not (status.state == "running" and status.managed):
+            console.print(
+                "[dim]Gateway is not running (managed) — nothing to restart. "
+                "It will pick up the new version on next start.[/dim]"
+            )
+            return True
+
+        console.print("Restarting managed gateway…")
+        result = manager.restart()
+        action = "restart"
+    if result.exit_code != 0:
+        console.print(
+            f"[red]Gateway {action} failed:[/red] {result.message or result.code or result.state}"
         )
         return False
 
@@ -198,12 +291,12 @@ def _restart_and_verify(
     while time.monotonic() <= deadline:
         observed = _query_gateway_version(config_path)
         if observed == expected_version:
-            console.print(f"Gateway: restarted and verified ({expected_version}).")
+            console.print(f"Gateway: {action}ed and verified ({expected_version}).")
             return True
         time.sleep(_VERIFY_POLL_S)
 
     console.print(
-        f"[red]Gateway restart could not be verified.[/red] Expected "
+        f"[red]Gateway {action} could not be verified.[/red] Expected "
         f"{expected_version}, gateway reports {observed or 'unreachable'}.\n"
         "Recovery: run 'agentos gateway status' to inspect, then "
         "'agentos gateway restart' to retry.",
@@ -352,12 +445,20 @@ def upgrade_command(
     # Execute the delegated upgrade under a bounded timeout.
     if source_dir is not None:
         _emit_source_install_notice(source_dir)
+    # Windows cannot replace files the managed gateway holds open, so it is
+    # stopped first and started again below. --no-restart means "do not touch my
+    # gateway", which this has to honour even though the upgrade may then fail.
+    stopped_for_upgrade = (
+        _stop_gateway_before_upgrade(config_path) if _ON_WINDOWS and not no_restart else False
+    )
     console.print(f"Upgrading use-agent-os via {plan.method.value}…")
     result = _run_upgrade_subprocess(plan.command, env=env, timeout=timeout)
     if result.stdout.strip():
         console.print(markup_escape(result.stdout.strip()))
 
     if result.timed_out:
+        if stopped_for_upgrade:
+            _start_gateway_after_failed_upgrade(config_path)
         console.print(
             f"[red]Upgrade timed out after {timeout:.0f}s and was terminated.[/red]\n"
             "The upgrade tool was killed (process group), so no half-finished child "
@@ -371,6 +472,10 @@ def upgrade_command(
             f"[red]Upgrade failed (exit {result.returncode}).[/red]\n"
             f"{markup_escape(result.stderr.strip())}"
         )
+        if _looks_like_file_lock(result):
+            _emit_file_lock_recovery(plan.manual_hint)
+        if stopped_for_upgrade:
+            _start_gateway_after_failed_upgrade(config_path)
         raise typer.Exit(1)
 
     # Report old → new by reading the version from a fresh subprocess of the
@@ -400,6 +505,7 @@ def upgrade_command(
         config_path=config_path,
         expected_version=new_version,
         json_output=json_output,
+        start_only=stopped_for_upgrade,
     )
     if json_output:
         print_json(

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -323,6 +323,15 @@ faking it; a failed or unverifiable upgrade is **exit 1**. Flags: `--timeout`
 (subprocess bound, default 600s; kills the process group on timeout),
 `--config`, `--json` (adds `sourceDirectory`).
 
+On Windows the managed gateway is stopped before the installer runs and started
+again afterwards — Windows cannot replace files a live process holds open, and
+the gateway runs the tool venv's own interpreter (that is the `Access is denied`
+on `…\uv\tools\use-agent-os\Scripts`). `--no-restart` opts out and can
+therefore still hit the lock. When the installer is refused anyway, the error
+names the recovery: stop the gateway, close every other AgentOS process, re-run
+the printed command from a fresh terminal, and restore uv's tool bin directory
+to PATH with `uv tool update-shell` if `agentos` has gone missing.
+
 Commands that reach the gateway compare CLI and gateway versions: a gateway
 **older** than the CLI warns (post-upgrade, before restart); a gateway
 **newer** than the CLI is *refused* (schema-corruption risk) unless

--- a/tests/test_cli/test_upgrade_cmd.py
+++ b/tests/test_cli/test_upgrade_cmd.py
@@ -426,3 +426,232 @@ def test_upgrade_subprocess_windows_guards_stuck_communicate_after_kill(
     assert result.ok is False
     assert result.stdout == ""
     assert result.stderr == ""
+
+
+# --- Windows: stop the gateway before its files are replaced (issue #1365) ---
+
+
+class _FakeLifecycleManager:
+    """Records the lifecycle calls `agentos upgrade` makes, in order."""
+
+    def __init__(self, calls: list[str], *, state: str = "running", managed: bool = True) -> None:
+        self._calls = calls
+        self._state = state
+        self._managed = managed
+        self.stop_exit_code = 0
+        self.start_exit_code = 0
+
+    def status(self) -> Any:
+        self._calls.append("status")
+        return types.SimpleNamespace(state=self._state, managed=self._managed)
+
+    def stop(self) -> Any:
+        self._calls.append("stop")
+        return types.SimpleNamespace(
+            exit_code=self.stop_exit_code, message="", code="", state="stopped"
+        )
+
+    def start(self) -> Any:
+        self._calls.append("start")
+        return types.SimpleNamespace(
+            exit_code=self.start_exit_code, message="", code="", state="running"
+        )
+
+    def restart(self) -> Any:
+        self._calls.append("restart")
+        return types.SimpleNamespace(exit_code=0, message="", code="", state="running")
+
+
+def _install_fake_lifecycle(
+    monkeypatch: pytest.MonkeyPatch, manager: _FakeLifecycleManager
+) -> None:
+    from agentos.cli import gateway_cmd
+
+    monkeypatch.setattr(gateway_cmd, "_lifecycle_manager", lambda **_: manager)
+
+
+def _lock_failure(*_: Any, **__: Any) -> upgrade_cmd.UpgradeRunResult:
+    return upgrade_cmd.UpgradeRunResult(
+        ok=False,
+        timed_out=False,
+        returncode=2,
+        stdout="",
+        stderr=(
+            r"error: failed to remove directory "
+            r"`...\uv\tools\use-agent-os\Scripts`: "
+            "Access is denied. (os error 5)"
+        ),
+    )
+
+
+def _upgrade_with_recorded_restart(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    on_windows: bool,
+    run: Any = _ok_run,
+    args: list[str] | None = None,
+) -> tuple[Any, list[dict[str, Any]]]:
+    restart_kwargs: list[dict[str, Any]] = []
+
+    def fake_restart(**kwargs: Any) -> bool:
+        restart_kwargs.append(kwargs)
+        return True
+
+    monkeypatch.setattr(upgrade_cmd, "_ON_WINDOWS", on_windows)
+    monkeypatch.setattr(upgrade_cmd, "build_upgrade_plan", _delegated_plan)
+    monkeypatch.setattr(upgrade_cmd, "_run_upgrade_subprocess", run)
+    monkeypatch.setattr(upgrade_cmd, "_installed_version_via", lambda *a, **k: "99999.2.0")
+    monkeypatch.setattr(upgrade_cmd, "_restart_and_verify", fake_restart)
+
+    result = runner.invoke(_app(), ["upgrade", *(args or [])])
+    return result, restart_kwargs
+
+
+def test_windows_stops_the_managed_gateway_before_replacing_its_files(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+    _install_fake_lifecycle(monkeypatch, _FakeLifecycleManager(calls))
+
+    result, restart_kwargs = _upgrade_with_recorded_restart(monkeypatch, on_windows=True)
+
+    assert result.exit_code == 0
+    assert calls == ["status", "stop"]
+    # Already stopped, so the gateway has to be started, not restarted.
+    assert restart_kwargs[0]["start_only"] is True
+
+
+def test_posix_keeps_the_restart_afterwards_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+    _install_fake_lifecycle(monkeypatch, _FakeLifecycleManager(calls))
+
+    result, restart_kwargs = _upgrade_with_recorded_restart(monkeypatch, on_windows=False)
+
+    assert result.exit_code == 0
+    assert calls == []
+    assert restart_kwargs[0]["start_only"] is False
+
+
+def test_windows_no_restart_leaves_the_gateway_alone(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+    _install_fake_lifecycle(monkeypatch, _FakeLifecycleManager(calls))
+    monkeypatch.setattr(upgrade_cmd, "_ON_WINDOWS", True)
+    monkeypatch.setattr(upgrade_cmd, "build_upgrade_plan", _delegated_plan)
+    monkeypatch.setattr(upgrade_cmd, "_run_upgrade_subprocess", _ok_run)
+    monkeypatch.setattr(upgrade_cmd, "_installed_version_via", lambda *a, **k: "99999.2.0")
+
+    result = runner.invoke(_app(), ["upgrade", "--no-restart"])
+
+    assert result.exit_code == 0
+    assert calls == []
+
+
+def test_windows_unmanaged_gateway_is_not_stopped(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+    _install_fake_lifecycle(
+        monkeypatch, _FakeLifecycleManager(calls, state="unmanaged", managed=False)
+    )
+
+    result, restart_kwargs = _upgrade_with_recorded_restart(monkeypatch, on_windows=True)
+
+    assert result.exit_code == 0
+    assert calls == ["status"]
+    assert restart_kwargs[0]["start_only"] is False
+
+
+def test_failed_upgrade_starts_the_gateway_it_stopped(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+    _install_fake_lifecycle(monkeypatch, _FakeLifecycleManager(calls))
+
+    result, _ = _upgrade_with_recorded_restart(monkeypatch, on_windows=True, run=_lock_failure)
+
+    assert result.exit_code == 1
+    assert calls == ["status", "stop", "start"]
+
+
+def test_access_denied_failure_names_the_recovery(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+    _install_fake_lifecycle(monkeypatch, _FakeLifecycleManager(calls))
+
+    result, _ = _upgrade_with_recorded_restart(monkeypatch, on_windows=True, run=_lock_failure)
+
+    assert result.exit_code == 1
+    assert "access denied" in result.stdout
+    assert "agentos gateway stop" in result.stdout
+    # Rich wraps the panel-free console output, so assert on stable fragments.
+    assert "uv tool install --force" in result.stdout
+    assert "uv tool update-shell" in result.stdout
+
+
+def test_ordinary_failure_does_not_print_the_lock_recovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _plain_failure(*_: Any, **__: Any) -> upgrade_cmd.UpgradeRunResult:
+        return upgrade_cmd.UpgradeRunResult(
+            ok=False,
+            timed_out=False,
+            returncode=1,
+            stdout="",
+            stderr="error: no solution found for use-agent-os",
+        )
+
+    calls: list[str] = []
+    _install_fake_lifecycle(monkeypatch, _FakeLifecycleManager(calls))
+
+    result, _ = _upgrade_with_recorded_restart(monkeypatch, on_windows=True, run=_plain_failure)
+
+    assert result.exit_code == 1
+    assert "uv tool update-shell" not in result.stdout
+
+
+@pytest.mark.parametrize(
+    "stderr",
+    [
+        "Access is denied. (os error 5)",
+        "ACCESS IS DENIED",
+        "PermissionError: [WinError 5] Access is denied",
+    ],
+)
+def test_looks_like_file_lock_matches_windows_denials(stderr: str) -> None:
+    result = upgrade_cmd.UpgradeRunResult(
+        ok=False, timed_out=False, returncode=2, stdout="", stderr=stderr
+    )
+
+    assert upgrade_cmd._looks_like_file_lock(result) is True
+
+
+def test_looks_like_file_lock_ignores_ordinary_failures() -> None:
+    result = upgrade_cmd.UpgradeRunResult(
+        ok=False, timed_out=False, returncode=1, stdout="", stderr="no solution found"
+    )
+
+    assert upgrade_cmd._looks_like_file_lock(result) is False
+
+
+def test_start_only_starts_instead_of_restarting(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+    _install_fake_lifecycle(monkeypatch, _FakeLifecycleManager(calls))
+    monkeypatch.setattr(upgrade_cmd, "_query_gateway_version", lambda _: "99999.2.0")
+
+    verified = upgrade_cmd._restart_and_verify(
+        config_path=None,
+        expected_version="99999.2.0",
+        json_output=False,
+        start_only=True,
+    )
+
+    assert verified is True
+    assert calls == ["start"]
+
+
+def test_stop_failure_falls_back_to_the_restart_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+    manager = _FakeLifecycleManager(calls)
+    manager.stop_exit_code = 1
+    _install_fake_lifecycle(monkeypatch, manager)
+
+    result, restart_kwargs = _upgrade_with_recorded_restart(monkeypatch, on_windows=True)
+
+    assert result.exit_code == 0
+    assert calls == ["status", "stop"]
+    assert restart_kwargs[0]["start_only"] is False


### PR DESCRIPTION
On Windows, `agentos upgrade` failed with `Access is denied` on
`…\uv\tools\use-agent-os\Scripts`, and afterwards `agentos` was gone from PATH.

The lock is one this repo creates. `GatewayLifecycleManager` spawns the managed
gateway as `sys.executable -m agentos.cli.main gateway run` — and inside a uv
tool venv `sys.executable` is `…\use-agent-os\Scripts\python.exe`. Windows will
not let anything delete or overwrite a file a live process has open, so
`uv tool install --force` rebuilding that venv underneath the running gateway is
refused, and the tool directory can be left half-replaced. That matches the
report exactly: "Leave AgentOS / Python running", and a workaround of "Task
Manager end Python, then `uv tool install --force …`".

Today the command restarts the gateway *after* the upgrade, which is the right
order on POSIX (files are replaced under a running process happily) and the
wrong one on Windows.

## Change

1. **Stop first on Windows.** When a managed gateway is running, it is stopped
   before the installer runs and started again afterwards
   (`_restart_and_verify(start_only=True)`), with the same bounded
   version verification as the restart path. POSIX keeps the lower-downtime
   restart-afterwards behaviour, unchanged.
2. **Don't strand the gateway.** If the upgrade then fails or times out, the
   gateway we stopped is started again on the previous version.
3. **Name the recovery when the installer is still refused.** An `Access is
   denied` / `os error 5` / `WinError 5` failure now prints what actually holds
   the install open and the three steps out — including restoring uv's tool bin
   directory to PATH with `uv tool update-shell`, which is the "then agentos is
   not found" half of the report. Ordinary failures are untouched.

`--no-restart` means "do not touch my gateway", so it opts out of the stop and
can therefore still hit the lock; that is stated in the docs.

## Caveat

I do not have Windows hardware, so the platform behaviour here is reasoned from
the report and from how `GatewayLifecycleManager` spawns the gateway, not
observed. The logic is fully covered by tests that drive the Windows branch from
either platform (the `_ON_WINDOWS` flag is read through a module constant, the
same technique `install_method.py` already uses for its Windows env-var rule).
If an operator's PATH points directly at the tool venv `Scripts` directory, the
running `agentos.exe` itself lives there and Windows may still refuse — which is
what step 3's guidance is for.

## Verification

- 13 new tests in `tests/test_cli/test_upgrade_cmd.py`: the Windows stop-then-
  start ordering, POSIX unchanged, `--no-restart` leaves the gateway alone, an
  unmanaged gateway is not stopped, a failed upgrade starts back what it
  stopped, the access-denied guidance fires (and does not fire on an ordinary
  failure), the marker matcher, `start_only` calling `start()` not `restart()`,
  and a failed stop falling back to the restart path.
- All 19 pre-existing `test_upgrade_cmd.py` tests pass unchanged.
- `ruff check src tests`, `mypy src/agentos`, and the full `pytest` suite pass.

Docs: `docs/cli.md` and `src/agentos/skills/bundled/agentos/SKILL.md`, per the
CLI-surface rule in AGENTS.md.

Fixes #1365

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0133si2sRrGEeYCzaiQuyKcb
