### PR TITLE
fix(mcp): re-clamp events_wait recv timeout on coarse clocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `events_wait` no longer hands `recv_event` a timeout above the five-minute
+  cap. On coarse clocks (Windows ticks at ~15ms) two `time.monotonic()` reads
+  inside one tick reduce the remaining wait to `(t + cap) - t`, which rounds a
+  hair above `cap` for many values of `t`; the remaining wait is now re-clamped
+  to the capped timeout on every loop iteration.
+
 ## [2026.9.7] - 2026-09-07
 
 ### Fixed

--- a/src/agentos/mcp_server/bridge.py
+++ b/src/agentos/mcp_server/bridge.py
@@ -157,10 +157,13 @@ class AgentOSMCPBridge:
             )
             max_events = _clamp_limit(max_events, _MAX_EVENTS_WAIT_EVENTS)
             timeout_ms = min(max(0, timeout_ms), _MAX_EVENTS_WAIT_TIMEOUT_MS)
-            deadline = time.monotonic() + timeout_ms / 1000
+            timeout_s = timeout_ms / 1000
+            deadline = time.monotonic() + timeout_s
 
             while len(events) < max_events:
-                remaining = deadline - time.monotonic()
+                # Re-clamp: on coarse clocks ``deadline - now`` can round a hair
+                # above ``timeout_s``, handing ``recv_event`` more than the cap.
+                remaining = min(deadline - time.monotonic(), timeout_s)
                 if remaining <= 0:
                     break
                 try:

--- a/tests/test_mcp_server/test_bridge.py
+++ b/tests/test_mcp_server/test_bridge.py
@@ -357,6 +357,27 @@ async def test_events_wait_clamps_effective_deadline() -> None:
 
 
 @pytest.mark.asyncio
+async def test_events_wait_clamps_deadline_on_a_coarse_clock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Windows' monotonic clock has ~15ms granularity, so two reads inside the
+    # same tick return the same float and ``deadline - now`` reduces to
+    # ``(t + cap) - t``, which rounds above ``cap`` for many values of ``t``.
+    frozen = 32554.749911971794
+    assert (frozen + 300.0) - frozen > 300.0
+    monkeypatch.setattr(bridge_module.time, "monotonic", lambda: frozen)
+
+    client = RecordingEventClient()
+    bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)
+
+    await bridge.events_wait("agent:main:main", timeout_ms=3_600_000)
+
+    first_timeout = client.recv_timeouts[0]
+    assert first_timeout is not None
+    assert first_timeout <= bridge_module._MAX_EVENTS_WAIT_TIMEOUT_MS / 1000
+
+
+@pytest.mark.asyncio
 async def test_events_wait_preserves_timeout_below_the_cap() -> None:
     client = RecordingEventClient()
     bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)


### PR DESCRIPTION
## Problem

CI on `main` is red: [run 34237927493](https://github.com/use-agent-os/agent-os/actions/runs/34237927493) — `Lint, test, and build (windows-latest, 3.12)`.

```
>       assert first_timeout <= bridge_module._MAX_EVENTS_WAIT_TIMEOUT_MS / 1000
E       assert 300.00000000000006 <= (300000 / 1000)
tests\test_mcp_server\test_bridge.py:356: AssertionError
FAILED tests/test_mcp_server/test_bridge.py::test_events_wait_clamps_effective_deadline
1 failed, 9945 passed, 81 skipped
```

The failure is unrelated to the merge that surfaced it (#1062) — it is a latent Windows-only flake in `AgentOSMCPBridge.events_wait`.

`events_wait` clamps the requested timeout to `_MAX_EVENTS_WAIT_TIMEOUT_MS`, then derives each `recv_event` timeout from `deadline - time.monotonic()`. Windows' monotonic clock ticks at ~15ms, so two reads inside the same tick return the same float and the subtraction reduces to `(t + cap) - t`. For many values of `t` that rounds a hair *above* `cap` — 300.00000000000006 on the runner. The invariant the test guards (never wait longer than the cap) is genuinely violated, by ~60ns.

## Fix

Clamp the remaining wait to the capped timeout on every loop iteration, so the invariant holds regardless of clock granularity:

```python
timeout_s = timeout_ms / 1000
deadline = time.monotonic() + timeout_s
...
remaining = min(deadline - time.monotonic(), timeout_s)
```

## Test

Added `test_events_wait_clamps_deadline_on_a_coarse_clock`, which freezes `time.monotonic` on a value that deterministically reproduces the rounding (`(32554.749911971794 + 300.0) - 32554.749911971794 == 300.00000000000364`). It fails on `main`'s source and passes with the fix:

```
$ git stash push src/agentos/mcp_server/bridge.py   # revert the fix
$ uv run pytest tests/test_mcp_server/test_bridge.py -q
FAILED tests/test_mcp_server/test_bridge.py::test_events_wait_clamps_deadline_on_a_coarse_clock
1 failed, 20 passed

$ git stash pop                                      # restore the fix
$ uv run pytest tests/test_mcp_server/test_bridge.py -q
21 passed
```

`ruff check`, `ruff format --check` (the one reported deviation in `bridge.py` is pre-existing on `main` and untouched here), and `mypy` all pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CnpuXDoNhWain7k2bFmJZc