### PR TITLE
fix(telegram): remove the write-only per-sender profile map

### DIFF
--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -208,9 +208,6 @@ class TelegramChannel:
     _dedupe: EventDedupeCache = field(init=False, repr=False)
     _connected: bool = field(default=False, init=False, repr=False)
     _last_message_at: datetime | None = field(default=None, init=False, repr=False)
-    _known_sender_profiles: dict[str, dict[str, str]] = field(
-        default_factory=dict, init=False, repr=False
-    )
     bot_user_id: str | None = None
     bot_username: str | None = None
 
@@ -238,11 +235,6 @@ class TelegramChannel:
             "chat_id": str(message.channel_id or message.metadata.get("chat_id") or ""),
         }
 
-    def _remember_sender(self, message: IncomingMessage) -> None:
-        profile = self._sender_profile(message)
-        if profile["sender_id"]:
-            self._known_sender_profiles[profile["sender_id"]] = profile
-
     def record_access_denial(self, message: IncomingMessage, reason: str) -> None:
         """Create a durable pairing request for an unauthorized Telegram DM."""
         if reason != "not_paired" or bool(message.metadata.get("is_group")):
@@ -251,7 +243,6 @@ class TelegramChannel:
         sender_id = profile["sender_id"]
         if not sender_id:
             return
-        self._known_sender_profiles[sender_id] = profile
         try:
             result = self.pairing_store.request(
                 self.config.name,
@@ -705,7 +696,6 @@ class TelegramChannel:
         return payload
 
     def enqueue(self, message: IncomingMessage) -> None:
-        self._remember_sender(message)
         msg_id = str(message.metadata.get("message_id", ""))
         update_id = message.metadata.get("update_id")
         dedupe_key = f"{update_id}:{msg_id}" if update_id is not None else msg_id

--- a/tests/test_channels/test_telegram_sender_profiles.py
+++ b/tests/test_channels/test_telegram_sender_profiles.py
@@ -1,0 +1,65 @@
+"""Regression tests for the removed Telegram sender-profile map (#1542).
+
+``_known_sender_profiles`` was written on every inbound update (``enqueue``)
+and for unpaired-DM pairing requests (``record_access_denial``) but had no
+reader anywhere in ``src/`` or ``tests/``. The fix removes the field and its
+write sites entirely instead of bounding dead state. These tests pin the
+removal: the write-only state must never come back, ``enqueue`` keeps
+queueing inbound messages, and pairing requests keep carrying the sender
+profile.
+"""
+
+from __future__ import annotations
+
+from agentos.channel_pairing import ChannelPairingStore
+from agentos.channels.telegram import TelegramChannel, TelegramChannelConfig
+from agentos.channels.types import IncomingMessage
+
+
+def _channel() -> TelegramChannel:
+    return TelegramChannel(TelegramChannelConfig(token="token"))
+
+
+def _incoming(sender_id: str) -> IncomingMessage:
+    return IncomingMessage(
+        sender_id=sender_id,
+        channel_id="-100999",
+        content="hi",
+        metadata={"message_id": sender_id},
+    )
+
+
+def test_inbound_updates_leave_no_sender_profile_state() -> None:
+    channel = _channel()
+
+    for sender_id in range(1, 201):
+        channel.enqueue(_incoming(str(sender_id)))
+
+    # The write-only profile map is gone and must not be resurrected (#1542).
+    assert not hasattr(channel, "_known_sender_profiles")
+    assert not hasattr(channel, "_remember_sender")
+    assert not hasattr(channel, "_store_sender_profile")
+
+
+def test_enqueue_still_queues_inbound_messages() -> None:
+    channel = _channel()
+
+    channel.enqueue(_incoming("42"))
+
+    assert channel._queue.qsize() == 1
+
+
+def test_record_access_denial_keeps_pairing_without_profile_side_state(tmp_path) -> None:
+    channel = TelegramChannel(
+        TelegramChannelConfig(name="tg"),
+        pairing_store=ChannelPairingStore(tmp_path / "pairing"),
+    )
+    message = IncomingMessage(sender_id="42", channel_id="42", content="hi", metadata={})
+
+    channel.record_access_denial(message, "not_paired")
+
+    assert not hasattr(channel, "_known_sender_profiles")
+    pending = channel.access_snapshot()["pending"]
+    assert len(pending) == 1
+    assert pending[0]["sender_id"] == "42"
+    assert pending[0]["username"] == ""


### PR DESCRIPTION
Closes #1542

## Problem

`TelegramChannel._known_sender_profiles` was written on every inbound update (`enqueue()` → `_remember_sender()`) and on unpaired-DM pairing requests (`record_access_denial()`), but a grep across `src/` and `tests/` shows **no reader and no eviction anywhere** — pure unbounded memory growth driven by attacker-reachable input (any user messaging a public bot).

## Fix (updated per triage on #1542)

The first revision bounded the dict with an LRU cap. As the triage note points out, that keeps dead state alive — just less of it. This revision **deletes the field and both write sites entirely**:

- removed the `_known_sender_profiles` field, `_remember_sender()`, and the write inside `record_access_denial()` — the profile dict still flows into `pairing_store.request()`, its sole real consumer
- removed the `self._remember_sender(message)` call from `enqueue()` — the inbound hot path no longer performs any profile bookkeeping
- no planned reader exists (same grep finding the triage confirmed), so deletion is the correct terminal state

Net diff vs `main`: dead state gone, zero behavior change to queueing, dedupe, or pairing.

## Testing

- `tests/test_channels/test_telegram_sender_profiles.py` rewritten to pin the **removal**: after 200 inbound updates and a pairing denial, the write-only attributes must not exist (`hasattr` assertions); `enqueue()` still queues messages; `record_access_denial()` still creates a pairing request carrying the sender profile. Proven RED on `origin/main` (attribute present → 2 failed) → GREEN with the fix (3 passed).
- `uv run ruff check src tests` — clean
- `uv run mypy src/agentos --show-error-codes` — Success: no issues found in 625 source files
- `uv run pytest -q` full suite — 25 failed / 10231 passed / 3 errors, identical failure set to the clean-tree baseline
- Clean-tree baseline delta (`origin/main` @ 0d9c59a) — **zero regressions** (28 test-level failures on both trees, none touching `channels/`); the fix tree passes 3 additional tests (the new regression tests)
