### PR TITLE
feat(mcp): add list_resources and read_resource to MCPClient and transports

### DIFF
--- a/src/agentos/mcp/__init__.py
+++ b/src/agentos/mcp/__init__.py
@@ -10,11 +10,19 @@ from agentos.mcp.discovery import (
     disconnect_and_unregister,
     discover_and_register,
 )
-from agentos.mcp.types import MCPServerConfig, MCPToolDef, MCPToolResult
+from agentos.mcp.types import (
+    MCPResourceContent,
+    MCPResourceDef,
+    MCPServerConfig,
+    MCPToolDef,
+    MCPToolResult,
+)
 
 __all__ = [
     "ActiveMCPClient",
     "MCPClient",
+    "MCPResourceContent",
+    "MCPResourceDef",
     "MCPServerConfig",
     "MCPToolDef",
     "MCPToolResult",

--- a/src/agentos/mcp/client.py
+++ b/src/agentos/mcp/client.py
@@ -9,7 +9,13 @@ from abc import ABC, abstractmethod
 from contextlib import AsyncExitStack
 from typing import Any
 
-from agentos.mcp.types import MCPServerConfig, MCPToolDef, MCPToolResult
+from agentos.mcp.types import (
+    MCPResourceContent,
+    MCPResourceDef,
+    MCPServerConfig,
+    MCPToolDef,
+    MCPToolResult,
+)
 
 
 class MCPClient(ABC):
@@ -33,6 +39,14 @@ class MCPClient(ABC):
     @abstractmethod
     async def call_tool(self, name: str, arguments: dict[str, Any]) -> MCPToolResult:
         """Call a tool on the MCP server."""
+
+    @abstractmethod
+    async def list_resources(self) -> list[MCPResourceDef]:
+        """List available resources from the MCP server."""
+
+    @abstractmethod
+    async def read_resource(self, uri: str) -> list[MCPResourceContent]:
+        """Read a resource by URI from the MCP server."""
 
 
 class MCPSessionClient(MCPClient):
@@ -204,3 +218,29 @@ class MCPSessionClient(MCPClient):
             content="\n".join(chunks),
             is_error=bool(getattr(result, "isError", False)),
         )
+
+    async def list_resources(self) -> list[MCPResourceDef]:
+        """List resources from the MCP server."""
+        result = await self._require_session().list_resources()
+        return [
+            MCPResourceDef(
+                uri=str(resource.uri),
+                name=resource.name,
+                description=getattr(resource, "description", "") or "",
+                mime_type=getattr(resource, "mimeType", None),
+            )
+            for resource in result.resources
+        ]
+
+    async def read_resource(self, uri: str) -> list[MCPResourceContent]:
+        """Read a resource by URI from the MCP server."""
+        result = await self._require_session().read_resource(uri)
+        return [
+            MCPResourceContent(
+                uri=str(content.uri),
+                mime_type=getattr(content, "mimeType", None),
+                text=getattr(content, "text", None),
+                blob=getattr(content, "blob", None),
+            )
+            for content in result.contents
+        ]

--- a/src/agentos/mcp/stdio.py
+++ b/src/agentos/mcp/stdio.py
@@ -9,7 +9,13 @@ from typing import Any, cast
 
 from agentos import __version__
 from agentos.mcp.client import MCPClient
-from agentos.mcp.types import MCPServerConfig, MCPToolDef, MCPToolResult
+from agentos.mcp.types import (
+    MCPResourceContent,
+    MCPResourceDef,
+    MCPServerConfig,
+    MCPToolDef,
+    MCPToolResult,
+)
 
 
 class MCPStdioClient(MCPClient):
@@ -228,4 +234,37 @@ class MCPStdioClient(MCPClient):
         result = response.get("result", {})
         content_list = result.get("content", [])
         text = "\n".join(c.get("text", "") for c in content_list if c.get("type") == "text")
-        return MCPToolResult(content=text)
+        return MCPToolResult(content=text, is_error=bool(result.get("isError", False)))
+
+    async def list_resources(self) -> list[MCPResourceDef]:
+        """List resources from the MCP server."""
+        response = await self._send_request("resources/list")
+        if "error" in response:
+            return []
+        resources_data = response.get("result", {}).get("resources", [])
+        return [
+            MCPResourceDef(
+                uri=r["uri"],
+                name=r.get("name", ""),
+                description=r.get("description", ""),
+                mime_type=r.get("mimeType"),
+            )
+            for r in resources_data
+        ]
+
+    async def read_resource(self, uri: str) -> list[MCPResourceContent]:
+        """Read a resource by URI from the MCP server."""
+        response = await self._send_request("resources/read", {"uri": uri})
+        if "error" in response:
+            return []
+        result = response.get("result", {})
+        contents_data = result.get("contents", [])
+        return [
+            MCPResourceContent(
+                uri=c.get("uri", uri),
+                mime_type=c.get("mimeType"),
+                text=c.get("text"),
+                blob=c.get("blob"),
+            )
+            for c in contents_data
+        ]

--- a/src/agentos/mcp/types.py
+++ b/src/agentos/mcp/types.py
@@ -32,3 +32,19 @@ class MCPToolDef:
 class MCPToolResult:
     content: str
     is_error: bool = False
