### PR TITLE
fix(skills): prevent single skill load failure from cascading to entire catalog

### DIFF
--- a/src/agentos/skills/hub/bankr.py
+++ b/src/agentos/skills/hub/bankr.py
@@ -321,11 +321,15 @@ class BankrSource(SkillSource):
                 loaded = await asyncio.gather(
                     *(_load_one(s) for s in self._allowlist),
                     *(_load_user(r) for r in self._user_refs),
+                    return_exceptions=True,
                 )
         except Exception as exc:
             log.warning("bankr.fetch_failed", error=str(exc))
             return None
 
+        # Filter out exception results from individual skill failures
+        if loaded:
+            loaded = [m for m in loaded if isinstance(m, SkillMeta) or m is None]
         metas = [m for m in loaded if m is not None]
         if not metas:
             # Every allowlisted skill failed to load (outage / rate limit) —

--- a/src/agentos/skills/hub/capminal.py
+++ b/src/agentos/skills/hub/capminal.py
@@ -150,11 +150,17 @@ class CapminalSource(SkillSource):
                     async with sem:
                         return await self._load_catalog_entry(client, slug)
 
-                loaded = await asyncio.gather(*(_load_one(s) for s in self._allowlist))
+                loaded = await asyncio.gather(
+                    *(_load_one(s) for s in self._allowlist),
+                    return_exceptions=True,
+                )
         except Exception as exc:
             log.warning("capminal.fetch_failed", error=str(exc))
             return None
 
+        # Filter out exception results from individual skill failures
+        if loaded:
+            loaded = [m for m in loaded if isinstance(m, SkillMeta) or m is None]
         metas = [m for m in loaded if m is not None]
         if not metas:
             return None


### PR DESCRIPTION
## Summary
`asyncio.gather` in `CapminalSource._fetch_catalog()` and `BankrSource._fetch_catalog()` lacked `return_exceptions=True`. A single network timeout, connection reset, or parse error on one allowlisted skill would cause the entire catalog fetch to fail, discarding all successfully loaded skills from that hub.

## Vulnerability
An operator who configures `allowlist=["skill-a", "broken-skill", "skill-b"]` would see zero skills loaded if `broken-skill` experiences a transient network issue. Both `skill-a` and `skill-b` are silently discarded despite being healthy. A single misconfigured skill can disable an entire hub's catalog.

## Root Cause
`asyncio.gather()` without `return_exceptions=True` — any coroutine exception cancels all still-running coroutines and propagates immediately.

## Fix
Added `return_exceptions=True` to both `asyncio.gather` calls. Added post-gather filtering with `isinstance(m, SkillMeta)` to exclude exception objects while keeping `None` (skill that gracefully returned nothing).

## Verification
**Tests:** `tests/test_gather_return_exceptions.py` — validates that `asyncio.gather(return_exceptions=True)` correctly collects both results and exceptions, keeping only the successes.
