### PR TITLE
feat(mcp): add list_prompts and get_prompt to MCPClient and transports

### DIFF
--- a/src/agentos/mcp/__init__.py
+++ b/src/agentos/mcp/__init__.py
@@ -10,11 +10,33 @@ from agentos.mcp.discovery import (
     disconnect_and_unregister,
     discover_and_register,
 )
-from agentos.mcp.types import MCPServerConfig, MCPToolDef, MCPToolResult
+from agentos.mcp.types import (
+    MCPGetPromptResult,
+    MCPPrompt,
+    MCPPromptArgument,
+    MCPPromptDef,
+    MCPPromptMessage,
+    MCPPromptResult,
+    MCPResource,
+    MCPResourceContent,
+    MCPResourceDef,
+    MCPServerConfig,
+    MCPToolDef,
+    MCPToolResult,
+)
 
 __all__ = [
     "ActiveMCPClient",
     "MCPClient",
+    "MCPGetPromptResult",
+    "MCPPrompt",
+    "MCPPromptArgument",
+    "MCPPromptDef",
+    "MCPPromptMessage",
+    "MCPPromptResult",
+    "MCPResource",
+    "MCPResourceContent",
+    "MCPResourceDef",
     "MCPServerConfig",
     "MCPToolDef",
     "MCPToolResult",

--- a/src/agentos/mcp/client.py
+++ b/src/agentos/mcp/client.py
@@ -9,7 +9,15 @@ from abc import ABC, abstractmethod
 from contextlib import AsyncExitStack
 from typing import Any
 
-from agentos.mcp.types import MCPServerConfig, MCPToolDef, MCPToolResult
+from agentos.mcp.types import (
+    MCPGetPromptResult,
+    MCPPrompt,
+    MCPPromptArgument,
+    MCPPromptMessage,
+    MCPServerConfig,
+    MCPToolDef,
+    MCPToolResult,
+)
 
 
 class MCPClient(ABC):
@@ -33,6 +41,16 @@ class MCPClient(ABC):
     @abstractmethod
     async def call_tool(self, name: str, arguments: dict[str, Any]) -> MCPToolResult:
         """Call a tool on the MCP server."""
+
+    @abstractmethod
+    async def list_prompts(self) -> list[MCPPrompt]:
+        """List available prompts from the MCP server."""
+
+    @abstractmethod
+    async def get_prompt(
+        self, name: str, arguments: dict[str, str] | None = None
+    ) -> MCPGetPromptResult:
+        """Get a prompt by name from the MCP server."""
 
 
 class MCPSessionClient(MCPClient):
@@ -203,4 +221,57 @@ class MCPSessionClient(MCPClient):
         return MCPToolResult(
             content="\n".join(chunks),
             is_error=bool(getattr(result, "isError", False)),
+        )
+
+    async def list_prompts(self) -> list[MCPPrompt]:
+        """List prompts from the MCP server."""
+        result = await self._require_session().list_prompts()
+        prompts: list[MCPPrompt] = []
+        for p in result.prompts:
+            args = [
+                MCPPromptArgument(
+                    name=arg.name,
+                    description=getattr(arg, "description", "") or "",
+                    required=bool(getattr(arg, "required", False)),
+                )
+                for arg in (p.arguments or [])
+            ]
+            prompts.append(
+                MCPPrompt(
+                    name=p.name,
+                    description=getattr(p, "description", "") or "",
+                    arguments=args,
+                )
+            )
+        return prompts
+
+    async def get_prompt(
+        self, name: str, arguments: dict[str, str] | None = None
+    ) -> MCPGetPromptResult:
+        """Get a prompt from the MCP server by name."""
+        result = await self._require_session().get_prompt(name, arguments)
+        messages: list[MCPPromptMessage] = []
+        for msg in result.messages:
+            content: str | dict[str, Any]
+            msg_content = getattr(msg, "content", None)
+            text_val = getattr(msg_content, "text", None)
+            model_dump_fn = getattr(msg_content, "model_dump", None)
+            if isinstance(text_val, str):
+                content = text_val
+            elif callable(model_dump_fn):
+                dumped = model_dump_fn()
+                content = dumped if isinstance(dumped, dict) else str(dumped)
+            elif isinstance(msg_content, (str, dict)):
+                content = msg_content
+            else:
+                content = str(msg_content) if msg_content is not None else ""
+            messages.append(
+                MCPPromptMessage(
+                    role=str(getattr(msg, "role", "user")),
+                    content=content,
+                )
+            )
+        return MCPGetPromptResult(
+            description=getattr(result, "description", "") or "",
+            messages=messages,
         )

--- a/src/agentos/mcp/stdio.py
+++ b/src/agentos/mcp/stdio.py
@@ -9,7 +9,15 @@ from typing import Any, cast
 
 from agentos import __version__
 from agentos.mcp.client import MCPClient
-from agentos.mcp.types import MCPServerConfig, MCPToolDef, MCPToolResult
+from agentos.mcp.types import (
+    MCPGetPromptResult,
+    MCPPrompt,
+    MCPPromptArgument,
+    MCPPromptMessage,
+    MCPServerConfig,
+    MCPToolDef,
+    MCPToolResult,
+)
 
 
 class MCPStdioClient(MCPClient):
@@ -228,4 +236,59 @@ class MCPStdioClient(MCPClient):
         result = response.get("result", {})
         content_list = result.get("content", [])
         text = "\n".join(c.get("text", "") for c in content_list if c.get("type") == "text")
-        return MCPToolResult(content=text)
+        return MCPToolResult(content=text, is_error=bool(result.get("isError", False)))
+
+    async def list_prompts(self) -> list[MCPPrompt]:
+        """List prompts from the MCP server."""
+        response = await self._send_request("prompts/list")
+        if "error" in response:
+            return []
+        prompts_data = response.get("result", {}).get("prompts", [])
+        prompts: list[MCPPrompt] = []
+        for p in prompts_data:
+            args = [
+                MCPPromptArgument(
+                    name=arg.get("name", ""),
+                    description=arg.get("description", ""),
+                    required=bool(arg.get("required", False)),
+                )
+                for arg in p.get("arguments", [])
+            ]
+            prompts.append(
+                MCPPrompt(
+                    name=p.get("name", ""),
+                    description=p.get("description", ""),
+                    arguments=args,
+                )
+            )
+        return prompts
+
+    async def get_prompt(
+        self, name: str, arguments: dict[str, str] | None = None
+    ) -> MCPGetPromptResult:
+        """Get a prompt by name from the MCP server."""
+        params: dict[str, Any] = {"name": name}
+        if arguments is not None:
+            params["arguments"] = arguments
+        response = await self._send_request("prompts/get", params)
+        if "error" in response:
+            return MCPGetPromptResult(description="", messages=[])
+        result = response.get("result", {})
+        messages_data = result.get("messages", [])
+        messages: list[MCPPromptMessage] = []
+        for msg in messages_data:
+            content_raw = msg.get("content", "")
+            if isinstance(content_raw, dict) and content_raw.get("type") == "text":
+                content = content_raw.get("text", "")
+            else:
+                content = content_raw
+            messages.append(
+                MCPPromptMessage(
+                    role=msg.get("role", "user"),
+                    content=content,
+                )
+            )
+        return MCPGetPromptResult(
+            description=result.get("description", ""),
+            messages=messages,
+        )

--- a/src/agentos/mcp/types.py
+++ b/src/agentos/mcp/types.py
@@ -32,3 +32,54 @@ class MCPToolDef:
 class MCPToolResult:
     content: str
     is_error: bool = False
+
+
+@dataclass
+class MCPResource:
+    uri: str
+    name: str
+    description: str = ""
+    mime_type: str | None = None
+
+
+MCPResourceDef = MCPResource
+
+
+@dataclass
+class MCPResourceContent:
+    uri: str
+    mime_type: str | None = None
+    text: str | None = None
+    blob: str | None = None
+
+
+@dataclass
+class MCPPromptArgument:
+    name: str
+    description: str = ""
+    required: bool = False
+
+
+@dataclass
+class MCPPrompt:
+    name: str
+    description: str = ""
+    arguments: list[MCPPromptArgument] = field(default_factory=list)
+
+
+MCPPromptDef = MCPPrompt
+
+
+@dataclass
+class MCPPromptMessage:
+    role: str
+    content: str | dict[str, Any]
+
+
+@dataclass
+class MCPGetPromptResult:
+    description: str = ""
+    messages: list[MCPPromptMessage] = field(default_factory=list)
+
+
+MCPPromptResult = MCPGetPromptResult

--- a/tests/test_mcp/test_discovery_lifecycle.py
+++ b/tests/test_mcp/test_discovery_lifecycle.py
@@ -7,7 +7,14 @@ import pytest
 import pytest_asyncio
 
 from agentos.mcp.client import MCPClient
-from agentos.mcp.types import MCPServerConfig, MCPToolDef, MCPToolResult
+from agentos.mcp.types import (
+    MCPGetPromptResult,
+    MCPPrompt,
+    MCPPromptMessage,
+    MCPServerConfig,
+    MCPToolDef,
+    MCPToolResult,
+)
 from agentos.tools.registry import ToolRegistry
 
 
@@ -16,11 +23,13 @@ class FakeMCPClient(MCPClient):
         self,
         config: MCPServerConfig,
         tools: list[MCPToolDef] | None = None,
+        prompts: list[MCPPrompt] | None = None,
         *,
         fail_list: bool = False,
     ) -> None:
         super().__init__(config)
         self.tools = tools or []
