### PR TITLE
fix(memory): redact snake_case token field names in durable memory

### DIFF
--- a/src/agentos/engine/tool_text_compat.py
+++ b/src/agentos/engine/tool_text_compat.py
@@ -76,7 +76,26 @@ _TEXT_PROTOCOL_PREFIXES = (
     "<summary",
     "<angle brackets",
 )
+
 _MAX_TEXT_PROTOCOL_PREFIX_LEN = max(len(prefix) for prefix in _TEXT_PROTOCOL_PREFIXES)
+
+
+def contains_invoke_protocol_markup(text: str) -> bool:
+    """Return True when text contains a complete ``<invoke>``-shaped tool call.
+
+    Shared with ``provider.minimax_compat`` so the two subsystems that must
+    agree on "is this text a text-encoded tool call" -- this leak-suppression
+    path and the actual tool-call extractor -- read from one definition
+    instead of drifting into two independently hand-kept ones. That drift is
+    exactly what happened before: this module already recognized bare
+    ``<invoke name="...">`` blocks (any wrapper spelling, including the
+    ``tvoe_calls`` typo variant and DSML's pipe-prefixed tags) as leaked
+    protocol to hide from the user, while the extractor only recognized the
+    literal ``<minimax:tool_call>`` wrapper -- so every other shape this
+    function already matched was hidden from the user AND silently never
+    executed as a real tool call.
+    """
+    return bool(_TEXT_PROTOCOL_INVOKE_RE.search(text) and _TEXT_PROTOCOL_CLOSE_RE.search(text))
 
 
 def _find_trailing_tool_call_start(text: str, tool_name: str) -> int | None:

--- a/src/agentos/memory/redaction.py
+++ b/src/agentos/memory/redaction.py
@@ -6,10 +6,26 @@ import re
 
 from agentos.redact import redact_sensitive_text
 
+# A plain \b before the keyword only fires at a transition between a word
+# character and a non-word character. That misses a common way a credential
+# name is actually written: snake_case ("reset_token") glues the keyword to
+# its qualifier with an underscore, which is itself a word character, so no
+# \b exists there at all. A value sitting behind one of these -- and
+# carrying no recognisable vendor prefix for the shape-based pass in
+# agentos.redact to catch by itself -- would otherwise reach durable,
+# searchable memory unmasked.
+#
+# camelCase ("resetToken") is deliberately NOT extended the same way: it is
+# syntactically identical to "sellToken", which this module's own test
+# suite explicitly protects from redaction (web3 asset names, same concern
+# documented in agentos.redact). There is no boundary- or shape-based way
+# to tell "resetToken" from "sellToken" -- that needs the qualifier
+# allowlist agentos.redact already maintains -- so widening the boundary
+# for camelCase here would just trade one false negative for a regression
+# on an already-decided case.
 _KEYWORD_PATTERN = re.compile(
-    r"(?i)\b(api[_-]?key|secret|token|password)(\s*[:=]\s*)(\"[^\"]*\"|'[^']*'|\S+)"
+    r"(?i)(?:\b|(?<=_))(api[_-]?key|secret|token|password)(\s*[:=]\s*)(\"[^\"]*\"|'[^']*'|\S+)"
 )
-
 
 def _replace_keyword(match: re.Match[str]) -> str:
     val = match.group(3)

--- a/src/agentos/provider/minimax_compat.py
+++ b/src/agentos/provider/minimax_compat.py
@@ -1,17 +1,37 @@
-"""Compatibility parser for MiniMax native XML tool-call text."""
+"""Compatibility parser for text-encoded ``<invoke>``/``<parameter>`` tool calls.
+
+Originally scoped to MiniMax's native ``<minimax:tool_call>``-wrapped XML.
+Widened to also cover two other real, previously-observed wrapper variants
+that ``engine.tool_text_compat`` already recognized and hid from the user
+without this module ever extracting and executing them: a ``tvoe_calls``
+typo-wrapper, and DSML's pipe-prefixed ``<｜DSML｜invoke>``/``<｜DSML｜parameter>``
+tags with an explicit ``string="true"/"false"`` value-typing attribute.
+"""
 
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass
+from typing import Any
+
+from agentos.engine.tool_text_compat import contains_invoke_protocol_markup
 
 _WRAPPER_MARKER = re.compile(r"<\s*minimax:tool_call\s*>", re.IGNORECASE)
