### PR TITLE
fix(provider): fail fast and name the cause when Ollama is down

### DIFF
--- a/src/agentos/provider/ollama.py
+++ b/src/agentos/provider/ollama.py
@@ -28,6 +28,8 @@ from .types import (
 
 _OLLAMA_DEFAULT_BASE = "http://localhost:11434"
 _OLLAMA_ERROR_BODY_LIMIT = 2000
+# Connect budget for a daemon on the same machine. See _stream_timeout.
+_OLLAMA_CONNECT_TIMEOUT_S = 5.0
 
 
 def _build_ollama_tool(tool: ToolDefinition) -> dict[str, Any]:
@@ -129,6 +131,45 @@ def _format_error_body(body: bytes) -> str:
     return text[: _OLLAMA_ERROR_BODY_LIMIT - 1].rstrip() + "…"
 
 
+def _stream_timeout(timeout: float) -> httpx.Timeout:
+    """Bound the connect phase separately from the request timeout.
+
+    Ollama is a local daemon: a connection nobody accepts within a few seconds
+    means the server is not there (or is wedged), and spending the full
+    ``cfg.timeout`` on it only leaves the caller waiting. The read timeout stays
+    ``timeout`` — a first token can legitimately wait for the model to load.
+    """
+
+    connect = min(_OLLAMA_CONNECT_TIMEOUT_S, max(timeout, 1.0))
+    return httpx.Timeout(timeout, connect=connect, write=10.0, pool=10.0)
+
+
+def _unreachable_message(exc: Exception, base_url: str) -> str:
+    """Name the cause instead of leaking a bare transport error.
+
+    Keeps the words the ollama branch of ``classify_provider_error`` keys on
+    ("connection error"), which httpx's own ``All connection attempts failed``
+    does not carry.
+    """
+
+    return (
+        f"Connection error: Ollama is not reachable at {base_url} — start it with "
+        f"'ollama serve', or point AgentOS at the host that runs it. "
+        f"({type(exc).__name__}: {exc})"
+    )
+
+
+def _http_error_message(status_code: int, detail: str, model: str, base_url: str) -> str:
+    """Turn Ollama's "model not found" 404 into the command that fixes it."""
+
+    if status_code == 404 and "model" in detail.lower():
+        return (
+            f"Ollama model {model!r} is not available at {base_url} — pull it first: "
+            f"ollama pull {model}. (HTTP {status_code}: {detail})"
+        )
+    return f"HTTP {status_code}: {detail}"
+
+
 def _parse_tool_call(value: Any, fallback_index: int) -> dict[str, Any] | None:
     if not isinstance(value, dict):
         return None
@@ -224,7 +265,7 @@ class OllamaProvider:
 
         try:
             async with httpx.AsyncClient(
-                timeout=cfg.timeout,
+                timeout=_stream_timeout(cfg.timeout),
                 trust_env=_trust_env(),
                 proxy=self._proxy,
             ) as client:
@@ -236,7 +277,12 @@ class OllamaProvider:
                     if response.status_code != 200:
                         body = await response.aread()
                         yield ErrorEvent(
-                            message=f"HTTP {response.status_code}: {_format_error_body(body)}",
+                            message=_http_error_message(
+                                response.status_code,
+                                _format_error_body(body),
+                                self._model,
+                                self._base_url,
+                            ),
                             code=str(response.status_code),
                         )
                         return
@@ -324,6 +370,11 @@ class OllamaProvider:
                         model=response_model,
                     )
 
+        except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
+            yield ErrorEvent(
+                message=_unreachable_message(exc, self._base_url),
+                code="connection_error",
+            )
         except httpx.TimeoutException as exc:
             yield ErrorEvent(message=f"Request timed out: {exc}", code="timeout")
         except httpx.RequestError as exc:

--- a/tests/test_provider_ollama.py
+++ b/tests/test_provider_ollama.py
@@ -18,7 +18,8 @@ from agentos.provider import (
     ToolInputSchema,
     ToolUseEndEvent,
 )
