### PR TITLE
fix(tools): let del/rmdir/git push --force reach the Windows approval warnlist instead of hard-denying

### DIFF
--- a/src/agentos/tools/builtin/shell_policy.py
+++ b/src/agentos/tools/builtin/shell_policy.py
@@ -24,13 +24,10 @@ DEFAULT_DENYLIST: list[str] = [
 ]
 
 DEFAULT_DENYLIST_WIN: list[str] = [
-    r"\bdel\b",
-    r"\brmdir\b",
     r"\bFormat-Volume\b",
     r"\bStop-Computer\b",
     r"\bRestart-Computer\b",
     r"\bClear-Disk\b",
-    r"\bgit push --force\b",
 ]
 
 # Patterns that require two-step confirmation (warn, not block)
@@ -48,7 +45,6 @@ DEFAULT_WARNLIST_WIN: list[str] = [
     r"\bdel\b",
     r"\brmdir\b",
     r"\bRemove-Item\b",
-    r"\bClear-Disk\b",
     r"\bgit push --force\b",
 ]
 
@@ -70,10 +66,7 @@ def _legacy_denylist_if_set() -> list[str]:
 
         structlog.get_logger(__name__).warning(
             "shell_policy.legacy_deny_env_detected",
-            message=(
-                "AGENTOS_SHELL_DENYLIST is deprecated; use "
-                "AGENTOS_SAFE_BIN_DENY"
-            ),
+            message=("AGENTOS_SHELL_DENYLIST is deprecated; use AGENTOS_SAFE_BIN_DENY"),
         )
         _LEGACY_ENV_WARNED = True
     return _resolve_env_list(legacy)

--- a/tests/test_tools/test_shell_policy_windows.py
+++ b/tests/test_tools/test_shell_policy_windows.py
@@ -24,13 +24,56 @@ def _windows_policy_env(monkeypatch: pytest.MonkeyPatch):
         r"dEl C:\Windows\System32\config\SAM",
     ],
 )
-def test_windows_del_variants_are_denied(command: str) -> None:
+def test_windows_del_variants_require_approval(command: str) -> None:
+    """``del`` deletes a file, same as ``Remove-Item`` (see
+    ``test_windows_remove_item_variants_warn`` below) -- there is no reason
+    for the cmd.exe spelling to be treated more severely than the PowerShell
+    spelling of the identical operation. Both must go through the
+    two-step approval warnlist, not an unconditional hard deny.
+    """
     result = shell_policy.SafeBinPolicy.from_env().check(command)
+
+    assert result.allowed is True
+    assert result.needs_approval is True
+    assert "requires approval" in result.reason
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        r"rmdir /s /q C:\tmp\stale",
+        r"RMDIR /s /q C:\tmp\stale",
+    ],
+)
+def test_windows_rmdir_variants_require_approval(command: str) -> None:
+    result = shell_policy.SafeBinPolicy.from_env().check(command)
+
+    assert result.allowed is True
+    assert result.needs_approval is True
+    assert "requires approval" in result.reason
+
+
+def test_windows_git_push_force_requires_approval() -> None:
+    result = shell_policy.SafeBinPolicy.from_env().check("git push --force origin main")
+
+    assert result.allowed is True
+    assert result.needs_approval is True
+    assert "requires approval" in result.reason
+
+
+def test_windows_clear_disk_remains_hard_denied() -> None:
+    """Unlike del/rmdir/git push --force, a full disk wipe stays an
+    unconditional hard deny -- it is categorically more destructive
+    (irreversible, whole-disk) than deleting specific files or a force
+    push, both of which have some recovery path (backups, reflog, remote
+    history). Confirms the DEFAULT_WARNLIST_WIN cleanup didn't
+    accidentally also drop it from DEFAULT_DENYLIST_WIN.
+    """
+    result = shell_policy.SafeBinPolicy.from_env().check("Clear-Disk -Number 0")
 
     assert result.allowed is False
     assert result.needs_approval is False
     assert "blocked by policy" in result.reason
