### PR TITLE
fix(approval): apply operator elevated mode to agent-kind contexts

### DIFF
--- a/src/agentos/application/approval_queue.py
+++ b/src/agentos/application/approval_queue.py
@@ -236,11 +236,18 @@ class ApprovalQueue:
                 return
             raise ValueError(f"Approval already resolved: {approval_id}")
 
+        # Persist the elevated mode together with the resolution. Tool code
+        # re-reads the entry via get() (rebuilt from this table), so keeping
+        # the mode only on the in-memory object loses it before the approved
+        # retry can apply it (#1512).
+        persisted_params = entry.params
+        if approved and elevated_mode in VALID_ELEVATED_MODES:
+            persisted_params = {**persisted_params, "elevatedMode": elevated_mode}
         cursor = self._conn.execute(
             "UPDATE approval_queue "
-            "SET resolved = 1, approved = ? "
+            "SET resolved = 1, approved = ?, params = ? "
             "WHERE approval_id = ? AND resolved = 0",
-            (1 if approved else 0, approval_id),
+            (1 if approved else 0, self._serialize_params(persisted_params), approval_id),
         )
         if cursor.rowcount != 1:
             self._conn.rollback()

--- a/src/agentos/tools/builtin/shell.py
+++ b/src/agentos/tools/builtin/shell.py
@@ -1353,6 +1353,15 @@ def _wait_for_inline_browser_approval(background: bool) -> bool:
 
 
 def _apply_approval_elevated_mode(entry: object) -> None:
+    """Apply an operator-resolved elevated mode to the active tool context.
+
+    ``entry.params["elevatedMode"]`` is written only by the approval resolve
+    path (Web UI / control-RPC operator action) — never by the tool call that
+    requested the approval. Inside the engine turn loop the requesting
+    ToolContext runs as ``CallerKind.AGENT``, so gating this on the caller
+    kind silently dropped the operator's choice (issue #1512). Apply it to
+    whatever context requested the approval, regardless of surface.
+    """
     params = getattr(entry, "params", None)
     if not isinstance(params, dict):
         return
@@ -1360,7 +1369,7 @@ def _apply_approval_elevated_mode(entry: object) -> None:
     if mode not in ("on", "bypass", "full"):
         return
     ctx = current_tool_context.get()
-    if ctx is not None and ctx.caller_kind in {CallerKind.CLI, CallerKind.WEB}:
+    if ctx is not None:
         ctx.elevated = mode
 
 

--- a/tests/test_tools/test_shell_approval_policy.py
+++ b/tests/test_tools/test_shell_approval_policy.py
@@ -6,7 +6,11 @@ from pathlib import Path
 
 import pytest
 
-from agentos.gateway.approval_queue import get_approval_queue, reset_approval_queue
+from agentos.gateway.approval_queue import (
+    PendingApproval,
+    get_approval_queue,
+    reset_approval_queue,
+)
 from agentos.sandbox.config import SandboxSettings
 from agentos.sandbox.integration import configure_runtime, reset_runtime
 from agentos.sandbox.intent_cache import get_intent_cache, reset_intent_cache
@@ -881,3 +885,95 @@ async def test_root_wipe_is_hard_blocked_at_the_exec_approval_boundary() -> None
         assert result["status"] == "blocked"
         assert result["reason"] == "sensitive_path"
         assert result["sensitive_path"] == "/"
