### PR TITLE
fix: _sandbox_request_for drops relative workdir in denial ledger (#1510)

### DIFF
--- a/src/agentos/tools/builtin/shell.py
+++ b/src/agentos/tools/builtin/shell.py
@@ -759,7 +759,7 @@ async def exec_command(
             status = approval_response.get("status")
             if status == "approval_denied":
                 await _record_shell_denial(
-                    "exec_command", command, workdir, DenialReason.HUMAN_REJECTED
+                    "exec_command", command, cwd, DenialReason.HUMAN_REJECTED
                 )
             return json.dumps(approval_response)
 
@@ -926,7 +926,7 @@ async def background_process(
             status = approval_response.get("status")
             if status == "approval_denied":
                 await _record_shell_denial(
-                    "background_process", command, workdir, DenialReason.HUMAN_REJECTED
+                    "background_process", command, cwd, DenialReason.HUMAN_REJECTED
                 )
             return json.dumps(approval_response)
 
@@ -1306,10 +1306,7 @@ def _sandbox_request_for(
         if runtime.effective.grading_enabled
         else runtime.effective.default_level
     )
-    # trusted=False: this function only ever records a command a human just
-    # denied, so the ledger must reflect that approval was required — not
-    # claim (as `trusted=True` would) that the action needed none.
-    policy = build_policy(level, action_kind, workspace, runtime.settings, trusted=False)
+    policy = build_policy(level, action_kind, workspace, runtime.settings, trusted=True)
     request = build_request(
         action_kind=action_kind,
         argv=(tool_name, command),

--- a/src/agentos/tools/builtin/shell.py
+++ b/src/agentos/tools/builtin/shell.py
@@ -1282,21 +1282,22 @@ def _sandbox_request_for(
 
     Returns ``None`` when the sandbox runtime is not configured (tests that
     don't boot the gateway) so callers skip the §8.3/§8.5 hooks cleanly.
+
+    The only current caller is :func:`_record_shell_denial`, invoked right
+    after a human has rejected a warned command — so the request this builds
+    always describes an action that needed (and did not get) approval.
     """
     runtime = get_runtime()
     if runtime is None:
         return None
     action_kind = "shell.background" if tool_name == "background_process" else "shell.exec"
     ctx = current_tool_context.get()
-    workspace = None
-    if workdir:
-        p = Path(workdir)
-        if p.is_absolute():
-            workspace = p
-    if workspace is None and ctx is not None and ctx.workspace_dir:
-        wp = Path(ctx.workspace_dir)
-        if wp.is_absolute():
-            workspace = wp
+    # Reuse the same resolution _check_exec_approval already ran on this
+    # command's workdir, so a relative path (e.g. "subproject") lands in the
+    # ledger as the directory the command actually targeted, not silently
+    # dropped in favour of the workspace root.
+    resolved_workdir = _effective_workdir(workdir)
+    workspace = Path(resolved_workdir) if resolved_workdir else None
     if workspace is None:
         workspace = runtime.workspace if runtime.workspace.is_absolute() else Path.cwd()
 
@@ -1305,7 +1306,10 @@ def _sandbox_request_for(
         if runtime.effective.grading_enabled
         else runtime.effective.default_level
     )
-    policy = build_policy(level, action_kind, workspace, runtime.settings, trusted=True)
+    # trusted=False: this function only ever records a command a human just
+    # denied, so the ledger must reflect that approval was required — not
+    # claim (as `trusted=True` would) that the action needed none.
+    policy = build_policy(level, action_kind, workspace, runtime.settings, trusted=False)
     request = build_request(
         action_kind=action_kind,
         argv=(tool_name, command),

--- a/tests/test_tools/test_shell_approval_policy.py
+++ b/tests/test_tools/test_shell_approval_policy.py
@@ -11,7 +11,6 @@ from agentos.sandbox.config import SandboxSettings
 from agentos.sandbox.governance import action_fingerprint
 from agentos.sandbox.integration import configure_runtime, reset_runtime
 from agentos.sandbox.intent_cache import get_intent_cache, reset_intent_cache
-from agentos.sandbox.types import SecurityLevel
 from agentos.tools.builtin import code_exec, filesystem, shell
 from agentos.tools.builtin.code_exec import execute_code
 from agentos.tools.builtin.shell_policy import PolicyResult
@@ -885,7 +884,7 @@ async def test_root_wipe_is_hard_blocked_at_the_exec_approval_boundary() -> None
         assert result["sensitive_path"] == "/"
 
 
-# ─── Issues #1510 / #1511: `_sandbox_request_for` denial-ledger accuracy ──
+# ─── Issue #1510: `_sandbox_request_for` denial-ledger cwd accuracy ───────
 #
 # `_sandbox_request_for` is only ever called by `_record_shell_denial`, right
 # after a human has rejected a warned command, to build the request that gets
@@ -941,23 +940,30 @@ def test_sandbox_request_for_distinguishes_denials_in_different_relative_workdir
     assert len({fingerprint_a, fingerprint_b, fingerprint_root}) == 3
 
 
-def test_sandbox_request_for_marks_denied_command_as_requiring_approval(
+@pytest.mark.asyncio
+async def test_exec_command_records_denial_against_resolved_workdir(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Regression for #1511: the request built for a just-denied command
-    hardcoded ``trusted=True``, so at ``SecurityLevel.STRICT`` the resulting
-    policy claimed ``require_approval=False`` — the opposite of what just
-    happened."""
-    configure_runtime(
-        SandboxSettings(
-            sandbox=False,
-            security_grading=False,
-            default_level=SecurityLevel.STRICT,
-        ),
-        workspace=tmp_path,
-    )
+    """The call site matters too: exec_command already has the resolved
+    ``cwd`` in hand from ``_effective_workdir`` a few lines earlier, so it
+    should hand that to ``_record_shell_denial`` instead of the raw,
+    possibly-relative ``workdir`` argument."""
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.workspace_dir = str(tmp_path)
 
-    built = shell._sandbox_request_for("exec_command", "rm -rf build", None)
-    assert built is not None
-    _, policy, _ = built
-    assert policy.require_approval is True
+    recorded: dict[str, object] = {}
+
+    async def _capture_denial(tool_name: str, command: str, workdir, reason) -> None:
+        recorded["workdir"] = workdir
+
+    monkeypatch.setattr(shell, "_record_shell_denial", _capture_denial)
+
+    pending = json.loads(await shell.exec_command("rm target.txt", workdir="subproject"))
+    approval_id = str(pending["approval_id"])
+    get_approval_queue().resolve(approval_id, approved=False)
+
+    await shell.exec_command("rm target.txt", workdir="subproject", approval_id=approval_id)
+
+    assert recorded["workdir"] == str((tmp_path / "subproject").resolve())

--- a/tests/test_tools/test_shell_approval_policy.py
+++ b/tests/test_tools/test_shell_approval_policy.py
@@ -8,8 +8,10 @@ import pytest
 
 from agentos.gateway.approval_queue import get_approval_queue, reset_approval_queue
 from agentos.sandbox.config import SandboxSettings
+from agentos.sandbox.governance import action_fingerprint
 from agentos.sandbox.integration import configure_runtime, reset_runtime
 from agentos.sandbox.intent_cache import get_intent_cache, reset_intent_cache
+from agentos.sandbox.types import SecurityLevel
 from agentos.tools.builtin import code_exec, filesystem, shell
 from agentos.tools.builtin.code_exec import execute_code
 from agentos.tools.builtin.shell_policy import PolicyResult
@@ -881,3 +883,81 @@ async def test_root_wipe_is_hard_blocked_at_the_exec_approval_boundary() -> None
         assert result["status"] == "blocked"
         assert result["reason"] == "sensitive_path"
         assert result["sensitive_path"] == "/"
+
+
+# ─── Issues #1510 / #1511: `_sandbox_request_for` denial-ledger accuracy ──
+#
+# `_sandbox_request_for` is only ever called by `_record_shell_denial`, right
+# after a human has rejected a warned command, to build the request that gets
+# fingerprinted into the sandbox denial ledger (§8.3/§8.5).
+
+
+def test_sandbox_request_for_resolves_relative_workdir_against_ctx_workspace(
+    tmp_path: Path,
+) -> None:
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.workspace_dir = str(tmp_path)
+    configure_runtime(
+        SandboxSettings(
+            sandbox=True, security_grading=False, backend="noop", allow_legacy_mode=True
+        ),
+        workspace=tmp_path,
+    )
+
+    built = shell._sandbox_request_for("exec_command", "rm -rf build", "subproject")
+    assert built is not None
+    request, _, _ = built
+    assert request.cwd == (tmp_path / "subproject").resolve()
+
+
+def test_sandbox_request_for_distinguishes_denials_in_different_relative_workdirs(
+    tmp_path: Path,
+) -> None:
+    """Regression for #1510: before the fix, every relative ``workdir`` was
+    silently dropped in favour of the workspace root, so denying the same
+    command from two different subdirectories fingerprinted identically and
+    collapsed into one counter in the §8.5 denial ledger."""
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.workspace_dir = str(tmp_path)
+    configure_runtime(
+        SandboxSettings(
+            sandbox=True, security_grading=False, backend="noop", allow_legacy_mode=True
+        ),
+        workspace=tmp_path,
+    )
+
+    built_a = shell._sandbox_request_for("exec_command", "rm -rf build", "subproject")
+    built_b = shell._sandbox_request_for("exec_command", "rm -rf build", "other")
+    built_root = shell._sandbox_request_for("exec_command", "rm -rf build", None)
+    assert built_a is not None
+    assert built_b is not None
+    assert built_root is not None
+
+    fingerprint_a = action_fingerprint(built_a[0])
+    fingerprint_b = action_fingerprint(built_b[0])
+    fingerprint_root = action_fingerprint(built_root[0])
+    assert len({fingerprint_a, fingerprint_b, fingerprint_root}) == 3
+
+
+def test_sandbox_request_for_marks_denied_command_as_requiring_approval(
+    tmp_path: Path,
+) -> None:
+    """Regression for #1511: the request built for a just-denied command
+    hardcoded ``trusted=True``, so at ``SecurityLevel.STRICT`` the resulting
+    policy claimed ``require_approval=False`` — the opposite of what just
+    happened."""
+    configure_runtime(
+        SandboxSettings(
+            sandbox=False,
+            security_grading=False,
+            default_level=SecurityLevel.STRICT,
+        ),
+        workspace=tmp_path,
+    )
+
+    built = shell._sandbox_request_for("exec_command", "rm -rf build", None)
+    assert built is not None
+    _, policy, _ = built
+    assert policy.require_approval is True


### PR DESCRIPTION
## Linked issue

Fixes #1510

- [x] This pull request fully resolves the linked issue.

## Summary

`_sandbox_request_for()` in `shell.py` is only ever called by
`_record_shell_denial()`, right after a human has denied a warned
`exec_command`/`background_process` call, to build the request that
gets fingerprinted into the sandbox denial ledger.

It only accepted an absolute `workdir` (`Path(workdir).is_absolute()`),
silently dropping any relative workdir (e.g. `"subproject"`) and
falling back to the workspace root. Since `action_fingerprint()` folds
`cwd` into its hash, a command denied from two different relative
subdirectories fingerprinted identically and collapsed into one
counter instead of being tracked separately. Fixed by resolving
`workdir` through the same `_effective_workdir()` helper the live
approval/sensitive-path checks already use.

Also fixed the call sites per review: `exec_command` and
`background_process` already have the resolved `cwd` in hand from
`_effective_workdir()` a few lines earlier, but were passing the raw
`workdir` to `_record_shell_denial` instead.

(Earlier revision of this PR also touched a `trusted=` argument
against #1511 — reverted per review: that argument never reaches the
ledger, since `_record_shell_denial` discards the policy object
entirely.)

## Tests

- relative `workdir` resolves against the workspace, not the root
- denials from different relative workdirs get distinct fingerprints
- `exec_command`'s call site passes the resolved `cwd`, not raw `workdir`

All fail against the pre-fix code and pass after the fix.

    ruff check src tests                  # All checks passed!
    mypy src/agentos --show-error-codes   # Success: no issues found
    pytest tests/test_tools tests/test_sandbox tests/test_cli/test_sandbox_cmd.py -q
    # 1175 passed, 11 pre-existing/unrelated failures (same on unmodified main)
    pytest tests/test_tools/test_shell_approval_policy.py -q
    # 72 passed