### PR TITLE
fix(sandbox): expand $HOME on Windows and neutralize ambient test git config

### DIFF
--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -187,7 +187,11 @@ def _expand_env_vars(text: str) -> str:
     if "$" not in text and "%" not in text:
         return text
     try:
-        return os.path.expandvars(text)
+        expanded = os.path.expandvars(text)
+        if ("$HOME" in expanded or "${HOME}" in expanded) and "HOME" not in os.environ:
+            home = os.environ.get("USERPROFILE") or str(Path.home())
+            expanded = expanded.replace("${HOME}", home).replace("$HOME", home)
+        return expanded
     except (KeyError, TypeError, ValueError):
         return text
 

--- a/tests/test_cli_skills_init.py
+++ b/tests/test_cli_skills_init.py
@@ -167,7 +167,7 @@ def test_init_fails_on_existing_files_without_force(
         ],
     )
     assert result2.exit_code == 1
-    assert "already exists" in result2.output
+    assert "already exists" in " ".join(result2.output.split())
 
 
 def test_init_overwrites_with_force(temp_home: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_security/test_git_output_redaction.py
+++ b/tests/test_security/test_git_output_redaction.py
@@ -34,12 +34,24 @@ def _git(repo: Path, *args: str) -> None:
     """
     missing = str(repo.parent / "no-such-gitconfig")
     subprocess.run(
-        ["git", *args],
+        [
+            "git",
+            "-c",
+            "user.name=t",
+            "-c",
+            "user.email=t@example.com",
+            "-c",
+            "commit.gpgsign=false",
+            "-c",
+            "tag.gpgsign=false",
+            *args,
+        ],
         cwd=repo,
         check=True,
         capture_output=True,
         env={
             **os.environ,
+            "GIT_CONFIG_NOSYSTEM": "1",
             "GIT_CONFIG_GLOBAL": missing,
             "GIT_CONFIG_SYSTEM": missing,
             "GIT_AUTHOR_NAME": "t",
@@ -55,6 +67,9 @@ def repo(tmp_path: Path) -> Path:
     repo = tmp_path / "repo"
     repo.mkdir()
     _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.name", "t")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "commit.gpgsign", "false")
     (repo / ".env").write_text(
         f"ANTHROPIC_KEY={VENDOR_KEY}\nMY_CUSTOM_SECRET={NAMED_SECRET}\n",
         encoding="utf-8",


### PR DESCRIPTION
### Summary

- **`src/agentos/sandbox/sensitive_paths.py`**: In `_expand_env_vars()`, fallback `$HOME` and `${HOME}` expansion to `USERPROFILE` / `Path.home()` on Windows when `HOME` is not present in `os.environ`. This guarantees parity between `$HOME/path` and `~/path` across platforms.
- **`tests/test_security/test_git_output_redaction.py`**: Add explicit CLI override flags (`-c user.name=... -c commit.gpgsign=false`), `GIT_CONFIG_NOSYSTEM=1`, and local repo config so test commits succeed across all environments without depending on ambient system git configs.
- **`tests/test_cli_skills_init.py`**: Normalize whitespace on CliRunner error assertions to prevent platform terminal width line-wrapping failures.

### Verification

- `uv run ruff check src tests` passed (0 errors).
- `uv run mypy src/agentos --show-error-codes` passed (625 files clean).
- `uv run pytest tests/test_sandbox/test_sensitive_paths.py tests/test_security/test_git_output_redaction.py tests/test_cli_skills_init.py` passed (90/90 tests).
closes #1524 