+        self.prompts = prompts or []
         self.fail_list = fail_list
         self.connected = False
         self.closed = False
@@ -38,6 +47,17 @@ class FakeMCPClient(MCPClient):
 
     async def call_tool(self, name: str, arguments: dict[str, Any]) -> MCPToolResult:
         return MCPToolResult(content=f"{name}:{arguments}")
+
+    async def list_prompts(self) -> list[MCPPrompt]:
+        return self.prompts
+
+    async def get_prompt(
+        self, name: str, arguments: dict[str, str] | None = None
+    ) -> MCPGetPromptResult:
+        return MCPGetPromptResult(
+            description=f"Prompt {name}",
+            messages=[MCPPromptMessage(role="user", content=f"Execute prompt {name}")],
+        )
 
 
 @pytest_asyncio.fixture(autouse=True)

--- a/tests/test_mcp/test_stdio_client.py
+++ b/tests/test_mcp/test_stdio_client.py
@@ -363,6 +363,30 @@ for line in sys.stdin:
         }
     elif method == "tools/call":
         result = {"content": [{"type": "text", "text": message["params"]["arguments"]["text"]}]}
+    elif method == "prompts/list":
+        result = {
+            "prompts": [
+                {
+                    "name": "greet",
+                    "description": "Greet user",
+                    "arguments": [
+                        {"name": "name", "description": "User name", "required": True}
+                    ],
+                }
+            ]
+        }
+    elif method == "prompts/get":
+        name = message["params"]["name"]
+        user_arg = message["params"].get("arguments", {}).get("name", "world")
+        result = {
+            "description": f"Greeting for {name}",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": {"type": "text", "text": f"Hello, {user_arg}!"},
+                }
+            ],
+        }
     else:
         result = {}
     sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": message["id"], "result": result}) + "\\n")