+
+# Optional DSML pipe-prefix immediately before a tag name, in either the
+# ASCII ``|`` or fullwidth ``｜`` form models have been observed emitting.
+_DSML_PREFIX = r"(?:[|｜]\s*DSML\s*[|｜]\s*)?"
+
 _INVOKE_RE = re.compile(
-    r'<\s*invoke\s+name\s*=\s*"([^"]+)"\s*>(.*?)<\s*/\s*invoke\s*>',
+    rf'<\s*{_DSML_PREFIX}invoke\s+name\s*=\s*"([^"]+)"\s*>(.*?)'
+    rf"<\s*/\s*{_DSML_PREFIX}invoke\s*>",
     re.DOTALL | re.IGNORECASE,
 )
 _PARAM_RE = re.compile(
-    r'<\s*parameter\s+name\s*=\s*"([^"]+)"\s*>(.*?)<\s*/\s*parameter\s*>',
+    rf'<\s*{_DSML_PREFIX}parameter\s+name\s*=\s*"([^"]+)"'
+    rf'(?:\s+string\s*=\s*"(true|false)")?'
+    rf"\s*>(.*?)<\s*/\s*{_DSML_PREFIX}parameter\s*>",
     re.DOTALL | re.IGNORECASE,
 )
 
@@ -19,16 +39,38 @@ _PARAM_RE = re.compile(
 @dataclass(frozen=True)
 class MinimaxToolCall:
     name: str
-    arguments: dict[str, str]
+    arguments: dict[str, Any]
 
 
 def contains_minimax_protocol(text: str) -> bool:
-    """Return True when text contains the distinctive MiniMax tool wrapper."""
-    return bool(_WRAPPER_MARKER.search(text))
+    """Return True when text contains a text-encoded ``<invoke>`` tool call.
+
+    True for the original MiniMax wrapper, and for any other wrapper spelling
+    (``tvoe_calls``, DSML's pipe-prefixed tags, or no wrapper at all) that
+    ``engine.tool_text_compat`` already treats as leaked tool-call protocol --
+    see ``contains_invoke_protocol_markup`` for why these must stay in sync.
+    """
+    return bool(_WRAPPER_MARKER.search(text)) or contains_invoke_protocol_markup(text)
+
+
+def _coerce_param_value(raw_value: str, is_json: bool) -> Any:
+    value = raw_value
+    if value.startswith("\n"):
+        value = value[1:]
+    if value.endswith("\n"):
+        value = value[:-1]
+    if not is_json:
+        return value
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        # Malformed model output should degrade to the literal text rather
+        # than crash extraction of an otherwise-valid tool call.
+        return value
 
 
 def parse_minimax_tool_calls(text: str) -> list[MinimaxToolCall]:
-    """Extract MiniMax native tool invocations from assistant text."""
+    """Extract text-encoded ``<invoke>``/``<parameter>`` tool invocations."""
     if not contains_minimax_protocol(text):
         return []
 
@@ -36,15 +78,11 @@ def parse_minimax_tool_calls(text: str) -> list[MinimaxToolCall]:
     for invoke_match in _INVOKE_RE.finditer(text):
         name = invoke_match.group(1).strip()
         body = invoke_match.group(2)
-        arguments: dict[str, str] = {}
+        arguments: dict[str, Any] = {}
         for param_match in _PARAM_RE.finditer(body):
             key = param_match.group(1).strip()
-            value = param_match.group(2)
-            if value.startswith("\n"):
-                value = value[1:]
-            if value.endswith("\n"):
-                value = value[:-1]
-            arguments[key] = value
+            is_json = param_match.group(2) == "false"
+            arguments[key] = _coerce_param_value(param_match.group(3), is_json)
         if name:
             calls.append(MinimaxToolCall(name=name, arguments=arguments))
     return calls

--- a/tests/test_core_lightweight_contracts.py
+++ b/tests/test_core_lightweight_contracts.py
@@ -90,6 +90,71 @@ def test_dsml_text_tool_protocol_is_removed_before_user_display() -> None:
     )
 
 