+
+
+@dataclass
+class MCPResourceDef:
+    uri: str
+    name: str
+    description: str = ""
+    mime_type: str | None = None
+
+
+@dataclass
+class MCPResourceContent:
+    uri: str
+    mime_type: str | None = None
+    text: str | None = None
+    blob: str | None = None

--- a/tests/test_mcp/test_discovery_lifecycle.py
+++ b/tests/test_mcp/test_discovery_lifecycle.py
@@ -7,7 +7,13 @@ import pytest
 import pytest_asyncio
 
 from agentos.mcp.client import MCPClient
-from agentos.mcp.types import MCPServerConfig, MCPToolDef, MCPToolResult
+from agentos.mcp.types import (
+    MCPResourceContent,
+    MCPResourceDef,
+    MCPServerConfig,
+    MCPToolDef,
+    MCPToolResult,
+)
 from agentos.tools.registry import ToolRegistry
 
 
@@ -16,11 +22,13 @@ class FakeMCPClient(MCPClient):
         self,
         config: MCPServerConfig,
         tools: list[MCPToolDef] | None = None,
+        resources: list[MCPResourceDef] | None = None,
         *,
         fail_list: bool = False,
     ) -> None:
         super().__init__(config)
         self.tools = tools or []
+        self.resources = resources or []
         self.fail_list = fail_list
         self.connected = False
         self.closed = False
@@ -38,6 +46,12 @@ class FakeMCPClient(MCPClient):
 
     async def call_tool(self, name: str, arguments: dict[str, Any]) -> MCPToolResult:
         return MCPToolResult(content=f"{name}:{arguments}")
+
+    async def list_resources(self) -> list[MCPResourceDef]:
+        return self.resources
+
+    async def read_resource(self, uri: str) -> list[MCPResourceContent]:
+        return [MCPResourceContent(uri=uri, text=f"content of {uri}")]
 
 
 @pytest_asyncio.fixture(autouse=True)

--- a/tests/test_mcp/test_stdio_client.py
+++ b/tests/test_mcp/test_stdio_client.py
@@ -363,6 +363,24 @@ for line in sys.stdin:
         }
     elif method == "tools/call":
         result = {"content": [{"type": "text", "text": message["params"]["arguments"]["text"]}]}
+    elif method == "resources/list":
+        result = {
+            "resources": [
+                {
+                    "uri": "demo://notes",
+                    "name": "Notes",
+                    "description": "Demo notes",
+                    "mimeType": "text/plain",
+                }
+            ]
+        }
+    elif method == "resources/read":
+        uri = message["params"]["uri"]
+        result = {
+            "contents": [
+                {"uri": uri, "mimeType": "text/plain", "text": "hello from resource"}
+            ]
+        }
     else:
         result = {}
     sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": message["id"], "result": result}) + "\\n")
@@ -416,3 +434,31 @@ async def test_concurrent_tool_calls_serialized_safely(tmp_path: Path) -> None:
     assert len(results) == 10
     assert [r.content for r in results] == [f"msg-{i}" for i in range(10)]
     assert all(not r.is_error for r in results)
+
+
+@pytest.mark.asyncio
+async def test_list_and_read_resources_from_stdio_server(tmp_path: Path) -> None:
+    """MCPStdioClient supports listing and reading MCP resources."""
+    server = tmp_path / "server.py"
+    server.write_text(_SPEC_COMPLIANT_SERVER)
+    client = MCPStdioClient(
+        MCPServerConfig(name="demo", transport="stdio", command=sys.executable, args=[str(server)])
+    )
+
+    try:
+        await client.connect()
+        resources = await client.list_resources()
+        contents = await client.read_resource("demo://notes")
+    finally:
+        await client.close()
+
+    assert len(resources) == 1
+    assert resources[0].uri == "demo://notes"
+    assert resources[0].name == "Notes"
+    assert resources[0].description == "Demo notes"
+    assert resources[0].mime_type == "text/plain"
+
+    assert len(contents) == 1
+    assert contents[0].uri == "demo://notes"
+    assert contents[0].text == "hello from resource"
+    assert contents[0].mime_type == "text/plain"


### PR DESCRIPTION
### Summary
Implements MCP resource inspection and retrieval methods (`list_resources` and `read_resource`) on `MCPClient` and its concrete implementations (`MCPStdioClient` and `MCPSessionClient` for SSE / Streamable HTTP).

### Changes
- Defined `MCPResourceDef` and `MCPResourceContent` dataclasses in `agentos.mcp.types` and exported them in `agentos.mcp`.
- Added abstract `list_resources` and `read_resource` methods to `MCPClient`.
- Implemented `list_resources` and `read_resource` in `MCPSessionClient` using the underlying MCP SDK session.
- Implemented JSON-RPC `resources/list` and `resources/read` handlers in `MCPStdioClient`.
- Added regression test `test_list_and_read_resources_from_stdio_server` covering resource listing and content reading over stdio.

### Verification
- `uv run ruff check src tests` (clean)
- `uv run mypy src/agentos --show-error-codes` (0 errors)
- `uv run pytest tests/test_mcp -v` (68 passed)
- `uv build --wheel` (clean)
closes #1549 