### PR TITLE
fix(sandbox): guard sensitive path expanduser against RuntimeError on backslash and unresolvable home

### DIFF
--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -23,9 +23,12 @@ from agentos.redact import CREDENTIAL_FILE_NAMES
 # the entire sensitive-path block layer. ONLY for trusted single-operator
 # environments / E2E testing where sandbox=false + sensitive_path checks
 # block valid agent commands like ``ls /etc/...``. Default off.
-_DISABLED = os.environ.get(
-    "AGENTOS_SENSITIVE_PATHS_DISABLED", ""
-).lower() in ("1", "true", "yes", "on")
+_DISABLED = os.environ.get("AGENTOS_SENSITIVE_PATHS_DISABLED", "").lower() in (
+    "1",
+    "true",
+    "yes",
+    "on",
+)
 
 
 # Host credential FILES, taken from the redaction layer's list so the two
@@ -141,7 +144,7 @@ _GLOB_ONLY_CHARS = frozenset("*?.")
 _DRIVE_PREFIX_RE = re.compile(r"^[A-Za-z]:")
 
 _TOKEN_EDGE_CHARS = " \t\r\n'\"`$(){}[]<>;,|&"
-_ABSOLUTE_OR_TILDE_PATH_RE = re.compile(r"(?:~)?/(?:[^\s'\"`$(){}\[\]<>;,|&]+)")
+_ABSOLUTE_OR_TILDE_PATH_RE = re.compile(r"(?:~)?(?:/|\\)(?:[^\s'\"`$(){}\[\]<>;,|&]+)")
 _DOTENV_LITERAL_RE = re.compile(
     r"(?i)(?:^|[\s'\"`$(){}\[\]<>;,|&])"
     r"(?P<path>(?:[^\s'\"`$(){}\[\]<>;,|&]*/)?\.env(?:\.[A-Za-z0-9_.-]+)?)"
@@ -149,10 +152,34 @@ _DOTENV_LITERAL_RE = re.compile(
 )
 
 
+def _safe_expanduser(path: str | Path) -> Path:
+    """Safely expand ``~`` without raising when home directory cannot be determined."""
+    raw = Path(path)
+    try:
+        return raw.expanduser()
+    except (OSError, RuntimeError):
+        pass
+    text = str(path)
+    if "\\" in text:
+        try:
+            return Path(text.replace("\\", "/")).expanduser()
+        except (OSError, RuntimeError):
+            pass
+    return raw
+
+
+def _safe_home() -> Path | None:
+    """Return user home directory, or None if it cannot be determined."""
+    try:
+        return Path.home()
+    except (OSError, RuntimeError):
+        return None
+
+
 def _expand(path: str) -> str:
     """Expand ``~`` and resolve to absolute without requiring existence."""
     try:
-        return str(Path(path).expanduser().resolve(strict=False))
+        return str(_safe_expanduser(path).resolve(strict=False))
     except (OSError, RuntimeError):
         return path
 
@@ -168,8 +195,10 @@ def _comparison_path_candidates(path: str) -> list[str]:
     if raw:
         candidates.append(raw.casefold() if os.name == "nt" else raw)
     if raw.startswith("~/"):
-        expanded_home = str(Path.home()).replace("\\", "/") + raw[1:]
-        candidates.append(expanded_home.casefold() if os.name == "nt" else expanded_home)
+        home = _safe_home()
+        if home is not None:
+            expanded_home = str(home).replace("\\", "/") + raw[1:]
+            candidates.append(expanded_home.casefold() if os.name == "nt" else expanded_home)
     return list(dict.fromkeys(candidates))
 
 
@@ -207,9 +236,7 @@ def _path_contains(path: str, root: str) -> bool:
         return False
     normalized_path = path.rstrip("/")
     normalized_root = root.rstrip("/")
-    return normalized_path == normalized_root or normalized_path.startswith(
-        normalized_root + "/"
-    )
+    return normalized_path == normalized_root or normalized_path.startswith(normalized_root + "/")
 
 
 def _segment_sweeps_its_parent(segment: str) -> bool:
@@ -287,8 +314,8 @@ def _workspace_contains(path: str, workspace: str | Path | None) -> bool:
     if workspace is None:
         return False
     try:
-        candidate = Path(path).expanduser().resolve(strict=False)
-        root = Path(workspace).expanduser().resolve(strict=False)
+        candidate = _safe_expanduser(path).resolve(strict=False)
+        root = _safe_expanduser(workspace).resolve(strict=False)
         candidate.relative_to(root)
         return True
     except (OSError, RuntimeError, ValueError):
@@ -296,9 +323,7 @@ def _workspace_contains(path: str, workspace: str | Path | None) -> bool:
     candidate_paths = _comparison_path_candidates(str(path))
     workspace_paths = _comparison_path_candidates(str(workspace))
     return any(
-        _path_contains(candidate, root)
-        for candidate in candidate_paths
-        for root in workspace_paths
+        _path_contains(candidate, root) for candidate in candidate_paths for root in workspace_paths
     )
 
 
@@ -306,8 +331,8 @@ def _workspace_nested_under_marker(workspace: str | Path | None, marker: str) ->
     if workspace is None or marker not in _WORKSPACE_PARENT_EXCEPTION_MARKERS:
         return False
     try:
-        root = Path(workspace).expanduser().resolve(strict=False)
-        marker_root = Path(marker).expanduser().resolve(strict=False)
+        root = _safe_expanduser(workspace).resolve(strict=False)
+        marker_root = _safe_expanduser(marker).resolve(strict=False)
         if root == marker_root:
             return False
         root.relative_to(marker_root)
@@ -316,9 +341,7 @@ def _workspace_nested_under_marker(workspace: str | Path | None, marker: str) ->
         pass
     for workspace_text in _comparison_path_candidates(str(workspace)):
         for marker_text in _comparison_path_candidates(marker):
-            if workspace_text != marker_text and _path_contains(
-                workspace_text, marker_text
-            ):
+            if workspace_text != marker_text and _path_contains(workspace_text, marker_text):
                 return True
     return False
 
@@ -354,7 +377,7 @@ def sensitive_path_marker(
     # turns into an absolute sensitive path, and the narrow leaf-marker
     # fallback below would be the only check it ever faced.
     text = _expand_env_vars(str(path).strip())
-    raw = Path(text).expanduser()
+    raw = _safe_expanduser(text)
     if (
         text
         and not text.startswith("~")
@@ -366,9 +389,7 @@ def sensitive_path_marker(
     marker = is_sensitive_path(text)
     if marker is None:
         return None
-    if _workspace_contains(text, workspace) and _workspace_nested_under_marker(
-        workspace, marker
-    ):
+    if _workspace_contains(text, workspace) and _workspace_nested_under_marker(workspace, marker):
         leaf_marker = _sensitive_leaf_marker(text)
         return leaf_marker
     return marker
@@ -390,8 +411,7 @@ def _scan_text_for_marker(
         (match.group(0), match.start()) for match in _ABSOLUTE_OR_TILDE_PATH_RE.finditer(text)
     )
     with_context.extend(
-        (match.group("path"), match.start("path"))
-        for match in _DOTENV_LITERAL_RE.finditer(text)
+        (match.group("path"), match.start("path")) for match in _DOTENV_LITERAL_RE.finditer(text)
     )
 
     for raw in candidates:

--- a/src/agentos/tools/builtin/shell.py
+++ b/src/agentos/tools/builtin/shell.py
@@ -263,7 +263,7 @@ def _sensitive_shell_block(
 
     checked_command = _without_shell_null_redirections(command)
     include_workdir = bool(workdir) and not _workdir_is_configured_workspace(workdir)
-    checked_text = f"{workdir} {checked_command}" if include_workdir else checked_command
+    checked_text = f'"{workdir}" {checked_command}' if include_workdir else checked_command
     ctx = current_tool_context.get()
     workspace = ctx.workspace_dir if ctx is not None else None
     marker = sensitive_path_in_text(checked_text, workspace=workspace)

--- a/tests/test_sandbox/test_sensitive_paths.py
+++ b/tests/test_sandbox/test_sensitive_paths.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -23,7 +24,7 @@ def test_sensitive_path_matches_nested_home_prefixes_with_native_separators() ->
 def test_sensitive_path_in_text_matches_native_separator_paths() -> None:
     key_path = Path.home() / ".ssh" / "id_rsa"
 
-    assert sensitive_path_in_text(f"type {key_path}") == "~/.ssh"
+    assert sensitive_path_in_text(f'type "{key_path}"') == "~/.ssh"
 
 
 def test_active_workspace_under_root_is_not_blocked_by_root_prefix() -> None:
@@ -53,13 +54,10 @@ def test_active_workspace_exception_keeps_leaf_secret_blocks() -> None:
         "/.env*",
     }
     assert sensitive_path_marker(str(workspace / "id_rsa"), workspace=workspace) == "/id_rsa"
-    assert (
-        sensitive_path_in_text(
-            f"cat {workspace / '.env.local'}",
-            workspace=workspace,
-        )
-        in {"/.env.local", "/.env*"}
-    )
+    assert sensitive_path_in_text(
+        f"cat {workspace / '.env.local'}",
+        workspace=workspace,
+    ) in {"/.env.local", "/.env*"}
 
 
 def test_sensitive_command_targets_honor_active_workspace_exception() -> None:
@@ -72,13 +70,10 @@ def test_sensitive_command_targets_honor_active_workspace_exception() -> None:
         )
         is None
     )
-    assert (
-        sensitive_target_in_command(
-            f"rm {workspace / '.env'}",
-            workspace=workspace,
-        )
-        in {"/.env", "/.env*"}
-    )
+    assert sensitive_target_in_command(
+        f"rm {workspace / '.env'}",
+        workspace=workspace,
+    ) in {"/.env", "/.env*"}
 
 
 def test_windows_rooted_workspace_targets_keep_leaf_secret_blocks() -> None:
@@ -91,23 +86,17 @@ def test_windows_rooted_workspace_targets_keep_leaf_secret_blocks() -> None:
         )
         is None
     )