-
 
 @pytest.mark.parametrize(
     "command",
@@ -74,13 +117,17 @@ def test_windows_empty_warn_env_clears_platform_default_warnlist(
 def test_windows_empty_warn_env_preserves_default_denylist(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """del is no longer a denylist-only entry (see the approval-required
+    tests above), so this exercises a command that still is: clearing
+    AGENTOS_SAFE_BIN_WARN must not affect AGENTOS_SAFE_BIN_DENY -- the two
+    env knobs are independent, and Clear-Disk's hard deny must survive.
+    """
     monkeypatch.setenv("AGENTOS_SAFE_BIN_WARN", "")
 
-    result = shell_policy.SafeBinPolicy.from_env().check(r"del C:\Windows\System32\config\SAM")
+    result = shell_policy.SafeBinPolicy.from_env().check("Clear-Disk -Number 0")
 
     assert result.allowed is False
     assert result.needs_approval is False
-
 
 def test_legacy_shell_denylist_warns_once(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("AGENTOS_SHELL_DENYLIST", r"\blegacy-block\b")


### PR DESCRIPTION
## Linked issue
Fixes #1464 

## Summary
`SafeBinPolicy.check()` checks the denylist before the warnlist. On
Windows, `DEFAULT_DENYLIST_WIN` and `DEFAULT_WARNLIST_WIN` both contained
identical patterns for `del`, `rmdir`, and `git push --force` (plus an
unreported fourth: `Clear-Disk`). Because denylist wins first, these
commands always hard-denied — their presence in the warnlist was 100%
dead code, defeating the two-step approval flow the warnlist exists to
provide.

Confirmed this is Windows-specific: `DEFAULT_DENYLIST`/`DEFAULT_WARNLIST`
(POSIX) have zero pattern overlap by design (specific catastrophic
patterns like `rm -rf /*` sit in deny; generic patterns like `rm` sit in
warn), so POSIX was never affected.

Strong internal-consistency evidence this is a bug, not intended
behavior: `Remove-Item` (PowerShell delete — the same operation as `del`,
different shell) was already tested to warn, not hard-deny
(`test_windows_remove_item_variants_warn`). There's no principled reason
`del somefile` should be treated more severely than `Remove-Item
somefile` doing the identical thing.

## Fix
Removed `del`, `rmdir`, `git push --force` from `DEFAULT_DENYLIST_WIN`
only — leaving them solely in the warnlist, so they now correctly
require approval. `Format-Volume`, `Stop-Computer`, `Restart-Computer`,
`Clear-Disk` remain unconditional hard denies (system-wide, irreversible
actions with no recovery path, categorically different from deleting
specific files or a force push).

Also removed `Clear-Disk` from `DEFAULT_WARNLIST_WIN`: it was dead code
before this fix (always caught by denylist first) and, being a
full-disk-wipe, should stay in the always-denied category rather than
becoming approval-only — same class of confusion that caused this bug,
fixed proactively.

Considered and rejected: swapping `check()`'s order to warnlist-before-
denylist globally. That would have fixed Windows but silently broken
POSIX — `rm -rf /*` matches both the specific catastrophic denylist
pattern and the generic `rm` warnlist pattern, so warn-first ordering
would downgrade a catastrophic command to merely "needs approval."
Scoping the fix to the Windows list contents avoids that regression
entirely; `check()`'s logic is untouched.

## Tests
- Renamed/rewrote `test_windows_del_variants_are_denied` →
  `test_windows_del_variants_require_approval`, asserting the corrected
  approval-required behavior, with a docstring citing the Remove-Item
  parallel.
- Added `test_windows_rmdir_variants_require_approval` and
  `test_windows_git_push_force_requires_approval` — neither was
  individually tested before.
- Added `test_windows_clear_disk_remains_hard_denied` — regression guard
  proving the severity floor for a full disk wipe survived the warnlist
  cleanup.
- Retargeted `test_windows_empty_warn_env_preserves_default_denylist`
  from `del` (no longer denylist-only) to `Clear-Disk`, preserving its
  original intent: the DENY and WARN env knobs are independent, so
  clearing WARN must not affect DENY-sourced entries.

Commands run, all clean:
    uv run ruff check src/agentos/tools/builtin/shell_policy.py tests/test_tools/test_shell_policy_windows.py
    uv run ruff format --check src/agentos/tools/builtin/shell_policy.py tests/test_tools/test_shell_policy_windows.py
    uv run mypy src/agentos/tools/builtin/shell_policy.py tests/test_tools/test_shell_policy_windows.py --show-error-codes
    uv run pytest tests/test_tools/ -k "shell" -v
    → 137 passed, 0 failed (full shell-related suite, not just the touched file)

Note: `ruff format` also reformatted one unrelated pre-existing line in
this file (unwrapped a multi-line string concatenation in the legacy-env
warning) since the whole file must satisfy `ruff format --check`. Pure
cosmetic change, verified via diff — no logic touched.

Third-party origin: none.