+
+
+def _exec_entry(elevated_mode: str | None) -> PendingApproval:
+    params: dict = {"toolName": "exec_command", "command": "rm target.txt", "sessionKey": ""}
+    if elevated_mode is not None:
+        params["elevatedMode"] = elevated_mode
+    return PendingApproval(approval_id="a-1", namespace="exec", params=params)
+
+
+def test_agent_caller_context_receives_operator_elevated_mode() -> None:
+    """Operator-resolved elevated modes must land on agent-kind contexts (#1512).
+
+    Engine turn loops run tools with ``caller_kind=AGENT`` even when the
+    operator resolves the approval from the CLI or Web UI, so the old
+    ``{CLI, WEB}`` gate silently dropped the operator's choice.
+    """
+    ctx = ToolContext(caller_kind=CallerKind.AGENT, session_key="agent:main:test")
+    token = current_tool_context.set(ctx)
+    try:
+        shell._apply_approval_elevated_mode(_exec_entry("bypass"))
+        assert ctx.elevated == "bypass"
+    finally:
+        current_tool_context.reset(token)
+
+
+@pytest.mark.parametrize("caller_kind", [CallerKind.CLI, CallerKind.WEB, CallerKind.SUBAGENT])
+def test_operator_elevated_mode_applies_for_every_caller_kind(caller_kind: CallerKind) -> None:
+    ctx = ToolContext(caller_kind=caller_kind, session_key="agent:main:test")
+    token = current_tool_context.set(ctx)
+    try:
+        shell._apply_approval_elevated_mode(_exec_entry("on"))
+        assert ctx.elevated == "on"
+    finally:
+        current_tool_context.reset(token)
+
+
+def test_apply_elevated_mode_ignores_unresolved_and_invalid_entries() -> None:
+    ctx = ToolContext(caller_kind=CallerKind.AGENT, session_key="agent:main:test")
+    token = current_tool_context.set(ctx)
+    try:
+        shell._apply_approval_elevated_mode(_exec_entry(None))
+        assert ctx.elevated is None
+        shell._apply_approval_elevated_mode(_exec_entry("off"))
+        assert ctx.elevated is None
+        shell._apply_approval_elevated_mode(
+            PendingApproval(approval_id="a-2", namespace="exec", params={})
+        )
+        assert ctx.elevated is None
+        shell._apply_approval_elevated_mode(object())
+        assert ctx.elevated is None
+    finally:
+        current_tool_context.reset(token)
+    missing = current_tool_context.set(None)
+    try:
+        shell._apply_approval_elevated_mode(_exec_entry("bypass"))
+    finally:
+        current_tool_context.reset(missing)
+
+
+@pytest.mark.asyncio
+async def test_agent_turn_honors_bypass_for_subsequent_commands_after_operator_approval() -> None:
+    """Full agent-turn flow: approval resolved with bypass must persist (#1512).
+
+    With no session key there is no session-map fallback, so the only path
+    carrying the operator's mode forward is ``_apply_approval_elevated_mode``.
+    """
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.caller_kind = CallerKind.AGENT
+    ctx.session_key = None
+    queue = get_approval_queue()
+    queue.set_settings("auto-approve")
+
+    command = "rm target.txt"
+    first = await shell._check_exec_approval(
+        "exec_command", command, None, "command requires approval", None, True
+    )
+    assert first is not None
+    assert first["status"] == "approval_required"
+    approval_id = str(first["approval_id"])
+
+    queue.resolve(approval_id, approved=True, elevated_mode="bypass")
+    retry = await shell._check_exec_approval(
+        "exec_command", command, None, "command requires approval", approval_id, True
+    )
+    assert retry is None, "approved command must run"
+    assert ctx.elevated == "bypass"
+
+    followup = await shell._check_exec_approval(
+        "exec_command", command, None, "command requires approval", None, True
+    )
+    assert followup is None, "operator bypass must silence the next warned command"


### PR DESCRIPTION
Fixes #1512

## Problem

When an operator resolves an exec approval with an elevated mode (`on` / `bypass` / `full`) from the CLI or Web UI, the requesting agent's `ToolContext.elevated` silently stays `None`. The approved command runs (it consumed the approval), but the operator's elevated mode is dropped — subsequent warned commands keep prompting instead of honoring `bypass`, and per-session elevation set at resolve time never reaches the tool layer through the context path.

## Root cause (two layers)

1. **Caller-kind gate in `_apply_approval_elevated_mode`** (`src/agentos/tools/builtin/shell.py`): the helper only applied `entry.params["elevatedMode"]` when `ctx.caller_kind in {CLI, WEB}`. But inside an engine turn loop the tool's `ToolContext` runs as `CallerKind.AGENT` (the agent executes the call; the *operator* resolves the approval out-of-band), so the operator's choice was dropped for exactly the surface that requests approvals.

2. **`elevatedMode` never persisted in `ApprovalQueue.resolve()`** (`src/agentos/application/approval_queue.py`): resolve wrote `elevatedMode` only onto the in-memory entry object, but the UPDATE statement persisted only `resolved`/`approved`. Both production call sites of `_apply_approval_elevated_mode` re-read the entry via `queue.get()`, which rebuilds from SQLite — overwriting the in-memory params before the elevated mode could be read. So even with the gate removed, the mode was lost before it could be applied.

## Changes

- `shell.py`: `_apply_approval_elevated_mode` now applies the operator's elevated mode to the active `ToolContext` regardless of caller kind (invalid/absent modes are still ignored). Added a docstring explaining why.
- `approval_queue.py`: `resolve()` persists `elevatedMode` in the `params` JSON column in the same transaction as the resolution, so `get()`-rebuilt entries carry it.
- `test_shell_approval_policy.py`: regression tests —
  - unit: agent-kind context receives the operator mode (old gate fails this with `assert None == 'bypass'`);
  - parametrized: every caller kind (CLI/WEB/SUBAGENT) applies the mode;
  - negative: unresolved / `off` / params-missing / non-entry objects are ignored, and no-context calls do not raise;
  - integration (no session key → no session-map fallback): approve with `elevated_mode="bypass"` → retry runs → a *follow-up* warned command in the same turn is skipped without a new prompt.

## Verification

- Regression suite RED before the fix (3 failed, including `AssertionError: assert None == 'bypass'` matching the issue symptom), GREEN after: `tests/test_tools/test_shell_approval_policy.py` 75 passed.
- Neighbor suites unaffected: approval-queue persistence, RPC approvals, approval RPC, intent cache, interactive approval retry, channel approvals, rate-limit approvals — 90 passed.
- `ruff check` + `mypy` clean on touched files; `uv build --wheel` succeeds.
- Full suite (`pytest tests -q`): 10123 passed, 31 skipped. The 18 failures + 3 errors are pre-existing and environment-dependent — the identical set fails on a clean checkout (verified via `git stash` baseline): onnx/model asset hydration, pilot-benchmark fixtures, wheelhouse build tests, and the machine-timezone hygiene test. The OpenRouter live smoke fails only when an unfunded `OPENROUTER_API_KEY` is exported; CI skips it (no key present).