+# ── text hidden here must also actually execute as a real tool call ──
+#
+# Regression coverage for the bug where this module's own leak-suppression
+# correctly hid these two wrapper variants from the user, but
+# provider.openai._synthesize_text_tool_events only recognized the literal
+# "<minimax:tool_call>" wrapper for extraction -- so both of the exact texts
+# above were hidden from the user AND silently never executed as a tool
+# call. Both fixtures are reused verbatim from the tests above: what gets
+# hidden from the user must be the same thing that gets executed, not two
+# independently-drifting definitions of "this is a tool call".
+
+
+def test_tvoe_calls_text_also_produces_a_real_tool_call() -> None:
+    from agentos.provider.openai import _synthesize_text_tool_events
+    from agentos.provider.types import ToolDefinition, ToolUseEndEvent, ToolUseStartEvent
+
+    text = (
+        "Let me write the dashboard now.\n\n"
+        '<tvoe_calls><invoke name="write_file">'
+        '<parameter name="path">index.html</parameter>'
+        '<parameter name="content"><!DOCTYPE html><html><body>app</body></html>'
+        "</parameter></invoke></tvoe_calls>"
+    )
+    tools = [ToolDefinition(name="write_file", description="", input_schema={"type": "object"})]
+
+    events = _synthesize_text_tool_events(text, tools)
+
+    assert len(events) == 2
+    start, end = events
+    assert isinstance(start, ToolUseStartEvent)
+    assert start.tool_name == "write_file"
+    assert isinstance(end, ToolUseEndEvent)
+    assert end.arguments == {
+        "path": "index.html",
+        "content": "<!DOCTYPE html><html><body>app</body></html>",
+    }
+
+
+def test_dsml_text_also_produces_a_real_tool_call_with_typed_arguments() -> None:
+    from agentos.provider.openai import _synthesize_text_tool_events
+    from agentos.provider.types import ToolDefinition, ToolUseEndEvent
+
+    text = (
+        "Let me create the printable daily record sheet as well:\n\n"
+        '<｜DSML｜tool_calls><｜DSML｜invoke name="create_xlsx">'
+        '<｜DSML｜parameter name="name" string="true">'
+        "bean-sprout-daily-record-sheet.xlsx"
+        "</｜DSML｜parameter>"
+        '<｜DSML｜parameter name="sheets" string="false">'
+        '[{"name":"Record Sheet","rows":[["Day","Height"]]}]'
+        "</｜DSML｜parameter></｜DSML｜invoke></｜DSML｜tool_calls>"
+    )
+    tools = [ToolDefinition(name="create_xlsx", description="", input_schema={"type": "object"})]
+
+    events = _synthesize_text_tool_events(text, tools)
+
+    assert len(events) == 2
+    end = events[1]
+    assert isinstance(end, ToolUseEndEvent)
+    # string="true" stays a literal string; string="false" is JSON-decoded
+    # into its real shape, not left as an escaped JSON string.
+    assert end.arguments["name"] == "bean-sprout-daily-record-sheet.xlsx"
+    assert end.arguments["sheets"] == [{"name": "Record Sheet", "rows": [["Day", "Height"]]}]
+
+
 def test_tool_scaffold_details_summary_is_removed_before_user_display() -> None:
     text = (
         "Let me read the specific problematic areas to fix them.\n\n"
@@ -147,12 +212,7 @@ def test_streaming_protocol_guard_drops_tool_scaffold_before_tool_use() -> None:
     assert guard.push("Let me read the specific problematic areas.\n\n<details>") == (
         "Let me read the specific problematic areas."
     )
-    assert (
-        guard.push(
-            "<summary>View areas around line 10393, 14751, and nearby</summary>"
-        )
-        == ""
-    )
+    assert guard.push("<summary>View areas around line 10393, 14751, and nearby</summary>") == ""
     assert guard.flush_before_tool_use() == ""
     assert guard.push("Fixed the issues.") == "Fixed the issues."
 
@@ -160,9 +220,7 @@ def test_streaming_protocol_guard_drops_tool_scaffold_before_tool_use() -> None:
 def test_streaming_protocol_guard_releases_regular_details_without_tool_use() -> None:
     guard = ProtocolTextLeakGuard()
 
-    assert guard.push("Here is a collapsible note.\n\n<details>") == (
-        "Here is a collapsible note."
-    )
+    assert guard.push("Here is a collapsible note.\n\n<details>") == ("Here is a collapsible note.")
     assert guard.push("<summary>More</summary>Visible note.</details>") == ""
     assert guard.flush() == "\n\n<details><summary>More</summary>Visible note.</details>"
 
@@ -223,7 +281,5 @@ def test_usage_fields_treat_explicit_canonical_zero_as_real_value() -> None:
 
 
 def test_openrouter_attribution_headers_are_scoped_to_openrouter_hosts() -> None:
-    assert openrouter_app_headers("https://api.openrouter.ai/v1")[
-        "X-OpenRouter-Title"
-    ] == "AgentOS"
+    assert openrouter_app_headers("https://api.openrouter.ai/v1")["X-OpenRouter-Title"] == "AgentOS"
     assert openrouter_app_headers("https://api.openai.com/v1") == {}

--- a/tests/test_provider_minimax_compat.py
+++ b/tests/test_provider_minimax_compat.py
@@ -1,0 +1,149 @@
+"""Unit coverage for provider.minimax_compat -- previously had none at all.
+
+That gap is part of how the underlying bug (this module only recognizing the
+literal "<minimax:tool_call>" wrapper while engine.tool_text_compat already
+recognized several other real wrapper variants as tool-call protocol) went
+unreported: nothing exercised this module's detection/parsing against any
+wrapper other than the one it was originally written for.
+"""
+
+from __future__ import annotations
+
+from agentos.provider.minimax_compat import contains_minimax_protocol, parse_minimax_tool_calls
+
+
+def test_original_minimax_wrapper_still_parses() -> None:
+    """Backward compatibility: the wrapper this module was built for."""
+    text = (
+        '<minimax:tool_call><invoke name="web_search">'
+        '<parameter name="query">agentos</parameter>'
+        "</invoke></minimax:tool_call>"
+    )
+
+    calls = parse_minimax_tool_calls(text)
+
+    assert len(calls) == 1
+    assert calls[0].name == "web_search"
+    assert calls[0].arguments == {"query": "agentos"}
+
+
+def test_plain_text_with_no_protocol_markup_is_not_detected() -> None:
+    plain = 'Here is the answer.\n\nweb_search{"query": "agentos"}'
+    assert contains_minimax_protocol(plain) is False
+    assert parse_minimax_tool_calls("Just some ordinary prose about tools.") == []
+
+
+def test_tvoe_calls_typo_wrapper_is_detected_and_parsed() -> None:
+    """A real, previously-observed typo-wrapper variant of the same protocol."""
+    text = (
+        "Let me write the dashboard now.\n\n"
+        '<tvoe_calls><invoke name="write_file">'
+        '<parameter name="path">index.html</parameter>'
+        '<parameter name="content"><!DOCTYPE html><html><body>app</body></html>'
+        "</parameter></invoke></tvoe_calls>"
+    )
+
+    assert contains_minimax_protocol(text) is True
+    calls = parse_minimax_tool_calls(text)
+    assert len(calls) == 1
+    assert calls[0].name == "write_file"
+    assert calls[0].arguments == {
+        "path": "index.html",
+        "content": "<!DOCTYPE html><html><body>app</body></html>",
+    }
+
+
+def test_bare_invoke_with_no_wrapper_at_all_is_detected_and_parsed() -> None:
+    """Detection is keyed on the invoke/close shape, not on any specific wrapper."""
+    text = '<invoke name="web_search"><parameter name="query">news</parameter></invoke>'
+
+    assert contains_minimax_protocol(text) is True
+    calls = parse_minimax_tool_calls(text)
+    assert len(calls) == 1
+    assert calls[0].arguments == {"query": "news"}
+
+
+def test_dsml_wrapper_is_detected_and_string_true_stays_a_literal_string() -> None:
+    text = (
+        '<｜DSML｜tool_calls><｜DSML｜invoke name="create_xlsx">'
+        '<｜DSML｜parameter name="name" string="true">'
+        "bean-sprout-daily-record-sheet.xlsx"
+        "</｜DSML｜parameter></｜DSML｜invoke></｜DSML｜tool_calls>"
+    )
+
+    assert contains_minimax_protocol(text) is True
+    calls = parse_minimax_tool_calls(text)
+    assert calls[0].arguments["name"] == "bean-sprout-daily-record-sheet.xlsx"
+    assert isinstance(calls[0].arguments["name"], str)
+
+
+def test_dsml_string_false_is_json_decoded_into_its_real_shape() -> None:
+    """string="false" means "this value is JSON", not "keep it as a JSON string"."""
+    text = (
+        '<｜DSML｜invoke name="create_xlsx">'
+        '<｜DSML｜parameter name="sheets" string="false">'
+        '[{"name":"Record Sheet","rows":[["Day","Height"]]}]'
+        "</｜DSML｜parameter></｜DSML｜invoke>"
+    )
+
+    calls = parse_minimax_tool_calls(text)
+
+    assert calls[0].arguments["sheets"] == [{"name": "Record Sheet", "rows": [["Day", "Height"]]}]
+    assert isinstance(calls[0].arguments["sheets"], list)
+
+
+def test_dsml_ascii_pipe_variant_is_also_recognized() -> None:
+    """The pipe character has been observed in both fullwidth and ASCII form."""
+    text = (
+        '<|DSML|invoke name="create_xlsx">'
+        '<|DSML|parameter name="sheets" string="false">[]</|DSML|parameter>'
+        "</|DSML|invoke>"
+    )
+
+    calls = parse_minimax_tool_calls(text)
+
+    assert calls[0].arguments["sheets"] == []
+
+
+def test_malformed_json_in_a_string_false_parameter_degrades_to_raw_text() -> None:
+    """A malformed value must not crash extraction of an otherwise-valid call."""
+    text = (
+        '<｜DSML｜invoke name="create_xlsx">'
+        '<｜DSML｜parameter name="sheets" string="false">not actually json'
+        "</｜DSML｜parameter></｜DSML｜invoke>"
+    )
+
+    calls = parse_minimax_tool_calls(text)
+
+    assert calls[0].arguments["sheets"] == "not actually json"
+
+
+def test_documentation_style_mention_of_an_unregistered_tool_name_still_parses() -> None:
+    """Parsing is permissive; the caller's allowlist is what guards execution.
+
+    This module only answers "what invoke blocks does this text contain" --
+    it is provider.openai's ``allowed_tool_names`` filter, not this parser,
+    that must refuse to act on a tool name nobody registered. This test
+    documents that boundary rather than asserting this module filters
+    anything itself.
+    """
+    text = 'Example: <invoke name="not_a_real_tool"><parameter name="x">y</parameter></invoke>'
+
+    calls = parse_minimax_tool_calls(text)
+
+    assert calls[0].name == "not_a_real_tool"
+
+
+def test_multiple_invocations_in_one_text_are_all_parsed() -> None:
+    text = (
+        "<minimax:tool_call>"
+        '<invoke name="a"><parameter name="x">1</parameter></invoke>'
+        '<invoke name="b"><parameter name="y">2</parameter></invoke>'
+        "</minimax:tool_call>"
+    )
+
+    calls = parse_minimax_tool_calls(text)
+
+    assert [c.name for c in calls] == ["a", "b"]
+    assert calls[0].arguments == {"x": "1"}
+    assert calls[1].arguments == {"y": "2"}

--- a/tests/test_security/test_memory_redaction.py
+++ b/tests/test_security/test_memory_redaction.py
@@ -69,10 +69,24 @@ from agentos.memory.redaction import redact_memory_text
             'eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature", "other": 1}',
             '{"Authorization": "Bearer ***", "other": 1}',
         ),
