### PR TITLE
fix(skills): keep docx replace_text from collapsing a paragraph's run…

### DIFF
--- a/src/agentos/skills/bundled/docx/scripts/edit_docx.py
+++ b/src/agentos/skills/bundled/docx/scripts/edit_docx.py
@@ -4,9 +4,13 @@ Operations:
     {"op": "replace_run", "para": <int>, "run": <int>, "text": "..."}
     {"op": "replace_text", "find": "...", "with": "..."}
 
-`replace_text` walks every paragraph and concatenates run texts when the
-target string spans multiple runs, then writes the replacement back into the
-first run and clears the others — preserving the first run's style.
+`replace_text` walks every paragraph and concatenates run texts to find
+matches that may span multiple runs, but only ever touches the characters a
+match actually covers: the replacement lands in the run that owned the
+match's first character, and every other run — including the rest of a run a
+match only partly overlapped — keeps its own original text untouched. Runs
+are where OOXML character formatting (bold, italic, font, colour, ...)
+lives, so a run this leaves alone keeps its formatting exactly as it was.
 """
 
 from __future__ import annotations
@@ -27,15 +31,39 @@ def _replace_run(para: Paragraph, run_idx: int, text: str) -> None:
 
 
 def _replace_text_in_paragraph(para: Paragraph, find: str, replacement: str) -> bool:
-    if not para.runs:
+    if not para.runs or not find:
         return False
     full = "".join(run.text for run in para.runs)
     if find not in full:
         return False
-    new_full = full.replace(find, replacement)
-    para.runs[0].text = new_full
-    for run in para.runs[1:]:
-        run.text = ""
+
+    # Which run each character of `full` originally belongs to, so a
+    # character a match never touched can be written back into its own run
+    # (and keep that run's formatting) even when the match right before or
+    # after it spans multiple runs.
+    run_at: list[int] = []
+    for run_idx, run in enumerate(para.runs):
+        run_at.extend([run_idx] * len(run.text))
+
+    new_texts = ["" for _ in para.runs]
+    find_len = len(find)
+    pos = 0
+    while True:
+        match_start = full.find(find, pos)
+        if match_start == -1:
+            for i in range(pos, len(full)):
+                new_texts[run_at[i]] += full[i]
+            break
+        for i in range(pos, match_start):
+            new_texts[run_at[i]] += full[i]
+        # The whole replacement goes to the run owning the match's first
+        # character. Every other run the match spans loses only the matched
+        # characters -- it is not otherwise touched.
+        new_texts[run_at[match_start]] += replacement
+        pos = match_start + find_len
+
+    for run, text in zip(para.runs, new_texts, strict=True):
+        run.text = text
     return True
 
 

--- a/tests/test_skill_docx.py
+++ b/tests/test_skill_docx.py
@@ -108,6 +108,111 @@ def test_edit_replace_text(tmp_path: Path) -> None:
     assert "Wei" in text
 
 
+def _load_edit_docx() -> object:
+    sys.path.insert(0, str(SCRIPTS))
+    try:
+        import edit_docx  # type: ignore[import-not-found]
+
+        return edit_docx
+    finally:
+        sys.path.pop(0)
+
+
+def test_replace_text_inside_a_single_run_only_touches_that_run() -> None:
+    """A match fully inside one run must not disturb any other run's text
+    or formatting (#1447)."""
+    from docx import Document
+
+    edit_docx = _load_edit_docx()
+    doc = Document()
+    para = doc.add_paragraph()
+    para.add_run("Hello ")
+    bold = para.add_run("world")
+    bold.bold = True
+    para.add_run(" and more")
+
+    changed = edit_docx.apply_ops(doc, [{"op": "replace_text", "find": "Hello", "with": "Hi"}])
+
+    assert changed == 1
+    texts = [run.text for run in para.runs]
+    assert texts == ["Hi ", "world", " and more"]
+    assert para.runs[1].bold is True
+
+
+def test_replace_text_spanning_two_runs_preserves_untouched_runs() -> None:
+    """A match spanning the boundary between run 0 and run 1 must land in
+    run 0 (the run owning the match's first character); run 1 keeps only
+    its unmatched characters, and run 2 -- which the match never reached --
+    must stay completely untouched, formatting included (#1447)."""
+    from docx import Document
+
+    edit_docx = _load_edit_docx()
+    doc = Document()
+    para = doc.add_paragraph()
+    para.add_run("Hello ")
+    bold = para.add_run("world")
+    bold.bold = True
+    tail = para.add_run(" and more")
+
+    changed = edit_docx.apply_ops(doc, [{"op": "replace_text", "find": "o world", "with": "!"}])
+
+    assert changed == 1
+    assert [run.text for run in para.runs] == ["Hell!", "", " and more"]
+    # The run that only lost matched characters still exists, with its
+    # formatting intact even though its text is now empty.
+    assert bold.bold is True
+    assert tail.text == " and more"
+
+
+def test_replace_text_multiple_matches_in_one_paragraph() -> None:
+    """Every non-overlapping occurrence is replaced, matching str.replace's
+    own left-to-right, non-overlapping semantics (#1447)."""
+    from docx import Document
+
+    edit_docx = _load_edit_docx()
+    doc = Document()
+    para = doc.add_paragraph()
+    para.add_run("cat sat on the cat mat")
+
+    changed = edit_docx.apply_ops(doc, [{"op": "replace_text", "find": "cat", "with": "dog"}])
+
+    assert changed == 1
+    assert para.runs[0].text == "dog sat on the dog mat"
+
+
+def test_replace_text_find_not_present_leaves_paragraph_byte_identical() -> None:
+    """A find that never matches must not touch any run at all (#1447)."""
+    from docx import Document
+
+    edit_docx = _load_edit_docx()
+    doc = Document()
+    para = doc.add_paragraph()
+    para.add_run("Hello ")
+    bold = para.add_run("world")
+    bold.bold = True
+
+    changed = edit_docx.apply_ops(doc, [{"op": "replace_text", "find": "missing", "with": "x"}])
+
+    assert changed == 0
+    assert [run.text for run in para.runs] == ["Hello ", "world"]
+    assert para.runs[1].bold is True
+
+
+def test_replace_run_is_unaffected_by_the_replace_text_fix() -> None:
+    from docx import Document
+
+    edit_docx = _load_edit_docx()
+    doc = Document()
+    para = doc.add_paragraph()
+    para.add_run("one")
+    para.add_run("two")
+
+    changed = edit_docx.apply_ops(doc, [{"op": "replace_run", "para": 0, "run": 1, "text": "TWO"}])
+
+    assert changed == 1
+    assert [run.text for run in para.runs] == ["one", "TWO"]
+
+
 def test_inspect_cli_outputs_json(tmp_path: Path) -> None:
     sys.path.insert(0, str(SCRIPTS))
     try:


### PR DESCRIPTION
Summary of the fix (issue #1447): _replace_text_in_paragraph used to join every run's text, do the replacement on the joined string, dump the whole result into run 0, and blank every other run — discarding bold/italic/font/color/highlight for the entire paragraph on a single-word replacement. Now the replacement is written only into the run that owns the match's first character; every other run — including one a match only partially overlapped — keeps its own original characters and formatting untouched. replace_run is unchanged.

Tests added to tests/test_skill_docx.py, all confirmed failing pre-fix / passing post-fix: match inside a single run, match spanning two runs (the issue's exact repro), multiple matches in one paragraph, a find that never occurs (paragraph byte-identical), and a sanity check that replace_run is unaffected. ruff check clean; mypy doesn't cover bundled skill scripts (excluded in pyproject.toml); tests/test_skill_docx.py + tests/test_skills/ (51 passed) all green. closes #1447 