### PR TITLE
fix(gateway): reject a non-integer maxMessages before truncating

### DIFF
--- a/src/agentos/gateway/rpc_sessions.py
+++ b/src/agentos/gateway/rpc_sessions.py
@@ -406,6 +406,33 @@ def _require_key(params: dict | None) -> str:
     return canonicalize_session_key(key)
 
 
+_MAX_MESSAGES_ERROR = "params.maxMessages must be a non-negative integer"
+
+
+def _require_max_messages(params: dict | None, default: int = 20) -> int:
+    """Validate ``maxMessages`` before anything destructive can run.
+
+    ``bool`` is a subclass of ``int``, so an unguarded read let ``false``
+    through as ``0`` — wiping the entire transcript and still answering
+    ``ok: true`` — and ``true`` through as "keep only the newest message".
+    A non-numeric value instead reached the session manager's own
+    ``max_messages < 0`` check and raised ``TypeError``, which the dispatcher's
+    catch-all turned into a raw INTERNAL_ERROR carrying the Python error string.
+
+    ``0`` stays valid: it is the intentional wipe, already gated by the
+    checkpoint/force safety check in the handler.
+    """
+
+    value = (params or {}).get("maxMessages", default)
+    if isinstance(value, bool):
+        raise ValueError(_MAX_MESSAGES_ERROR)
+    if not isinstance(value, int):
+        raise ValueError(_MAX_MESSAGES_ERROR)
+    if value < 0:
+        raise ValueError(_MAX_MESSAGES_ERROR)
+    return value
+
+
 def _effective_agent_id_for_session(session: Any | None, session_key: str) -> str:
     """Prefer the explicit agent encoded in modern session keys.
 
@@ -2251,7 +2278,7 @@ async def _handle_sessions_truncate(params: dict | None, ctx: RpcContext) -> dic
     if ctx.session_manager is None:
         raise KeyError("No session manager available")
 
-    max_messages = (params or {}).get("maxMessages", 20)
+    max_messages = _require_max_messages(params)
     force = bool((params or {}).get("force", False))
 
     turn_runner = ctx.turn_runner

--- a/tests/test_gateway/test_rpc_sessions_truncate_validation.py
+++ b/tests/test_gateway/test_rpc_sessions_truncate_validation.py
@@ -1,0 +1,136 @@
+"""``sessions.truncate`` validates ``maxMessages`` before it destroys anything.
+
+``bool`` is a subclass of ``int``, so an unguarded read let ``maxMessages:
+false`` reach the truncation as ``0`` — wiping the whole transcript while
+answering ``ok: true`` — and ``true`` as "keep only the newest message". A
+string reached the session manager's ``max_messages < 0`` comparison and
+raised ``TypeError``, surfacing as a raw INTERNAL_ERROR. See issue #1371.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agentos.gateway.config import GatewayConfig
+from agentos.gateway.rpc import RpcContext, get_dispatcher
+from agentos.gateway.rpc_sessions import _require_max_messages
+
+
+class _FakeSession:
+    def __init__(self, session_key: str) -> None:
+        self.session_key = session_key
+        self.session_id = session_key.rsplit(":", 1)[-1]
+
+
+class _FakeStorage:
+    def __init__(self, session: _FakeSession) -> None:
+        self._session = session
+        self.memory_durable_receipts: list[Any] = []
+
+    async def get_session(self, key: str) -> _FakeSession | None:
+        return self._session if key == self._session.session_key else None
+
+
+class _FakeSessionManager:
+    """Just enough manager for the truncate handler's happy path."""
+
+    def __init__(self, session: _FakeSession) -> None:
+        self._storage = _FakeStorage(session)
+        self.transcript: list[Any] = []
+        self.truncate_calls: list[tuple[str, int]] = []
+
+    async def get_transcript(self, key: str) -> list[Any]:
+        return list(self.transcript)
+
+    async def truncate(self, session_key: str, max_messages: int = 20) -> dict:
+        self.truncate_calls.append((session_key, max_messages))
+        return {"truncated": False, "before_count": 0, "after_count": 0}
+
+
+SESSION_KEY = "agent:main:webchat:truncate-validation"
+
+
+@pytest.fixture
+def dispatcher():
+    return get_dispatcher()
+
+
+@pytest.fixture
+def manager() -> _FakeSessionManager:
+    return _FakeSessionManager(_FakeSession(SESSION_KEY))
+
+
+@pytest.fixture
+def ctx(manager: _FakeSessionManager) -> RpcContext:
+    context = RpcContext(conn_id="test-conn", config=GatewayConfig())
+    context.session_manager = manager
+    return context
+
+
+# ---------------------------------------------------------------------------
+# Unit: the guard itself.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", [False, True, "20", 20.0, None, -1, [], {"a": 1}])
+def test_rejected_values(value: Any) -> None:
+    with pytest.raises(ValueError, match="params.maxMessages must be a non-negative integer"):
+        _require_max_messages({"maxMessages": value})
+
+
+@pytest.mark.parametrize("value", [0, 1, 20, 10_000])
+def test_accepted_values_pass_through(value: int) -> None:
+    assert _require_max_messages({"maxMessages": value}) == value
+
+
+def test_missing_key_uses_the_default() -> None:
+    assert _require_max_messages({}) == 20
+    assert _require_max_messages(None) == 20
+
+
+# ---------------------------------------------------------------------------
+# Handler: a bad value is a client error, and nothing is truncated.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", [False, True, "20", 20.0, -1])
+async def test_bad_max_messages_is_invalid_request_and_truncates_nothing(
+    dispatcher, ctx, manager, value: Any
+) -> None:
+    manager.transcript = [object(), object(), object()]
+
+    res = await dispatcher.dispatch(
+        "r1",
+        "sessions.truncate",
+        {"key": SESSION_KEY, "maxMessages": value},
+        ctx,
+    )
+
+    assert res.ok is False
+    assert res.error.code == "INVALID_REQUEST"
+    assert res.error.message == "params.maxMessages must be a non-negative integer"
+    assert manager.truncate_calls == []
+
+
+@pytest.mark.asyncio
+async def test_zero_remains_an_accepted_wipe(dispatcher, ctx, manager) -> None:
+    res = await dispatcher.dispatch(
+        "r1",
+        "sessions.truncate",
+        {"key": SESSION_KEY, "maxMessages": 0},
+        ctx,
+    )
+
+    assert res.ok is True
+    assert manager.truncate_calls == [(SESSION_KEY, 0)]
+
+
+@pytest.mark.asyncio
+async def test_default_is_used_when_max_messages_is_absent(dispatcher, ctx, manager) -> None:
+    res = await dispatcher.dispatch("r1", "sessions.truncate", {"key": SESSION_KEY}, ctx)
+
+    assert res.ok is True
+    assert manager.truncate_calls == [(SESSION_KEY, 20)]


