### PR TITLE
fix(skills): check has_notes_slide in pptx extract_text before accessing notes_slide

### DIFF
--- a/src/agentos/skills/bundled/pptx/scripts/extract_text.py
+++ b/src/agentos/skills/bundled/pptx/scripts/extract_text.py
@@ -93,6 +93,8 @@ def _slide_text(slide) -> list[str]:
 
 
 def _notes_text(slide) -> str:
+    if not getattr(slide, "has_notes_slide", False):
+        return ""
     notes = getattr(slide, "notes_slide", None)
     if not notes:
         return ""

--- a/tests/test_skill_pptx_extract_text.py
+++ b/tests/test_skill_pptx_extract_text.py
@@ -68,3 +68,14 @@ def test_shape_text_and_table_text_extraction(tmp_path: Path) -> None:
     assert "Secondary point" in slide_data["text"]
     assert "Metric | Value" in slide_data["text"]
     assert "Q1 Revenue (USD) | $100M" in slide_data["text"]
+
+
+def test_notes_text_does_not_instantiate_blank_notes_slide() -> None:
+    """_notes_text must not instantiate a NotesSlide when has_notes_slide is False."""
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    assert slide.has_notes_slide is False
+
+    notes = extract_text._notes_text(slide)
+    assert notes == ""
+    assert slide.has_notes_slide is False


### PR DESCRIPTION
Fixes #1528

## Summary of Changes
- In `src/agentos/skills/bundled/pptx/scripts/extract_text.py`, guarded `slide.notes_slide` access with `getattr(slide, "has_notes_slide", False)`.
- Prevents `python-pptx` from automatically instantiating blank `NotesSlide` objects on slides without speaker notes when extracting presentation text.

## Testing & Quality Gate
- Added `test_notes_text_does_not_instantiate_blank_notes_slide` to `tests/test_skill_pptx_extract_text.py` verifying that `has_notes_slide` remains `False` after calling `_notes_text`.
- `uv run ruff check` passed.
- `uv run ruff format` passed.
- `uv run mypy src/agentos` passed.
- `uv run pytest tests/test_skill_pptx_extract_text.py` passed (2/2 passed).
