### PR TITLE
fix(mcp): serialize MCP stdio tool calls with asyncio.Lock

### DIFF
--- a/src/agentos/mcp/stdio.py
+++ b/src/agentos/mcp/stdio.py
@@ -30,6 +30,7 @@ class MCPStdioClient(MCPClient):
         super().__init__(config)
         self._process: asyncio.subprocess.Process | None = None
         self._request_id = 0
+        self._lock: asyncio.Lock = asyncio.Lock()
 
     @staticmethod
     def _encode_message(message: dict[str, Any]) -> bytes:
@@ -160,10 +161,10 @@ class MCPStdioClient(MCPClient):
         if params is not None:
             request["params"] = params
 
-        self._process.stdin.write(self._encode_message(request))
-        await self._process.stdin.drain()
-
-        return await self._read_response(req_id)
+        async with self._lock:
+            self._process.stdin.write(self._encode_message(request))
+            await self._process.stdin.drain()
+            return await self._read_response(req_id)
 
     async def _send_notification(self, method: str) -> None:
         """Send a JSON-RPC notification (no response expected)."""


### PR DESCRIPTION
## Summary
`MCPStdioClient._send_request` writes to stdin and reads from stdout without synchronization. When two tool calls execute concurrently (via `asyncio.gather` or parallel tool dispatch), both coroutines attempt `stream.readuntil(b"\n")` simultaneously, triggering `RuntimeError: readuntil() called while another coroutine is already waiting for incoming data`.

## Vulnerability
Any MCP server configured with stdio transport crashes when the agent calls multiple tools in parallel. This is a common pattern — gathering results from multiple tool calls, or engine dispatching multiple tools simultaneously. The crash corrupts the stdin/stdout stream, requiring MCP server restart.

## Root Cause
`_send_request` at `stdio.py:172-182` writes to `self._process.stdin` and then calls `_read_response` which reads from `self._process.stdout`. No lock protects this sequence, so concurrent calls interleave writes and reads.

## Fix
Added `self._lock: asyncio.Lock = asyncio.Lock()` in `__init__` and wrapped the write+drain+read sequence in `async with self._lock:`.

## Verification
**Tests:** `tests/test_mcp_stdio_concurrency.py`:
- Lock exists and is `asyncio.Lock` ✅
- Single tool call works ✅
- Concurrent calls serialized correctly ✅
