### PR TITLE
fix(telegram): protect href attributes from inline markdown formatting (#1435)

### DIFF
--- a/src/agentos/channels/_telegram_formatting.py
+++ b/src/agentos/channels/_telegram_formatting.py
@@ -40,14 +40,36 @@ def _replace_code_spans(text: str) -> tuple[str, list[str]]:
     return "".join(output), chunks
 
 
-def _render_inline(text: str) -> str:
-    protected, code_chunks = _replace_code_spans(text)
-    rendered = html.escape(protected)
-    rendered = _LINK_RE.sub(r'<a href="\2">\1</a>', rendered)
-    rendered = re.sub(r"\*\*(?=\S)(.+?)(?<=\S)\*\*", r"<b>\1</b>", rendered)
+def _apply_inline_formatting(text: str) -> str:
+    rendered = re.sub(r"\*\*(?=\S)(.+?)(?<=\S)\*\*", r"<b>\1</b>", text)
     rendered = re.sub(r"__(?=\S)(.+?)(?<=\S)__", r"<b>\1</b>", rendered)
     rendered = re.sub(r"~~(?=\S)(.+?)(?<=\S)~~", r"<s>\1</s>", rendered)
     rendered = re.sub(r"(?<!\*)\*(?=\S)(.+?)(?<=\S)\*(?!\*)", r"<i>\1</i>", rendered)
+    return rendered
+
+
+def _replace_links(text: str) -> tuple[str, list[str]]:
+    """Replace Markdown links with private placeholders to protect href attributes."""
+    chunks: list[str] = []
+
+    def _sub(match: re.Match[str]) -> str:
+        label = _apply_inline_formatting(match.group(1))
+        url = match.group(2)
+        placeholder = f"\x00TG_LINK_{len(chunks)}\x00"
+        chunks.append(f'<a href="{url}">{label}</a>')
+        return placeholder
+
+    output = _LINK_RE.sub(_sub, text)
+    return output, chunks
+
+
+def _render_inline(text: str) -> str:
+    protected, code_chunks = _replace_code_spans(text)
+    rendered = html.escape(protected)
+    rendered, link_chunks = _replace_links(rendered)
+    rendered = _apply_inline_formatting(rendered)
+    for index, chunk in enumerate(link_chunks):
+        rendered = rendered.replace(f"\x00TG_LINK_{index}\x00", chunk)
     for index, chunk in enumerate(code_chunks):
         rendered = rendered.replace(f"\x00TG_CODE_{index}\x00", chunk)
     return rendered
@@ -131,9 +153,7 @@ def _render_table(headers: list[str], rows: list[list[str]]) -> list[str]:
     clean_headers = [_plain_inline(header) for header in headers]
     column_count = len(headers)
     if column_count == 2:
-        rendered = [
-            f"<b>{html.escape(clean_headers[0])} — {html.escape(clean_headers[1])}</b>"
-        ]
+        rendered = [f"<b>{html.escape(clean_headers[0])} — {html.escape(clean_headers[1])}</b>"]
         for row in rows:
             normalised = _normalize_row(row, column_count)
             label = normalised[0]

--- a/tests/test_channels/test_telegram_formatting.py
+++ b/tests/test_channels/test_telegram_formatting.py
@@ -48,8 +48,7 @@ if x < 2:
     assert "<b>Result &lt;safe&gt;</b>" in rendered
     assert "Use <b>care &amp; caution</b> with <code>x &lt; 2</code>." in rendered
     assert (
-        '<pre><code class="language-python">'
-        "if x &lt; 2:\n    print(&quot;&amp;&quot;)</code></pre>"
+        '<pre><code class="language-python">if x &lt; 2:\n    print(&quot;&amp;&quot;)</code></pre>'
     ) in rendered
 
 
@@ -127,12 +126,7 @@ async def test_telegram_send_falls_back_to_plain_text_on_entity_parse_error() ->
 
 def test_two_column_table_with_short_row_pads_missing_cell() -> None:
     """A 2-column table row with only 1 cell should be padded, not dropped."""
-    markdown = (
-        "| Header A | Header B |\n"
-        "| --- | --- |\n"
-        "| Row 1 Only |\n"
-        "| x | y |\n"
-    )
+    markdown = "| Header A | Header B |\n| --- | --- |\n| Row 1 Only |\n| x | y |\n"
     rendered = render_telegram_html(markdown)
 
     # Both rows must appear — the old `break` dropped "| x | y |".
@@ -146,12 +140,7 @@ def test_two_column_table_with_short_row_pads_missing_cell() -> None:
 
 def test_three_column_table_with_short_row_pads_missing_cells() -> None:
     """A 3-column table row missing trailing cells should be padded."""
-    markdown = (
-        "| A | B | C |\n"
-        "| --- | --- | --- |\n"
-        "| only-a |\n"
-        "| x | y | z |\n"
-    )
+    markdown = "| A | B | C |\n| --- | --- | --- |\n| only-a |\n| x | y | z |\n"
     rendered = render_telegram_html(markdown)
 
     assert "<b>A · B · C</b>" in rendered
@@ -166,12 +155,7 @@ def test_three_column_table_with_short_row_pads_missing_cells() -> None:
 
 def test_table_row_with_extra_columns_is_truncated() -> None:
     """A row with more cells than headers should be truncated, not break."""
-    markdown = (
-        "| A | B |\n"
-        "| --- | --- |\n"
-        "| 1 | 2 | 3 | 4 |\n"
-        "| x | y |\n"
-    )
+    markdown = "| A | B |\n| --- | --- |\n| 1 | 2 | 3 | 4 |\n| x | y |\n"
     rendered = render_telegram_html(markdown)
 
     assert "<b>A — B</b>" in rendered
@@ -207,3 +191,39 @@ def test_mixed_ragged_rows_all_render_without_raw_pipes() -> None:
     assert "extra" not in rendered
     # No raw pipe characters.
     assert "|" not in rendered
+
+
+# ── Issue #1435: URL href mutation ──────────────────────────────────────
+
+
+def test_telegram_markdown_preserves_href_urls_with_formatting_markers() -> None:
+    """URLs containing __, *, or ~~ must not be mutated by inline formatting."""
+    double_underscore = "[test](https://example.com/foo__bar__baz)"
+    asterisk = "[test](https://example.com/foo*bar*baz)"
+    strikethrough = "[test](https://example.com/foo~~bar~~baz)"
+
+    assert (
+        render_telegram_html(double_underscore)
+        == '<a href="https://example.com/foo__bar__baz">test</a>'
+    )
+    assert render_telegram_html(asterisk) == '<a href="https://example.com/foo*bar*baz">test</a>'
+    assert (
+        render_telegram_html(strikethrough)
+        == '<a href="https://example.com/foo~~bar~~baz">test</a>'
+    )
+
+
+def test_telegram_markdown_formats_link_labels_with_protected_href() -> None:
+    """Link labels containing bold/italic formatting should render, while href remains unmutated."""
+    bold_label = "[**bold label**](https://x.com/a__b)"
+    italic_label = "[*italic label*](https://x.com/a*b)"
+    code_label = "[`code label`](https://x.com/a~~b)"
+
+    assert render_telegram_html(bold_label) == '<a href="https://x.com/a__b"><b>bold label</b></a>'
+    assert (
+        render_telegram_html(italic_label) == '<a href="https://x.com/a*b"><i>italic label</i></a>'
+    )
+    assert (
+        render_telegram_html(code_label)
+        == '<a href="https://x.com/a~~b"><code>code label</code></a>'
+    )


### PR DESCRIPTION
Fixes #1435