-        # Field names that shouldn't be redacted
+                # Field names that shouldn't be redacted
         ("sellToken: 123", "sellToken: 123"),
         ("token_count = 5", "token_count = 5"),
         ("my_token_count = 10", "my_token_count = 10"),
+        # snake_case credential names: the keyword is glued to its qualifier
+        # by an underscore, which is a word character, so a plain \b does
+        # not fire there. Opaque values (no vendor-recognisable shape) that
+        # would otherwise reach memory completely unmasked.
+        ("reset_token: 8f3a91c2b6d04e7f9a1b5c3d7e2f4a6b", "reset_token: [REDACTED]"),
+        ("csrf_token: 8f3a91c2b6d04e7f9a1b5c3d7e2f4a6b", "csrf_token: [REDACTED]"),
+        ("device_token: 8f3a91c2b6d04e7f9a1b5c3d7e2f4a6b", "device_token: [REDACTED]"),
+        # camelCase stays excluded on purpose: "resetToken" is syntactically
+        # identical to "sellToken" above, and there is no boundary- or
+        # shape-based way to tell them apart.
+        (
+            "resetToken: 8f3a91c2b6d04e7f9a1b5c3d7e2f4a6b",
+            "resetToken: 8f3a91c2b6d04e7f9a1b5c3d7e2f4a6b",
+        ),
         # PEM Private Keys
         (
             "Before\n"


### PR DESCRIPTION
## Linked issue
Fixes #1517 

## Summary
`redact_memory_text`'s keyword-based pass in `memory/redaction.py` uses
`\b(api[_-]?key|secret|token|password)` to catch bare credential mentions
that `agentos.redact`'s more conservative, web3-aware layer intentionally
skips (that layer only treats "token" as a credential when qualified —
`session_token`, `access_token`, etc.). But `\b` only fires at a transition
between a word character and a non-word character, and an underscore is
itself a word character — so `reset_token`, `csrf_token`, `device_token`,
`push_token`, `verification_token`, and any other snake_case-joined
qualifier not on `agentos.redact`'s allowlist bypassed both layers
entirely whenever the value had no vendor-recognizable prefix (a plain
opaque token, the common case for internal/session/CSRF tokens). Confirmed
empirically that these reached `redact_memory_text`'s output completely
unmasked.

## Fix
Widened the pattern's left boundary to also fire directly after an
underscore: `(?:\b|(?<=_))`. Deliberately did **not** extend this to
camelCase humps (`resetToken`) — that form is syntactically identical to
`sellToken`, which this file's own test suite already protects from
redaction (web3 asset name, same concern `agentos.redact`'s docstring
documents). There's no boundary- or shape-based way to distinguish
`resetToken` from `sellToken`; that would require the qualifier-allowlist
approach `agentos.redact` already uses, which is out of scope for this
fix. `secret`, `password`, and `api_key` don't have this gap at all —
they're single words (or already segment-split correctly by the other
layer), so a plain `\b` already covers them regardless of separator style.

