### PR TITLE
fix(tools): record shell security hard-blocks and auto-denials in sandbox ledger (Closes #1513)

### DIFF
--- a/src/agentos/tools/builtin/shell.py
+++ b/src/agentos/tools/builtin/shell.py
@@ -733,16 +733,20 @@ async def exec_command(
 
     # Denylist: hard-block, never bypassable
     if not result.allowed:
+        await _record_shell_denial("exec_command", command, cwd, DenialReason.POLICY_DENIED)
         raise ToolError(result.reason)
 
     sensitive_block = _sensitive_shell_block("exec_command", command, workdir=cwd)
     if sensitive_block is not None:
+        await _record_shell_denial("exec_command", command, cwd, DenialReason.POLICY_DENIED)
         return sensitive_block
     lockdown_block = _workspace_lockdown_shell_block("exec_command", command, cwd)
     if lockdown_block is not None:
+        await _record_shell_denial("exec_command", command, cwd, DenialReason.POLICY_DENIED)
         return json.dumps(lockdown_block, ensure_ascii=False)
     deny_block = _workspace_write_deny_shell_block("exec_command", command, cwd)
     if deny_block is not None:
+        await _record_shell_denial("exec_command", command, cwd, DenialReason.POLICY_DENIED)
         return json.dumps(deny_block, ensure_ascii=False)
 
     # Warnlist: two-step approval flow
@@ -758,9 +762,15 @@ async def exec_command(
         if approval_response is not None:
             status = approval_response.get("status")
             if status == "approval_denied":
-                await _record_shell_denial(
-                    "exec_command", command, workdir, DenialReason.HUMAN_REJECTED
+                is_policy = (
+                    bool(approval_response.get("auto_denied"))
+                    or "denied by the active approval policy"
+                    in str(approval_response.get("message") or "")
                 )
+                reason = DenialReason.POLICY_DENIED if is_policy else DenialReason.HUMAN_REJECTED
+                await _record_shell_denial("exec_command", command, cwd, reason)
+            elif status == "blocked":
+                await _record_shell_denial("exec_command", command, cwd, DenialReason.POLICY_DENIED)
             return json.dumps(approval_response)
 
     # AgentOS's own provider credentials do not cross into a child process;
@@ -895,15 +905,19 @@ async def background_process(
     result = check_safe_bin(command)
     cwd = _effective_workdir(workdir)
     if not result.allowed:
+        await _record_shell_denial("background_process", command, cwd, DenialReason.POLICY_DENIED)
         raise ToolError(result.reason)
     sensitive_block = _sensitive_shell_block("background_process", command, workdir=cwd)
     if sensitive_block is not None:
+        await _record_shell_denial("background_process", command, cwd, DenialReason.POLICY_DENIED)
         return sensitive_block
     lockdown_block = _workspace_lockdown_shell_block("background_process", command, cwd)
     if lockdown_block is not None:
+        await _record_shell_denial("background_process", command, cwd, DenialReason.POLICY_DENIED)
         return json.dumps(lockdown_block, ensure_ascii=False)
     deny_block = _workspace_write_deny_shell_block("background_process", command, cwd)
     if deny_block is not None:
+        await _record_shell_denial("background_process", command, cwd, DenialReason.POLICY_DENIED)
         return json.dumps(deny_block, ensure_ascii=False)
     if result.needs_approval:
         prior_elevation = _approval_elevation_state()
@@ -925,8 +939,16 @@ async def background_process(
         if approval_response is not None:
             status = approval_response.get("status")
             if status == "approval_denied":
+                is_policy = (
+                    bool(approval_response.get("auto_denied"))
+                    or "denied by the active approval policy"
+                    in str(approval_response.get("message") or "")
+                )
+                reason = DenialReason.POLICY_DENIED if is_policy else DenialReason.HUMAN_REJECTED
+                await _record_shell_denial("background_process", command, cwd, reason)
+            elif status == "blocked":
                 await _record_shell_denial(
-                    "background_process", command, workdir, DenialReason.HUMAN_REJECTED
+                    "background_process", command, cwd, DenialReason.POLICY_DENIED
                 )
             return json.dumps(approval_response)
 
@@ -937,7 +959,7 @@ async def background_process(
         decision, policy, request = await gate_action(
             action_kind="shell.background",
             argv=("background_process", command),
-            cwd=Path(workdir) if workdir else None,
+            cwd=Path(cwd) if cwd else None,
             env=dict(os.environ),
         )
         if isinstance(decision, DenialResult):
@@ -1293,6 +1315,12 @@ def _sandbox_request_for(
         p = Path(workdir)
         if p.is_absolute():
             workspace = p
+        elif ctx and ctx.workspace_dir:
+            workspace = (Path(ctx.workspace_dir).expanduser().resolve() / p).resolve()
+        elif runtime.workspace.is_absolute():
+            workspace = (runtime.workspace / p).resolve()
+        else:
+            workspace = (Path.cwd() / p).resolve()
     if workspace is None and ctx is not None and ctx.workspace_dir:
         wp = Path(ctx.workspace_dir)
         if wp.is_absolute():

--- a/tests/test_tools/test_shell_ledger_denials.py
+++ b/tests/test_tools/test_shell_ledger_denials.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from agentos.gateway.approval_queue import get_approval_queue, reset_approval_queue
+from agentos.sandbox.config import SandboxSettings
+from agentos.sandbox.integration import configure_runtime, get_runtime, reset_runtime
+from agentos.sandbox.intent_cache import reset_intent_cache
+from agentos.sandbox.types import DenialReason
+from agentos.tools.builtin import shell
+from agentos.tools.types import CallerKind, ToolContext, ToolError, current_tool_context
+
+
+@pytest.fixture(autouse=True)
+def reset_sandbox_and_tool_state(tmp_path: Path):
+    reset_approval_queue()
+    reset_intent_cache()
+    reset_runtime()
+    configure_runtime(
+        SandboxSettings(sandbox=True, security_grading=False, allow_legacy_mode=True),
+        workspace=tmp_path,
+    )
+    token = current_tool_context.set(
+        ToolContext(
+            caller_kind=CallerKind.CLI,
+            session_key="test-session-1513",
+            workspace_dir=str(tmp_path),
+        )
+    )
+    yield
+    current_tool_context.reset(token)
+    reset_approval_queue()
+    reset_intent_cache()
+    reset_runtime()
+
+
+@pytest.mark.asyncio
+async def test_denylist_command_records_policy_denied_in_ledger() -> None:
+    runtime = get_runtime()
+    assert runtime is not None
+
+    denied_cmd = "Clear-Disk -Number 1" if os.name == "nt" else "mkfs.ext4 /dev/sda"
+    with pytest.raises(ToolError):
+        await shell.exec_command(denied_cmd)
+
+    assert await runtime.ledger.count_session("test-session-1513") == 1
+    _, last_reason = await runtime.ledger.last_denial("test-session-1513")
+    assert last_reason == DenialReason.POLICY_DENIED
+
+
+@pytest.mark.asyncio
+async def test_sensitive_path_block_records_policy_denied_in_ledger() -> None:
+    runtime = get_runtime()
+    assert runtime is not None
+
+    result = await shell.exec_command("cat ~/.ssh/id_rsa")
+    payload = json.loads(result)
+    assert payload["status"] == "blocked"
+    assert payload["reason"] == "sensitive_path"
+
+    assert await runtime.ledger.count_session("test-session-1513") == 1
+    _, last_reason = await runtime.ledger.last_denial("test-session-1513")
+    assert last_reason == DenialReason.POLICY_DENIED
+
+
+@pytest.mark.asyncio
+async def test_workspace_lockdown_block_records_policy_denied_in_ledger(tmp_path: Path) -> None:
+    runtime = get_runtime()
+    assert runtime is not None
+
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.workspace_lockdown = True
+
+    outside_path = "C:/outside_lockdown.txt" if os.name == "nt" else "/outside_lockdown.txt"
+    result = await shell.exec_command(f"echo payload > {outside_path}")
+    payload = json.loads(result)
+    assert payload["status"] == "blocked"
+    assert payload["reason"] == "workspace_lockdown"
+
+    assert await runtime.ledger.count_session("test-session-1513") == 1
+    _, last_reason = await runtime.ledger.last_denial("test-session-1513")
+    assert last_reason == DenialReason.POLICY_DENIED
+
+
+@pytest.mark.asyncio
+async def test_workspace_write_deny_block_records_policy_denied_in_ledger() -> None:
+    runtime = get_runtime()
+    assert runtime is not None
+
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.workspace_write_deny_globs = ["*.secret"]
+
+    result = await shell.exec_command("echo payload > token.secret")
+    payload = json.loads(result)
+    assert payload["status"] == "blocked"
+    assert payload["reason"] == "workspace_write_deny"
+
+    assert await runtime.ledger.count_session("test-session-1513") == 1
+    _, last_reason = await runtime.ledger.last_denial("test-session-1513")
+    assert last_reason == DenialReason.POLICY_DENIED
+
+
+@pytest.mark.asyncio
+async def test_background_process_hard_blocks_record_policy_denied_in_ledger() -> None:
+    runtime = get_runtime()
+    assert runtime is not None
+
+    denied_cmd = "Clear-Disk -Number 1" if os.name == "nt" else "mkfs.ext4 /dev/sda"
+    with pytest.raises(ToolError):
+        await shell.background_process(denied_cmd)
+
+    assert await runtime.ledger.count_session("test-session-1513") == 1
+    _, last_reason = await runtime.ledger.last_denial("test-session-1513")
+    assert last_reason == DenialReason.POLICY_DENIED
+
+    result = await shell.background_process("cat ~/.ssh/id_rsa")
+    payload = json.loads(result)
+    assert payload["status"] == "blocked"
+    assert await runtime.ledger.count_session("test-session-1513") == 2
+    _, last_reason = await runtime.ledger.last_denial("test-session-1513")
+    assert last_reason == DenialReason.POLICY_DENIED
+
+
+@pytest.mark.asyncio
+async def test_approval_auto_deny_records_policy_denied_in_ledger(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = get_runtime()
+    assert runtime is not None
+    monkeypatch.setattr(shell, "_sandbox_effectively_off", lambda: True)
+
+    queue = get_approval_queue()
+    queue.set_settings("auto-deny")
+
+    warned_cmd = "Remove-Item target.txt" if os.name == "nt" else "rm target.txt"
+    result = await shell.exec_command(warned_cmd)
+    payload = json.loads(result)
+    assert payload["status"] == "approval_denied"
+
+    assert await runtime.ledger.count_session("test-session-1513") == 1
+    _, last_reason = await runtime.ledger.last_denial("test-session-1513")
+    assert last_reason == DenialReason.POLICY_DENIED
+
+
+def test_sandbox_request_for_resolves_relative_workdir(tmp_path: Path) -> None:
+    built = shell._sandbox_request_for("exec_command", "echo ok", "nested/subfolder")
+    assert built is not None
+    request, _, session_id = built
+    assert session_id == "test-session-1513"
+    assert request.cwd == (tmp_path / "nested" / "subfolder").resolve()


### PR DESCRIPTION
Closes #1513


## Summary

`_record_shell_denial` records shell-layer denials into `runtime.ledger` for §8.3/§8.5 compliance. However, prior to this change, hard security blocks (denylist binary execution, sensitive host path access, workspace lockdown violations, and write-denied path pattern matches) returned early or raised `ToolError` without recording into the ledger. In addition, approval queue `auto-deny` responses were unconditionally recorded as `DenialReason.HUMAN_REJECTED` rather than `DenialReason.POLICY_DENIED`.

This PR fixes these issues by:
1. Invoking `_record_shell_denial(..., DenialReason.POLICY_DENIED)` prior to raising or returning on `check_safe_bin` denylist hits, `_sensitive_shell_block`, `_workspace_lockdown_shell_block`, and `_workspace_write_deny_shell_block` in both `exec_command` and `background_process`.
2. Accurately classifying approval queue `auto-deny` responses as `DenialReason.POLICY_DENIED` and recording `status == "blocked"` responses from approval checks.
3. Passing the resolved working directory (`cwd`) instead of the raw un-resolved `workdir` string to `_record_shell_denial` and `gate_action`.
4. Updating `_sandbox_request_for` to resolve relative `workdir` paths against `ctx.workspace_dir` or `runtime.workspace`.
5. Adding dedicated unit test suite in `tests/test_tools/test_shell_ledger_denials.py`.

## Tests

- `uv run pytest tests/test_tools/test_shell_ledger_denials.py -v` (7 passed)
- `uv run ruff check src/agentos/tools/builtin/shell.py tests/test_tools/test_shell_ledger_denials.py` (0 errors)
- `uv run mypy src/agentos/tools/builtin/shell.py tests/test_tools/test_shell_ledger_denials.py --show-error-codes` (0 errors)