-from agentos.provider.ollama import OllamaProvider
+from agentos.provider.failures import ProviderFailureKind, classify_provider_error
+from agentos.provider.ollama import OllamaProvider, _stream_timeout
 
 
 def _patch_transport(
@@ -260,3 +261,108 @@ def test_ollama_ignores_malformed_tool_call_chunks(monkeypatch: pytest.MonkeyPat
     assert not any(isinstance(event, ToolUseEndEvent) for event in events)
     done = next(event for event in events if isinstance(event, DoneEvent))
     assert done.stop_reason == "stop"
+
+
+def _patch_raising_transport(monkeypatch: pytest.MonkeyPatch, exc: Exception) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise exc
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def patched_async_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr("agentos.provider.ollama.httpx.AsyncClient", patched_async_client)
+
+
+def _first_event(provider: OllamaProvider) -> Any:
+    async def _run() -> list[Any]:
+        return [event async for event in provider.chat([Message(role="user", content="Hi")])]
+
+    events = asyncio.run(_run())
+    assert len(events) == 1
+    return events[0]
+
+
+def test_ollama_connect_timeout_is_bounded_below_the_request_timeout() -> None:
+    timeout = _stream_timeout(120.0)
+
+    assert timeout.connect == 5.0
+    assert timeout.read == 120.0
+
+
+def test_ollama_connect_timeout_never_exceeds_a_short_request_timeout() -> None:
+    assert _stream_timeout(2.0).connect == 2.0
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        httpx.ConnectError("All connection attempts failed"),
+        httpx.ConnectTimeout("timed out"),
+    ],
+)
+def test_ollama_server_down_names_the_cause(
+    monkeypatch: pytest.MonkeyPatch, exc: Exception
+) -> None:
+    _patch_raising_transport(monkeypatch, exc)
+    provider = OllamaProvider(model="llama3.1:8b")
+
+    error = _first_event(provider)
+
+    assert isinstance(error, ErrorEvent)
+    assert error.code == "connection_error"
+    assert "Ollama is not reachable at http://localhost:11434" in error.message
+    assert "ollama serve" in error.message
+    # The ollama branch of classify_provider_error keys on this wording.
+    assert (
+        classify_provider_error(
+            provider_name="ollama",
+            status_code=None,
+            raw_code=error.code,
+            message=error.message,
+        )
+        is ProviderFailureKind.TRANSPORT_TRANSIENT
+    )
+
+
+def test_ollama_missing_model_404_says_how_to_pull_it(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(
+        monkeypatch,
+        captured,
+        '{"error":"model \\"llama3.1:8b\\" not found, try pulling it first"}',
+        status_code=404,
+    )
+    provider = OllamaProvider(model="llama3.1:8b")
+
+    error = _first_event(provider)
+
+    assert isinstance(error, ErrorEvent)
+    assert error.code == "404"
+    assert "ollama pull llama3.1:8b" in error.message
+    assert "not found, try pulling it first" in error.message
+    assert (
+        classify_provider_error(
+            provider_name="ollama",
+            status_code=404,
+            raw_code=error.code,
+            message=error.message,
+        )
+        is ProviderFailureKind.MODEL_NOT_FOUND
+    )
+
+
+def test_ollama_non_model_404_keeps_the_plain_http_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, captured, "404 page not found", status_code=404)
+    provider = OllamaProvider(model="llama3.1:8b")
+
+    error = _first_event(provider)
+
+    assert isinstance(error, ErrorEvent)
+    assert error.message == "HTTP 404: 404 page not found"


### PR DESCRIPTION
`OllamaProvider` passed `cfg.timeout` (120s by default) to `httpx.AsyncClient`
as a single timeout, so the connect phase got the whole request budget, and it
surfaced transport and HTTP failures verbatim — `Request error: All connection
attempts failed`, or a raw `HTTP 404: {"error":"model \"x\" not found, try
pulling it first"}`. Neither tells an operator what to do.

## Change

Three contained changes in `src/agentos/provider/ollama.py`:

1. `_stream_timeout` bounds the connect phase at 5s while leaving the read
   timeout at `cfg.timeout` (mirrors the helper `openai.py` already has). Ollama
   is a local daemon: a connection nobody accepts in five seconds means it is
   not there or is wedged. The read timeout deliberately stays put — a first
   token can legitimately wait for a model to load.
2. `httpx.ConnectError` / `ConnectTimeout` are classified ahead of the generic
   handlers and answered with
   `Connection error: Ollama is not reachable at <base_url> — start it with
   'ollama serve', or point AgentOS at the host that runs it. (…)`.
3. A 404 whose body mentions the model becomes
   `Ollama model 'llama3.1:8b' is not available at <base_url> — pull it first:
   ollama pull llama3.1:8b. (HTTP 404: …)`. Any other 404, and every other
   status, keeps the existing `HTTP <code>: <body>` shape and the numeric
   `code`, so the existing contract is unchanged.

Both new messages deliberately keep the words the `ollama` branch of
`classify_provider_error` keys on, so `TRANSPORT_TRANSIENT` and
`MODEL_NOT_FOUND` classification (and the recovery it drives) is preserved —
httpx's own `All connection attempts failed` carries neither.

## Scope

This covers the two failures the issue names under "Expected behavior" — Ollama
not running, and the model not pulled — and bounds the connect phase so a wedged
listener fails in seconds instead of two minutes.

It does **not** shorten the read timeout, so the reporter's other observation —
Ollama itself taking a long time and then answering `500 Internal error, check
server logs` (a model that crashed or ran out of memory) — is still as slow as
Ollama is; failing faster there would cut off legitimate model loading. The
"sometimes the reply was JSON, not the word ok" note is model behaviour, not a
transport problem, and is not addressed here either. Hence `Refs`, not `Fixes` —
happy to widen if you'd rather this closed the issue.

## Verification

- 7 new tests in `tests/test_provider_ollama.py`: the connect bound and its
  clamp for short timeouts, both connect-failure types (message + classification
  round-trip), the model-not-pulled 404, and a non-model 404 keeping the plain
  `HTTP 404: …` message.
- All 5 pre-existing Ollama tests pass unchanged, including the one that pins
  the `HTTP 502: …` message shape and body truncation.
- `ruff check src tests`, `mypy src/agentos`, and the full `pytest` suite pass.

Refs #1366

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0133si2sRrGEeYCzaiQuyKcb
