### PR TITLE
fix(mcp,tools): fix stdio overrun delimiter handling and shell UTF-8 chunk decoding

### DIFF
--- a/src/agentos/mcp/stdio.py
+++ b/src/agentos/mcp/stdio.py
@@ -85,6 +85,8 @@ class MCPStdioClient(MCPClient):
                         f"MCP server message exceeds {cls._MAX_MESSAGE_BYTES} bytes "
                         "with no newline delimiter"
                     ) from exc
+                if chunks[-1].endswith(b"\n"):
+                    return b"".join(chunks)
                 continue
             except asyncio.IncompleteReadError as exc:
                 partial = b"".join([*chunks, exc.partial])

--- a/src/agentos/tools/builtin/shell.py
+++ b/src/agentos/tools/builtin/shell.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import codecs
 import contextlib
 import contextvars
 import json
@@ -567,8 +568,12 @@ async def _read_bg_output(session: _BgSession) -> None:
     stdout = session.process.stdout
     if stdout is None:
         return
+    decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
     while chunk := await stdout.read(4096):
-        _append_bg_output(session, chunk.decode("utf-8", errors="replace"))
+        if decoded := decoder.decode(chunk):
+            _append_bg_output(session, decoded)
+    if final_decoded := decoder.decode(b"", final=True):
+        _append_bg_output(session, final_decoded)
 
 
 def _append_bg_output(session: _BgSession, output: str) -> None:

--- a/tests/test_mcp/test_stdio_client.py
+++ b/tests/test_mcp/test_stdio_client.py
@@ -33,6 +33,7 @@ class _FakeProcess:
         self.wait_calls += 1
         if self.returncode is None:
             await asyncio.sleep(3600)
+        assert self.returncode is not None
         return self.returncode
 
 
@@ -271,6 +272,16 @@ async def test_read_response_reads_message_longer_than_the_stream_limit() -> Non
     """
     payload: dict[str, Any] = {"jsonrpc": "2.0", "id": 1, "result": {"text": "x" * 4096}}
     client = _client_reading(json.dumps(payload).encode() + b"\n", limit=64)
+
+    assert await client._read_response(1) == payload
+
+
+@pytest.mark.asyncio
+async def test_read_response_handles_overrun_with_newline_boundary() -> None:
+    """A message whose line exceeds StreamReader limit but ends with newline must be returned."""
+    payload: dict[str, Any] = {"jsonrpc": "2.0", "id": 1, "result": {"data": "test_overrun"}}
+    raw = json.dumps(payload).encode() + b"\n"
+    client = _client_reading(raw, limit=len(raw) - 1)
 
     assert await client._read_response(1) == payload
 

--- a/tests/test_tools/test_shell_process_isolation.py
+++ b/tests/test_tools/test_shell_process_isolation.py
@@ -312,3 +312,13 @@ async def test_process_subagent_context_has_no_global_bypass() -> None:
         current_tool_context.reset(token)
 
     assert [session["session_id"] for session in payload["sessions"]] == ["own"]
+
+
+@pytest.mark.asyncio
+async def test_read_bg_output_handles_split_multibyte_utf8() -> None:
+    session = _session("utf8_split", "agent:main:one")
+    # '🎉' is b'\xf0\x9f\x8e\x89' (4 bytes) split across two read chunks
+    fake_stdout = _FakeStdout([b"hello \xf0\x9f", b"\x8e\x89 world\n", b""])
+    session.process.stdout = fake_stdout  # type: ignore[assignment]
+    await shell._read_bg_output(session)
+    assert "".join(session.output_lines) == "hello 🎉 world\n"


### PR DESCRIPTION
## Summary

This PR addresses two stream/chunk boundary handling issues across the MCP stdio transport and background shell output collector:

1. **MCP stdio reader (`src/agentos/mcp/stdio.py`)**: Fixed an issue where `_read_line_chunks` caught `asyncio.LimitOverrunError` but unconditionally continued reading even if the overrun chunk already concluded with a `\n` delimiter, causing frame desync or message size error on large payloads.
2. **Background shell tool (`src/agentos/tools/builtin/shell.py`)**: Replaced direct per-chunk `chunk.decode("utf-8", errors="replace")` in `_read_bg_output` with `codecs.getincrementaldecoder("utf-8")` to prevent character corruption when multi-byte UTF-8 characters (e.g. CJK or emojis) are split across 4096-byte chunk boundaries.

## Changes

- [x] `src/agentos/mcp/stdio.py`: Check `if chunks[-1].endswith(b"\n")` on `LimitOverrunError` recovery to immediately return complete framed messages.
- [x] `src/agentos/tools/builtin/shell.py`: Use `codecs.getincrementaldecoder` for robust background process stdout stream decoding.
- [x] Added regression tests in `tests/test_mcp/test_stdio_client.py` and `tests/test_tools/test_shell_process_isolation.py`.

## Verification

- `uv run pytest tests/test_mcp/test_stdio_client.py tests/test_tools/test_shell_process_isolation.py -q` (39 passed)
- `uv run ruff check` (passed)
- `uv run mypy` (0 errors)
closes #1534 