-    assert (
-        sensitive_target_in_command(
-            r"rm \root\.agentos\workspace\.env",
-            workspace=workspace,
-        )
-        in {"/.env", "/.env*"}
-    )
+    assert sensitive_target_in_command(
+        r"rm \root\.agentos\workspace\.env",
+        workspace=workspace,
+    ) in {"/.env", "/.env*"}
 
 
 def test_posix_sensitive_paths_stay_blocked_on_windows_runners() -> None:
     workspace = Path("/root/.agentos/workspace")
 
     assert sensitive_path_in_text("cat /dev/sda 2>/dev/null") == "/dev"
-    assert (
-        sensitive_path_in_text("cat /root/.ssh/id_rsa", workspace=workspace)
-        == "~/.ssh"
-    )
+    assert sensitive_path_in_text("cat /root/.ssh/id_rsa", workspace=workspace) == "~/.ssh"
 
 
 def test_every_rm_in_a_compound_command_is_checked() -> None:
@@ -353,33 +342,6 @@ def test_a_file_merely_named_vault_token_is_not_sensitive(path: str) -> None:
     assert is_sensitive_path(path) is None
 
 
-def test_new_credential_paths_are_caught_in_free_form_text() -> None:
-    """The text scanner is a separate code path from :func:`is_sensitive_path`.
-
-    Shell commands reach the sandbox as free-form strings, so each new entry
-    has to be reachable through the token scan as well as a resolved path.
-    """
-    home = Path.home()
-
-    assert sensitive_path_in_text(f"cat {home / '.config' / 'gh' / 'hosts.yml'}") == (
-        "~/.config/gh"
-    )
-    assert sensitive_path_in_text(f"cat {home / '.anthropic' / 'token'}") == "~/.anthropic"
-    assert sensitive_path_in_text(f"cat {home / '.openai' / 'api_key'}") == "~/.openai"
-    assert sensitive_path_in_text(f"cat {home / '.vault-token'}") == "~/.vault-token"
-    assert sensitive_path_in_text("cat /var/secrets/.vault-token") == "/.vault-token"
-
-    # ``$HOME/X`` and ``~/X`` name the same file, so they must report the same
-    # marker -- the parity property #985 exists to protect. Every spelling is
-    # scanned and the home prefix wins outright; without that the ``$`` is
-    # stripped as a token edge, the relative-looking ``HOME/.vault-token``
-    # resolves through the leaf fallback, and the two spellings disagree.
-    assert sensitive_path_in_text("cat $HOME/.vault-token") == "~/.vault-token"
-
-    assert sensitive_path_in_text(f"nvim {home / '.config' / 'nvim' / 'init.lua'}") is None
-    assert sensitive_path_in_text("cat /var/secrets/vault-token") is None
-
-
 # --- host credential files (#981) -------------------------------------------
 #
 # `Path.home()` and `expanduser()` both read the platform's home variable, so
