### PR TITLE
fix(telegram): group multiline blockquotes and preserve empty quote lines (Closes #1532)

### DIFF
--- a/src/agentos/channels/_telegram_formatting.py
+++ b/src/agentos/channels/_telegram_formatting.py
@@ -11,6 +11,7 @@ _HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s+(?P<text>.+?)\s*#*\s*$")
 _ORDERED_LIST_RE = re.compile(r"^(?P<indent>\s*)(?P<number>\d+)[.)]\s+(?P<text>.+)$")
 _UNORDERED_LIST_RE = re.compile(r"^(?P<indent>\s*)[-+*]\s+(?P<text>.+)$")
 _LINK_RE = re.compile(r"\[([^\]\n]+)\]\((https?://[^\s)<]+)\)")
+_BLOCKQUOTE_RE = re.compile(r"^\s{0,3}>(?: ?(.*))$")
 
 
 def _replace_code_spans(text: str) -> tuple[str, list[str]]:
@@ -229,9 +230,16 @@ def render_telegram_html(markdown: str) -> str:
             rendered.append(f"<b>{_render_inline(heading.group('text'))}</b>")
             index += 1
             continue
-        if line.startswith("> "):
-            rendered.append(f"<blockquote>{_render_inline(line[2:])}</blockquote>")
-            index += 1
+        blockquote_match = _BLOCKQUOTE_RE.match(line)
+        if blockquote_match:
+            quote_lines: list[str] = []
+            while index < len(lines):
+                match = _BLOCKQUOTE_RE.match(lines[index])
+                if not match:
+                    break
+                quote_lines.append(_render_inline(match.group(1)))
+                index += 1
+            rendered.append(f"<blockquote>{'\n'.join(quote_lines)}</blockquote>")
             continue
         ordered = _ORDERED_LIST_RE.match(line)
         if ordered:

--- a/tests/test_channels/test_telegram_formatting.py
+++ b/tests/test_channels/test_telegram_formatting.py
@@ -286,3 +286,43 @@ def test_a_url_inside_a_code_span_is_untouched() -> None:
     assert render_telegram_html("`https://x.test/a__b__c`") == (
         "<code>https://x.test/a__b__c</code>"
     )
+
+
+def test_multiline_blockquote_renders_as_single_tag() -> None:
+    markdown = "> Line 1\n> Line 2\n> Line 3"
+    rendered = render_telegram_html(markdown)
+
+    assert rendered == "<blockquote>Line 1\nLine 2\nLine 3</blockquote>"
+
+
+def test_blockquote_with_empty_quote_line_preserves_internal_paragraphs() -> None:
+    markdown = "> Paragraph 1\n>\n> Paragraph 2"
+    rendered = render_telegram_html(markdown)
+
+    assert rendered == "<blockquote>Paragraph 1\n\nParagraph 2</blockquote>"
+    assert "&gt;" not in rendered
+
+
+def test_blockquote_syntax_variations_and_inline_formatting() -> None:
+    markdown = (
+        "> **Note**: check `status`\n"
+        ">visit [AgentOS](https://agentos.dev)\n"
+        "  >   indented quote"
+    )
+    rendered = render_telegram_html(markdown)
+
+    assert rendered == (
+        "<blockquote><b>Note</b>: check <code>status</code>\n"
+        'visit <a href="https://agentos.dev">AgentOS</a>\n'
+        "  indented quote</blockquote>"
+    )
+
+
+def test_distinct_blockquotes_separated_by_blank_lines_remain_separate() -> None:
+    markdown = "> First block\n\n> Second block"
+    rendered = render_telegram_html(markdown)
+
+    assert rendered == (
+        "<blockquote>First block</blockquote>\n\n"
+        "<blockquote>Second block</blockquote>"
+    )


### PR DESCRIPTION
Closes #1532

### Problem
In Telegram Bot API HTML formatting (`src/agentos/channels/_telegram_formatting.py`):
1. **Multiline quotes are fragmented**: Each `> ` line was emitted as its own `<blockquote>...</blockquote>` tag. Telegram renders each tag as a separate visual quote bubble with an isolated border bar, rather than grouping them into a single multiline blockquote.
2. **Empty quote lines leak as raw `&gt;`**: Internal empty lines within a blockquote (`>`) failed `line.startswith("> ")`, falling through to inline rendering where `>` escaped into `&gt;` outside any quote.
3. **Prefix variations missed**: Standard CommonMark variations such as `>quote` (no space after `>`) or 0-3 leading indent spaces were not recognized.

### Solution
- Introduced `_BLOCKQUOTE_RE = re.compile(r"^\s{0,3}>(?: ?(.*))$")` to recognize CommonMark blockquote lines with optional space and standard indentation.
- Grouped consecutive blockquote lines into a single `<blockquote>...</blockquote>` tag joined by newlines, preserving internal empty lines and rendering inline formatting across each line.
- Added comprehensive unit test coverage in `tests/test_channels/test_telegram_formatting.py`.