### PR DESCRIPTION
`_handle_sessions_truncate` read `maxMessages` with no validation:

```python
max_messages = (params or {}).get("maxMessages", 20)
```

`bool` is a subclass of `int`, so the value flowed straight into the truncation:

- `maxMessages: false` → `max_messages == 0` → `recent = []` → the whole
  transcript is wiped, silently, with `ok: true`.
- `maxMessages: true` → `entries[-1:]` → only the newest message survives.
- `maxMessages: "20"` → reached `session_manager.truncate`'s own
  `if max_messages < 0` and raised `TypeError`, which the dispatcher's catch-all
  turned into a raw `INTERNAL_ERROR` leaking the Python error string.

Same class as #1261, but on a destructive operation.

## Change

`_require_max_messages` validates before anything destructive can run, next to
the existing `_require_key`. A bad value raises `ValueError`, which the RPC
registry already maps to `INVALID_REQUEST`:

```
error.code    = "INVALID_REQUEST"
error.message = "params.maxMessages must be a non-negative integer"
```

`maxMessages: 0` stays valid, as the issue asks — it is the intentional wipe,
already gated by the existing checkpoint/force safety check.

## Verification

- New: `tests/test_gateway/test_rpc_sessions_truncate_validation.py` (20 tests):
  the guard itself over rejected (`False`, `True`, `"20"`, `20.0`, `None`, `-1`,
  `[]`, `{}`) and accepted (`0`, `1`, `20`, `10000`) values and the default; and
  through the dispatcher, that a bad value is `INVALID_REQUEST` with
  `truncate()` never called, that `0` still truncates, and that the absent key
  still means 20.
- Existing `TestSessionsTruncate` cases pass unchanged.
- `ruff check src tests`, `mypy src/agentos`, and the full `pytest` suite pass.

Fixes #1371

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0133si2sRrGEeYCzaiQuyKcb