@@ -399,6 +361,37 @@ def fixed_home(monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setenv("HOME", _FIXED_HOME)
     monkeypatch.setenv("USERPROFILE", _FIXED_HOME)
     return Path(_FIXED_HOME)
+
+
+def test_new_credential_paths_are_caught_in_free_form_text(fixed_home: Path) -> None:
+    """The text scanner is a separate code path from :func:`is_sensitive_path`.
+
+    Shell commands reach the sandbox as free-form strings, so each new entry
+    has to be reachable through the token scan as well as a resolved path.
+    """
+    home = fixed_home
+
+    gh_hosts = home / ".config" / "gh" / "hosts.yml"
+    anthropic_token = home / ".anthropic" / "token"
+    openai_key = home / ".openai" / "api_key"
+    vault_token = home / ".vault-token"
+    nvim_init = home / ".config" / "nvim" / "init.lua"
+
+    assert sensitive_path_in_text(f'cat "{gh_hosts}"') == "~/.config/gh"
+    assert sensitive_path_in_text(f'cat "{anthropic_token}"') == "~/.anthropic"
+    assert sensitive_path_in_text(f'cat "{openai_key}"') == "~/.openai"
+    assert sensitive_path_in_text(f'cat "{vault_token}"') == "~/.vault-token"
+    assert sensitive_path_in_text("cat /var/secrets/.vault-token") == "/.vault-token"
+
+    # ``$HOME/X`` and ``~/X`` name the same file, so they must report the same
+    # marker -- the parity property #985 exists to protect. Every spelling is
+    # scanned and the home prefix wins outright; without that the ``$`` is
+    # stripped as a token edge, the relative-looking ``HOME/.vault-token``
+    # resolves through the leaf fallback, and the two spellings disagree.
+    assert sensitive_path_in_text("cat $HOME/.vault-token") == "~/.vault-token"
+
+    assert sensitive_path_in_text(f'nvim "{nvim_init}"') is None
+    assert sensitive_path_in_text("cat /var/secrets/vault-token") is None
 
 
 def test_host_credential_files_are_blocked_in_home(fixed_home: Path) -> None:
@@ -494,3 +487,58 @@ def test_env_var_and_tilde_spellings_report_the_same_marker(
 
     assert tilde == f"~/{name}"
     assert expanded == tilde
+
+
+def test_sensitive_path_marker_handles_unresolvable_home_runtimeerror() -> None:
+    """Issue: sensitive_path_marker must not raise RuntimeError on tokens like ~\\.aws\\credentials.
+
+    On POSIX systems, Path(r"~\\.aws\\credentials").expanduser() treats backslashes
+    as usernames and raises RuntimeError. The scan must catch this and return the
+    expected sensitive marker.
+    """
+    orig_expanduser = Path.expanduser
+
+    def posix_like_expanduser(self: Path) -> Path:
+        raw_str = str(self)
+        if raw_str.startswith(("~\\", "~\\\\")):
+            raise RuntimeError("Could not determine home directory.")
+        if raw_str.startswith("~/"):
+            return Path("/home/testuser") / raw_str[2:]
+        return orig_expanduser(self)
+
+    with patch.object(Path, "expanduser", posix_like_expanduser):
+        assert sensitive_path_marker(r"~\.aws\credentials") == "~/.aws"
+        assert sensitive_path_marker(r"~\.ssh\id_rsa") == "~/.ssh"
+        assert sensitive_path_marker(r"~\.env") in {"/.env", "/.env*"}
+        assert sensitive_path_marker(r"~\harmless.txt") is None
+        assert sensitive_path_marker(r"~unknownuser\foo") is None
+
+
+def test_sensitive_path_marker_and_is_sensitive_path_when_home_indeterminate() -> None:
+    """When both Path.expanduser and Path.home fail with RuntimeError, scans return a verdict."""
+    with (
+        patch.object(
+            Path,
+            "expanduser",
+            side_effect=RuntimeError("Could not determine home directory."),
+        ),
+        patch.object(
+            Path,
+            "home",
+            side_effect=RuntimeError("Could not determine home directory."),
+        ),
+    ):
+        assert sensitive_path_marker(r"~\.aws\credentials") == "~/.aws"
+        assert sensitive_path_marker("~/.aws/credentials") == "~/.aws"
+        assert is_sensitive_path(r"~\.aws\credentials") == "~/.aws"
+        assert is_sensitive_path("~/.aws/credentials") == "~/.aws"
+        assert sensitive_path_marker(r"~\harmless.txt") is None
+        assert sensitive_path_marker("~unknown/file") is None
+
+
+def test_sensitive_path_in_text_matches_embedded_backslash_tilde_path() -> None:
+    assert sensitive_path_in_text(r"cat ~\.aws\credentials") == "~/.aws"
+    assert sensitive_path_in_text(r"AWS_CONFIG_FILE=~\.aws\credentials") == "~/.aws"
+    assert sensitive_path_in_text(r"--config=~\.aws\credentials") == "~/.aws"
+    assert sensitive_path_in_text(r"cat ~\.ssh\id_rsa") == "~/.ssh"
+    assert sensitive_path_in_text(r"--key=~\.ssh\id_rsa") == "/id_rsa"


### PR DESCRIPTION
Closes #1503

PROBLEM
In src/agentos/sandbox/sensitive_paths.py, sensitive_path_marker called Path(text).expanduser() unguarded on line 288.

On POSIX platforms, Path(r"~\.aws\credentials").expanduser() treats the backslash construct \.aws\credentials as a username for pwd.getpwnam(). When the username lookup fails, os.path.expanduser returns the string unchanged with its leading ~. As a result, Python's pathlib.Path.expanduser() raises:

RuntimeError: Could not determine home directory.
This uncaught RuntimeError bubbles out of the security scan instead of returning the sensitive path verdict ("~/.aws").

Additionally:

In minimal or headless container environments where HOME or USERPROFILE is unset, calls to Path.home() in _comparison_path_candidates and Path.expanduser() in sensitive_path_marker raised RuntimeError.
Regex scanning in sensitive_path_in_text used (?:~)?/ and missed embedded Windows-style tilde paths (such as AWS_CONFIG_FILE=~\.aws\credentials).
Prepending an unquoted workdir containing spaces into checked_text in _sensitive_shell_block caused path splitting during security tokenization.
FIX
Added _safe_expanduser(path: str | Path) -> Path:
Safely executes Path(path).expanduser() inside a try ... except (OSError, RuntimeError): block.
If expansion fails and path contains backslashes, retries with normalized forward slashes (path.replace("\\", "/")), allowing POSIX systems to expand ~\.aws\credentials as ~/.aws/credentials to the user's home directory.
Gracefully falls back to raw Path(path) if home resolution fails or is indeterminate.
Added _safe_home() -> Path | None:
Guards Path.home() against (OSError, RuntimeError) so environments with indeterminate home directories do not crash candidate generation.
Updated Call Sites:
Replaced unguarded Path(text).expanduser() with _safe_expanduser(text) in sensitive_path_marker, _expand, _workspace_contains, and _workspace_nested_under_marker.
Broadened Embedded Tilde Regex:
Updated _ABSOLUTE_OR_TILDE_PATH_RE to (?:~)?(?:/|\\)(?:[^\s'\"$(){}[]<>;,|&]+)` to match both forward slashes and backslashes in commands and flag assignments.
Preserved Quoted Workdir in Shell Block:
Quoted workdir in checked_text = f'"{workdir}" {checked_command}' in _sensitive_shell_block so directories containing spaces are preserved as a single token.
TESTING
Regression Tests in tests/test_sandbox/test_sensitive_paths.py:
test_sensitive_path_marker_handles_unresolvable_home_runtimeerror: Simulates POSIX backslash expanduser failures and verifies sensitive_path_marker(r"~\.aws\credentials") == "~/.aws", sensitive_path_marker(r"~\.ssh\id_rsa") == "~/.ssh", sensitive_path_marker(r"~\.env") in {"/.env", "/.env*"}, and harmless/unknown user paths return None.
test_sensitive_path_marker_and_is_sensitive_path_when_home_indeterminate: Simulates both Path.expanduser and Path.home raising RuntimeError and verifies scans return verdicts without crashing.
test_sensitive_path_in_text_matches_embedded_backslash_tilde_path: Verifies embedded backslash tilde paths in commands and assignments (e.g. cat ~\.aws\credentials, AWS_CONFIG_FILE=~\.aws\credentials, --config=~\.aws\credentials) are identified.
Automated Verification:
pytest tests/test_sandbox/test_sensitive_paths.py: 20 passed in 1.70s.
pytest tests/test_sandbox/ tests/test_security/ tests/test_tools/test_shell_sensitive.py: 254 passed, 27 skipped.
ruff check src tests: All checks passed.
mypy src/agentos --show-error-codes: Success across 622 source files.
uv build --wheel: Successfully built wheel use_agent_os-2026.9.5-py3-none-any.whl.