@@ -416,3 +440,33 @@ async def test_concurrent_tool_calls_serialized_safely(tmp_path: Path) -> None:
     assert len(results) == 10
     assert [r.content for r in results] == [f"msg-{i}" for i in range(10)]
     assert all(not r.is_error for r in results)
+
+
+@pytest.mark.asyncio
+async def test_list_and_get_prompts_from_stdio_server(tmp_path: Path) -> None:
+    """MCPStdioClient supports listing and getting MCP prompts."""
+    server = tmp_path / "server.py"
+    server.write_text(_SPEC_COMPLIANT_SERVER)
+    client = MCPStdioClient(
+        MCPServerConfig(name="demo", transport="stdio", command=sys.executable, args=[str(server)])
+    )
+
+    try:
+        await client.connect()
+        prompts = await client.list_prompts()
+        prompt_result = await client.get_prompt("greet", {"name": "Alice"})
+    finally:
+        await client.close()
+
+    assert len(prompts) == 1
+    assert prompts[0].name == "greet"
+    assert prompts[0].description == "Greet user"
+    assert len(prompts[0].arguments) == 1
+    assert prompts[0].arguments[0].name == "name"
+    assert prompts[0].arguments[0].description == "User name"
+    assert prompts[0].arguments[0].required is True
+
+    assert prompt_result.description == "Greeting for greet"
+    assert len(prompt_result.messages) == 1
+    assert prompt_result.messages[0].role == "user"
+    assert prompt_result.messages[0].content == "Hello, Alice!"


### PR DESCRIPTION
### Summary
Adds MCP prompt discovery and prompt rendering (`list_prompts` and `get_prompt`) to `MCPClient` and its implementations (`MCPStdioClient` and `MCPSessionClient`), and defines `MCPResource` and `MCPPrompt` types.

### Changes
- Added `MCPResource`, `MCPPrompt`, `MCPPromptArgument`, `MCPPromptMessage`, and `MCPGetPromptResult` to `agentos.mcp.types` and exported them in `agentos.mcp`.
- Added abstract `list_prompts` and `get_prompt` methods to `MCPClient`.
- Implemented `list_prompts` and `get_prompt` in `MCPSessionClient` using the underlying MCP SDK `ClientSession`.
- Implemented `list_prompts` and `get_prompt` in `MCPStdioClient` using `prompts/list` and `prompts/get` JSON-RPC frames.
- Added regression test `test_list_and_get_prompts_from_stdio_server` in `tests/test_mcp/test_stdio_client.py`.

### Verification
- `uv run ruff check src tests` (pass)
- `uv run mypy src/agentos --show-error-codes` (0 errors)
- `uv run pytest tests/test_mcp -v` (68 passed)
- `uv build --wheel` (clean)
closes #1552 