### PR TITLE
fix(tools): handle multibyte UTF-8 decoding across background output chunks

### DIFF
--- a/src/agentos/tools/builtin/shell.py
+++ b/src/agentos/tools/builtin/shell.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import codecs
 import contextlib
 import contextvars
 import json
@@ -567,8 +568,12 @@ async def _read_bg_output(session: _BgSession) -> None:
     stdout = session.process.stdout
     if stdout is None:
         return
+    decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
     while chunk := await stdout.read(4096):
-        _append_bg_output(session, chunk.decode("utf-8", errors="replace"))
+        if decoded := decoder.decode(chunk):
+            _append_bg_output(session, decoded)
+    if final_decoded := decoder.decode(b"", final=True):
+        _append_bg_output(session, final_decoded)
 
 
 def _append_bg_output(session: _BgSession, output: str) -> None:

--- a/tests/test_tools/test_shell_process_isolation.py
+++ b/tests/test_tools/test_shell_process_isolation.py
@@ -312,3 +312,13 @@ async def test_process_subagent_context_has_no_global_bypass() -> None:
         current_tool_context.reset(token)
 
     assert [session["session_id"] for session in payload["sessions"]] == ["own"]
+
+
+@pytest.mark.asyncio
+async def test_read_bg_output_handles_split_multibyte_utf8() -> None:
+    session = _session("utf8_split", "agent:main:one")
+    # '🎉' is b'\xf0\x9f\x8e\x89' (4 bytes) split across two 4096-byte chunk boundaries
+    fake_stdout = _FakeStdout([b"hello \xf0\x9f", b"\x8e\x89 world\n", b""])
+    session.process.stdout = fake_stdout  # type: ignore[assignment]
+    await shell._read_bg_output(session)
+    assert "".join(session.output_lines) == "hello 🎉 world\n"


### PR DESCRIPTION
## Summary

Fixes character corruption in `_read_bg_output` where multi-byte UTF-8 sequences (such as CJK characters or emojis) straddling 4096-byte chunk boundaries were decoded per-chunk with `errors="replace"`, corrupting split bytes into `U+FFFD`.

## Key Changes

- `src/agentos/tools/builtin/shell.py`: Replaced direct per-chunk `chunk.decode("utf-8", errors="replace")` with `codecs.getincrementaldecoder("utf-8")(errors="replace")` to preserve partial byte sequences across chunk boundaries and flush remaining decoded text upon EOF.
- `tests/test_tools/test_shell_process_isolation.py`: Added regression test `test_read_bg_output_handles_split_multibyte_utf8` simulating a 4-byte UTF-8 emoji split across read chunks.

## Verification

- `uv run pytest tests/test_tools/test_shell_process_isolation.py -v` (16 passed, 3 skipped)
- `uv run ruff check src/agentos/tools/builtin/shell.py tests/test_tools/test_shell_process_isolation.py` (all passed)
- `uv run mypy src/agentos/tools/builtin/shell.py tests/test_tools/test_shell_process_isolation.py --show-error-codes` (0 errors)

Refs #1535
