### PR TITLE
fix(tools): stop a replaced browser supervisor outside the registry lock

### DIFF
--- a/src/agentos/tools/browser_supervisor.py
+++ b/src/agentos/tools/browser_supervisor.py
@@ -444,12 +444,18 @@ class SupervisorRegistry:
             existing = self._by_key.get(session_key)
             if existing is not None and existing.cdp_url == cdp_url and existing.active:
                 return existing
-            if existing is not None:
-                # URL changed or connection dead — tear down and restart.
-                try:
-                    existing.stop()
-                except Exception:  # noqa: BLE001
-                    pass
+            # URL changed or connection dead — the old one is replaced in the
+            # map here and torn down below, outside the lock. `stop()` reaches
+            # `_WebSocketTransport.stop()`, which is bounded at 5s on the close
+            # call plus 5s on the thread join, and this branch is entered
+            # exactly when the connection is dead — the case that pays both in
+            # full. Holding the registry lock across it stalls every other
+            # session, because `get`, `stop` and `stop_all` share this lock:
+            # the dialog and eval paths, `agent_browser._drop_session`, the
+            # idle reaper and gateway teardown all queue behind one dead
+            # socket. `stop()` and `stop_all()` already release the lock first;
+            # this was the one place that did not.
+            doomed = existing
             supervisor = CDPSupervisor(
                 session_key,
                 cdp_url,
@@ -458,6 +464,11 @@ class SupervisorRegistry:
                 transport=transport,
             )
             self._by_key[session_key] = supervisor
+        if doomed is not None:
+            # Before start(), so the replacement never attaches while the old
+            # connection is still up.
+            with contextlib.suppress(Exception):
+                doomed.stop()
         # start() does I/O; keep it outside the registry lock.
         try:
             supervisor.start()

--- a/tests/test_tools/test_browser_supervisor.py
+++ b/tests/test_tools/test_browser_supervisor.py
@@ -6,6 +6,7 @@ Chromium required.
 
 from __future__ import annotations
 
+import threading
 import time
 from typing import Any
 
@@ -241,6 +242,94 @@ class TestRegistry:
         # A later attempt with a working transport must succeed.
         good = registry.get_or_start("k", "ws://127.0.0.1:1/a", transport=FakeTransport())
         assert good.active is True
+
+    def test_replacing_a_dead_supervisor_does_not_hold_the_registry_lock(self) -> None:
+        """Teardown must not stall every other session.
+
+        `stop()` reaches `_WebSocketTransport.stop()`, bounded at 5s on the
+        close call plus 5s on the thread join — and this branch runs exactly
+        when the connection is dead, the case that pays both in full. `get`,
+        `stop` and `stop_all` share one process-wide lock, so holding it across
+        teardown queues the dialog and eval paths, `_drop_session`, the idle
+        reaper and gateway shutdown behind one wedged socket.
+
+        The lock is probed with a timeout rather than timed: a regression makes
+        this fail instead of hang.
+        """
+        registry = SupervisorRegistry()
+        teardown_started = threading.Event()
+        release_teardown = threading.Event()
+
+        class BlockingStopTransport(FakeTransport):
+            def stop(self) -> None:
+                teardown_started.set()
+                release_teardown.wait(timeout=5)
+                super().stop()
+
+        registry.get_or_start("k", "ws://127.0.0.1:1/a", transport=BlockingStopTransport())
+        registry.get("k")._active = False  # force the "connection dead" branch
+
+        worker = threading.Thread(
+            target=registry.get_or_start,
+            args=("k", "ws://127.0.0.1:1/a"),
+            kwargs={"transport": FakeTransport()},
+        )
+        worker.start()
+        try:
+            assert teardown_started.wait(timeout=5), "teardown never ran"
+            acquired = registry._lock.acquire(timeout=2)
+            if acquired:
+                registry._lock.release()
+            assert acquired, "registry lock is held while a supervisor is torn down"
+        finally:
+            release_teardown.set()
+            worker.join(timeout=5)
+
+    def test_the_replaced_supervisor_is_still_torn_down(self) -> None:
+        """Moving the stop out of the lock must not drop it."""
+        registry = SupervisorRegistry()
+        first = FakeTransport()
+        registry.get_or_start("k", "ws://127.0.0.1:1/a", transport=first)
+        registry.get("k")._active = False
+
+        registry.get_or_start("k", "ws://127.0.0.1:1/a", transport=FakeTransport())
+
+        assert first.stopped is True
+
+    def test_the_old_connection_is_stopped_before_the_new_one_starts(self) -> None:
+        """Two live CDP attachments to one page must not overlap."""
+        order: list[str] = []
+        registry = SupervisorRegistry()
+
+        class Recording(FakeTransport):
+            def __init__(self, label: str) -> None:
+                super().__init__()
+                self._label = label
+
+            def start(self, on_event: Any) -> None:
+                order.append(f"start:{self._label}")
+                super().start(on_event)
+
+            def stop(self) -> None:
+                order.append(f"stop:{self._label}")
+                super().stop()
+
+        registry.get_or_start("k", "ws://127.0.0.1:1/a", transport=Recording("old"))
+        registry.get("k")._active = False
+        registry.get_or_start("k", "ws://127.0.0.1:1/a", transport=Recording("new"))
+
+        assert order == ["start:old", "stop:old", "start:new"]
+
+    def test_a_live_supervisor_on_the_same_url_is_reused_untouched(self) -> None:
+        """The short-circuit still fires, so nothing is torn down needlessly."""
+        registry = SupervisorRegistry()
+        transport = FakeTransport()
+        first = registry.get_or_start("k", "ws://127.0.0.1:1/a", transport=transport)
+
+        second = registry.get_or_start("k", "ws://127.0.0.1:1/a", transport=FakeTransport())
+
+        assert second is first
+        assert transport.stopped is False
 
 
 def test_invalid_dialog_policy_rejected() -> None:


