### PR TITLE
perf(gateway): bound the send-path freshness probe to one transcript row

### DIFF
--- a/src/agentos/gateway/rpc_sessions.py
+++ b/src/agentos/gateway/rpc_sessions.py
@@ -71,6 +71,25 @@ _MAX_TOTAL_ATTACHMENT_BYTES = _attachment_ingest.MAX_TOTAL_ATTACHMENT_BYTES
 _MAX_ATTACHMENTS = _attachment_ingest.MAX_ATTACHMENTS
 
 
+async def _probe_fresh_user_session(get_transcript: Any, key: str) -> bool:
+    """True when ``key`` has no transcript yet, reading at most one row.
+
+    This runs on every user message, and only a single boolean is being
+    decided, so an unbounded ``get_transcript(key)`` would read and
+    deserialise the entire history of the conversation the user is currently
+    having — cost that grows with the conversation, on its own send path.
+
+    The call is duck-typed through ``getattr``: several session managers take
+    the key alone, and passing ``limit=`` to those would raise ``TypeError``
+    instead of merely reading too much, so the bound is only applied when the
+    callable actually accepts it.
+    """
+
+    if accepts_keyword_arg(get_transcript, "limit"):
+        return not bool(await get_transcript(key, limit=1))
+    return not bool(await get_transcript(key))
+
+
 def _clean_cancel_source(value: Any, default: str) -> str:
     text = str(value or "").strip()
     if not text:
@@ -1053,7 +1072,7 @@ async def _handle_sessions_send(params: dict | None, ctx: RpcContext) -> dict:
         nonlocal message_text, persisted_entry, fresh_user_session
         get_transcript = getattr(ctx.session_manager, "get_transcript", None)
         if callable(get_transcript):
-            fresh_user_session = not bool(await get_transcript(key))
+            fresh_user_session = await _probe_fresh_user_session(get_transcript, key)
         if raw_attachments:
             from agentos.gateway.transcripts import (
                 build_transcript_attachment_envelope,

--- a/tests/test_gateway/test_rpc_sessions_fresh_probe.py
+++ b/tests/test_gateway/test_rpc_sessions_fresh_probe.py
@@ -1,0 +1,102 @@
+"""The freshness probe on the send path reads at most one transcript row.
+
+``_persist_user_message`` only needs to know whether a session has any
+history yet. Reading the whole transcript to answer that made every user
+message cost O(conversation length) — see issue #1368.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agentos.compat.inspect_utils import accepts_keyword_arg
+from agentos.gateway.rpc_sessions import _probe_fresh_user_session
+from agentos.session.manager import SessionManager
+
+
+class _BoundedManager:
+    """Mirrors the real ``SessionManager.get_transcript`` signature."""
+
+    def __init__(self, entries: list[str]) -> None:
+        self._entries = entries
+        self.calls: list[int | None] = []
+
+    async def get_transcript(self, session_key: str, limit: int | None = None) -> list[str]:
+        self.calls.append(limit)
+        rows = self._entries
+        return list(rows if limit is None else rows[:limit])
+
+
+class _KwargsManager:
+    """A manager that swallows keywords it does not name explicitly."""
+
+    def __init__(self, entries: list[str]) -> None:
+        self._entries = entries
+        self.calls: list[dict[str, Any]] = []
+
+    async def get_transcript(self, session_key: str, **kwargs: Any) -> list[str]:
+        self.calls.append(dict(kwargs))
+        return list(self._entries)
+
+
+class _KeyOnlyManager:
+    """A manager that takes the key alone — ``limit=`` would be a TypeError."""
+
+    def __init__(self, entries: list[str]) -> None:
+        self._entries = entries
+        self.calls = 0
+
+    async def get_transcript(self, session_key: str) -> list[str]:
+        self.calls += 1
+        return list(self._entries)
+
+
+@pytest.mark.asyncio
+async def test_bounded_manager_is_asked_for_one_row_only() -> None:
+    manager = _BoundedManager(["a", "b", "c"])
+
+    fresh = await _probe_fresh_user_session(manager.get_transcript, "agent:main:webchat:x")
+
+    assert fresh is False
+    assert manager.calls == [1]
+
+
+@pytest.mark.asyncio
+async def test_bounded_manager_reports_empty_session_as_fresh() -> None:
+    manager = _BoundedManager([])
+
+    fresh = await _probe_fresh_user_session(manager.get_transcript, "agent:main:webchat:x")
+
+    assert fresh is True
+    assert manager.calls == [1]
+
+
+@pytest.mark.asyncio
+async def test_var_keyword_manager_still_receives_the_bound() -> None:
+    manager = _KwargsManager(["a"])
+
+    fresh = await _probe_fresh_user_session(manager.get_transcript, "agent:main:webchat:x")
+
+    assert fresh is False
+    assert manager.calls == [{"limit": 1}]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("entries", "expected"), [([], True), (["a"], False)])
+async def test_key_only_manager_is_called_without_a_bound(
+    entries: list[str], expected: bool
+) -> None:
+    manager = _KeyOnlyManager(entries)
+
+    fresh = await _probe_fresh_user_session(manager.get_transcript, "agent:main:webchat:x")
+
+    assert fresh is expected
+    assert manager.calls == 1
+
+
+def test_real_session_manager_takes_the_bounded_path() -> None:
+    """Pins the production manager on the one-row branch, not the fallback."""
+
+    assert accepts_keyword_arg(SessionManager.get_transcript, "limit") is True


### PR DESCRIPTION
`_persist_user_message` decides one boolean — "has this session said anything
yet?" — and was reading the entire transcript to do it:

```python
fresh_user_session = not bool(await get_transcript(key))
```

`SessionManager.get_transcript` defaults `limit` to `None`, and
`SessionStorage.get_transcript` turns that into `LIMIT -1`, then builds a
`TranscriptEntry` per row through `_deserialize_row`. The measurement in the
issue, on a 5,000-entry session: 135.12 ms unbounded vs 4.39 ms at `limit=1`.

This sits on the send path of the conversation the user is currently having, so
the cost grows with the conversation: every turn gets slower the longer they
talk.

## Change

A small `_probe_fresh_user_session` helper, and the call site now goes through
it. The bound is applied only when the callable actually accepts `limit` — the
call is duck-typed through `getattr`, and several session managers (including
the fakes in this repo's own tests) take the key alone, so passing `limit=`
unconditionally would turn "reads too much" into `TypeError`. This is the guard
the issue asks for; it uses the canonical `accepts_keyword_arg` from
`agentos.compat.inspect_utils` that #1201 landed, rather than the local copy the
issue text refers to.

No behaviour change: `not bool(rows)` is the same answer whether one row or all
of them came back.

## Verification

- New: `tests/test_gateway/test_rpc_sessions_fresh_probe.py` (6 tests) covering
  the bounded manager (asserts exactly `limit=1` is passed), a `**kwargs`
  manager, a key-only manager (no `TypeError`, no bound), empty vs non-empty,
  and a contract test pinning the real `SessionManager.get_transcript` on the
  bounded branch rather than the fallback.
- The pre-existing `sessions.send` freshness tests in
  `tests/test_gateway/test_rpc_sessions.py` cover the key-only path end to end
  and still pass unchanged.
- `ruff check src tests`, `mypy src/agentos`, and the full `pytest` suite pass.

Fixes #1368

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0133si2sRrGEeYCzaiQuyKcb
