### PR TITLE
fix(xlsx): accept string and dict merged ranges in create_xlsx (#1250)

### DIFF
--- a/src/agentos/skills/bundled/xlsx/SKILL.md
+++ b/src/agentos/skills/bundled/xlsx/SKILL.md
@@ -134,12 +134,15 @@ Spec:
         ["NA", 1200000, "=B2/SUM($B$2:$B$4)"],
         ["EU", 850000, "=B3/SUM($B$2:$B$4)"]
       ],
-      "merged": [{"range": "A1:C1"}],
+      "merged": ["A1:C1"],
       "freeze": "A2"
     }
   ]
 }
 ```
+
+`merged` entries may be specified either as plain strings (e.g. `["A1:C1"]`)
+or as dictionaries with a `"range"` key (e.g. `[{"range": "A1:C1"}]`).
 
 For programmatic use:
 

--- a/src/agentos/skills/bundled/xlsx/scripts/create_xlsx.py
+++ b/src/agentos/skills/bundled/xlsx/scripts/create_xlsx.py
@@ -6,11 +6,15 @@ Spec:
         {
           "name": "Sales",
           "rows": [["A", "B"], [1, "=B1*2"]],
-          "merged": [{"range": "A1:B1"}],
+          "merged": ["A1:B1", {"range": "C1:D1"}],
           "freeze": "A2"
         }
       ]
     }
+
+Merged cell ranges may be specified as strings (e.g. "A1:B1") or as
+dictionaries with a "range" key (e.g. {"range": "A1:B1"}). Any other shape
+raises ValueError.
 """
 
 from __future__ import annotations
@@ -54,8 +58,20 @@ def build(spec: dict[str, Any]) -> Workbook:
             ws.append([_coerce(v) for v in row])
 
         for merged in sheet_spec.get("merged") or []:
-            if isinstance(merged, dict) and "range" in merged:
-                ws.merge_cells(str(merged["range"]))
+            if isinstance(merged, str) and merged.strip():
+                ws.merge_cells(merged.strip())
+            elif (
+                isinstance(merged, dict)
+                and "range" in merged
+                and isinstance(merged["range"], str)
+                and merged["range"].strip()
+            ):
+                ws.merge_cells(merged["range"].strip())
+            else:
+                raise ValueError(
+                    f"Invalid merged range specification: expected string (e.g. 'A1:B1') "
+                    f"or dict with 'range' key, got {merged!r}"
+                )
 
         freeze = sheet_spec.get("freeze")
         if isinstance(freeze, str) and freeze:

--- a/tests/test_skill_xlsx.py
+++ b/tests/test_skill_xlsx.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -148,3 +149,65 @@ def test_inspect_xlsx_creates_parent_directory(
     monkeypatch.setattr(sys, "argv", ["inspect_xlsx.py", str(src), "--out", str(out)])
     assert inspect_xlsx.main() == 0
     assert out.is_file()
+
+
+@pytest.mark.parametrize(
+    "merged_entries",
+    [
+        ["A1:B1", "C1:D1"],
+        [{"range": "A1:B1"}, {"range": "C1:D1"}],
+        ["A1:B1", {"range": "C1:D1"}],
+    ],
+)
+def test_create_xlsx_merged_shapes(merged_entries: list[Any]) -> None:
+    sys.path.insert(0, str(SCRIPTS))
+    try:
+        import create_xlsx  # type: ignore[import-not-found]
+    finally:
+        sys.path.pop(0)
+
+    spec = {
+        "sheets": [
+            {
+                "name": "Sheet1",
+                "rows": [["1", "2", "3", "4"]],
+                "merged": merged_entries,
+            }
+        ]
+    }
+    wb = create_xlsx.build(spec)
+    ranges = sorted(str(r) for r in wb.active.merged_cells.ranges)
+    assert ranges == ["A1:B1", "C1:D1"]
+
+
+@pytest.mark.parametrize(
+    "bad_entry",
+    [
+        42,
+        {"range": 123},
+        {"invalid": "A1:B1"},
+        "",
+        "   ",
+        [],
+        None,
+    ],
+)
+def test_create_xlsx_rejects_invalid_merged_shapes(bad_entry: Any) -> None:
+    sys.path.insert(0, str(SCRIPTS))
+    try:
+        import create_xlsx  # type: ignore[import-not-found]
+    finally:
+        sys.path.pop(0)
+
+    spec = {
+        "sheets": [
+            {
+                "name": "Sheet1",
+                "rows": [["1", "2"]],
+                "merged": [bad_entry],
+            }
+        ]
+    }
+    with pytest.raises(ValueError, match="Invalid merged range"):
+        create_xlsx.build(spec)
+


### PR DESCRIPTION
## Summary
Closes #1250 

`create_xlsx.build()` previously only checked `if isinstance(merged, dict) and "range" in merged:`, silently ignoring plain string ranges like `"A1:B1"` (as emitted by `inspect_xlsx.py` and common LLM outputs). The workbook was generated without the merges and reported as successful.

## Fix
- In `create_xlsx.py:build()`, accept both plain strings (`"A1:B1"`) and dict entries (`{"range": "A1:B1"}`).
- Reject any other shape loudly with `ValueError` instead of silently skipping it.
- Update docstring in `create_xlsx.py` and `SKILL.md` to document accepted merged range shapes.
- Added regression tests covering string, dict, mixed shapes, and validation rejection of malformed inputs.