### PR DESCRIPTION
## Summary

`SupervisorRegistry.get_or_start` (`tools/browser_supervisor.py:444-458`) tore down the previous supervisor **inside** `self._lock`:

```python
with self._lock:
    existing = self._by_key.get(session_key)
    if existing is not None and existing.cdp_url == cdp_url and existing.active:
        return existing
    if existing is not None:
        # URL changed or connection dead — tear down and restart.
        try:
            existing.stop()
        except Exception:
            pass
    ...
# start() does I/O; keep it outside the registry lock.
```

That trailing comment is the whole point: the file already knows I/O must not run under this lock and moves `start()` out for exactly that reason. `stop()` blocks just as long and stayed in.

`CDPSupervisor.stop()` reaches `_WebSocketTransport.stop()`, which is bounded at **10 seconds**, not milliseconds:

```python
asyncio.run_coroutine_threadsafe(self._close_async(), self._loop).result(timeout=5)
...
self._thread.join(timeout=5)
```

`SUPERVISOR_REGISTRY` is process-wide and `get`, `stop` and `stop_all` all take the same lock, so while one dead supervisor is torn down, every other browser session is stalled — the dialog and `evaluate` paths, `agent_browser._drop_session`, the idle reaper, and `stop_all()` during gateway teardown. The branch is reached precisely when a connection is dead, which is the case where both timeouts are paid in full rather than returning at once.

Measured on `upstream/main` (`e0e7c88`) with a transport whose `stop()` sleeps 3s:

```
unrelated get() blocked 2.70s      # before
unrelated get() blocked 0.00s      # after
```

The other two methods in the same class already get this right — `stop()` pops under the lock and tears down outside it, `stop_all()` collects and clears under the lock then stops outside. `get_or_start` was the only one that did not.

## Changes

**`src/agentos/tools/browser_supervisor.py`** (+20/-6)

The doomed supervisor is handed out of the locked section and stopped after the lock is released, **before** `supervisor.start()` — so the ordering is unchanged and the replacement never attaches while the old connection is still up.

Nothing else moves: the same-URL-and-active short circuit, the failed-attach cleanup, and the registry contents are untouched.

## Tests

**`tests/test_tools/test_browser_supervisor.py`** — 4 new cases in `TestRegistry`, using the existing `FakeTransport` and a local `SupervisorRegistry()` in the style already there.

*Regression test — this one fails on `upstream/main` and passes with the fix:*

| Test | Covers |
|---|---|
| `test_replacing_a_dead_supervisor_does_not_hold_the_registry_lock` | a transport whose `stop()` blocks on an event; the test then probes `registry._lock.acquire(timeout=2)` from the main thread |

The lock is **probed with a timeout rather than timed**, deliberately: a regression makes this fail in ~2s with a clear assertion instead of hanging the suite, and there is no sleep-based threshold to go flaky on a loaded runner.

*Guard tests — these pass in both states by construction; the old code also stopped the doomed supervisor, and in the same order. They are here because each is a way this change could have gone wrong:*

| Test | Covers |
|---|---|
| `test_the_replaced_supervisor_is_still_torn_down` | moving the stop out of the lock did not drop it |
| `test_the_old_connection_is_stopped_before_the_new_one_starts` | asserts the exact order `["start:old", "stop:old", "start:new"]` |
| `test_a_live_supervisor_on_the_same_url_is_reused_untouched` | the short circuit still fires and nothing is torn down needlessly |

No existing test was modified; all 31 in the file pass, and 64 together with `test_browser_tool.py`.

## Status

- `uv run ruff check src tests` ✅
- `uv run mypy src/agentos --show-error-codes` ✅ (625 source files, no issues)
- `uv run pytest tests/test_tools/test_browser_supervisor.py tests/test_tools/test_browser_tool.py -q` ✅ 64 passed
- `uv run pytest --collect-only -q` ✅ 10030 tests collect cleanly
- Self-check: reverted `browser_supervisor.py` with `git checkout upstream/main -- <file>` — exactly the one regression test fails, in 2.85s, with an assertion rather than a hang.
- `ruff format --diff` on both changed files reports no hunks.

I did not run the full local suite: it is ~17 minutes single-process here (`pytest-xdist` is not installed) against ~5 minutes in CI across both platforms. The change is confined to lock scope in one method.

Fixes #1496

🤖 Generated with [Claude Code](https://claude.com/claude-code)