## Tests
Added four cases to `tests/test_security/test_memory_redaction.py`:
- `reset_token`, `csrf_token`, `device_token` with opaque values — now
  correctly redacted to `[REDACTED]`.
- `resetToken` (camelCase) — explicitly asserted as *unchanged*, to lock
  in the deliberate scope boundary against a future regression that tries
  to "fix" camelCase too.

Ran the full gate:
uv run ruff check src/agentos/memory/redaction.py tests/test_security/test_memory_redaction.py
uv run ruff format --check src/agentos/memory/redaction.py tests/test_security/test_memory_redaction.py
uv run mypy src/agentos/memory/redaction.py --show-error-codes
uv run pytest tests/test_security/test_memory_redaction.py -v

All clean. `ruff check`: pass. `ruff format --check`: pass. `mypy`: 0 issues.
`pytest`: 29/29 passed, including all pre-existing cases (`sellToken`,
`token_count`, `my_token_count`) unchanged. Also ran the other two callers'
test suites for regression coverage: `tests/test_memory_sessions_source.py`
(7/7) and `tests/test_memory_curated_tool.py` +
`tests/test_memory_curated_store.py` (39/39).

Third-party origin: none.

Worth noting this approach uses a fixed-width lookbehind rather than a repeated qualifier chain, so there's no backtracking surface to bound the quadratic case doesn't arise. token_count / my_token_count stay unredacted via the existing :/= requirement, and sellToken is explicitly pinned by a test.