### PR TITLE
fix(tools): allow _apply_approval_elevated_mode to apply to agent and channel callers (Closes #1512)

### DIFF
--- a/src/agentos/tools/builtin/shell.py
+++ b/src/agentos/tools/builtin/shell.py
@@ -1360,7 +1360,12 @@ def _apply_approval_elevated_mode(entry: object) -> None:
     if mode not in ("on", "bypass", "full"):
         return
     ctx = current_tool_context.get()
-    if ctx is not None and ctx.caller_kind in {CallerKind.CLI, CallerKind.WEB}:
+    if ctx is not None and ctx.caller_kind in {
+        CallerKind.CLI,
+        CallerKind.WEB,
+        CallerKind.AGENT,
+        CallerKind.CHANNEL,
+    }:
         ctx.elevated = mode
 
 

--- a/tests/test_tools/test_shell_approval_policy.py
+++ b/tests/test_tools/test_shell_approval_policy.py
@@ -881,3 +881,65 @@ async def test_root_wipe_is_hard_blocked_at_the_exec_approval_boundary() -> None
         assert result["status"] == "blocked"
         assert result["reason"] == "sensitive_path"
         assert result["sensitive_path"] == "/"
+
+
+class _FakeApprovalEntry:
+    def __init__(self, elevated_mode: str | None = None) -> None:
+        self.params: dict[str, object] = {"elevatedMode": elevated_mode} if elevated_mode else {}
+
+
+def test_apply_approval_elevated_mode_sets_elevated_for_agent_and_channel() -> None:
+    ctx = current_tool_context.get()
+    assert ctx is not None
+
+    for caller in (CallerKind.AGENT, CallerKind.CHANNEL, CallerKind.CLI, CallerKind.WEB):
+        ctx.caller_kind = caller
+        ctx.elevated = None
+        shell._apply_approval_elevated_mode(_FakeApprovalEntry("bypass"))
+        assert ctx.elevated == "bypass", f"Failed for {caller}"
+
+        ctx.elevated = None
+        shell._apply_approval_elevated_mode(_FakeApprovalEntry("full"))
+        assert ctx.elevated == "full", f"Failed for {caller}"
+
+
+def test_apply_approval_elevated_mode_ignores_subagent() -> None:
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.caller_kind = CallerKind.SUBAGENT
+    ctx.elevated = None
+
+    shell._apply_approval_elevated_mode(_FakeApprovalEntry("bypass"))
+    assert ctx.elevated is None
+
+
+@pytest.mark.asyncio
+async def test_approval_resolution_with_elevated_mode_applies_to_agent_context() -> None:
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.caller_kind = CallerKind.AGENT
+    ctx.elevated = None
+
+    queue = get_approval_queue()
+    approval_id = queue.request(
+        namespace="exec",
+        params={
+            "toolName": "exec_command",
+            "command": "rm target.txt",
+            "sessionKey": ctx.session_key,
+        },
+    )
+    queue.resolve(approval_id, approved=True, elevated_mode="bypass")
+
+    # Retry the command with approval_id as an AGENT caller
+    result = await shell._check_exec_approval(
+        "exec_command",
+        "rm target.txt",
+        None,
+        "command requires approval",
+        approval_id,
+        False,
+    )
+    assert result is None
+    assert ctx.elevated == "bypass"
+


### PR DESCRIPTION
Closes #1512

## Summary

When an operator resolves an approval in the Web UI or CLI with an elevated mode (e.g. `elevatedMode: "bypass"`), `_apply_approval_elevated_mode` is called to update `ToolContext.elevated`. 

Previously, `_apply_approval_elevated_mode` only checked `ctx.caller_kind in {CallerKind.CLI, CallerKind.WEB}`. However, when an agent executes tools during an interactive turn, `ctx.caller_kind` is `CallerKind.AGENT`. As a result, the operator's "Bypass Approvals" decision was discarded and subsequent commands in the same turn continued prompting for approval.

This PR fixes this by:
1. Updating `_apply_approval_elevated_mode` in `shell.py` to allow `CallerKind.AGENT` and `CallerKind.CHANNEL` callers to receive the elevated mode when an approval is granted.
2. Adding unit tests in `test_shell_approval_policy.py` verifying that elevation applies to `AGENT` and `CHANNEL` contexts, that subagent contexts remain un-elevated, and that approval resolution with `elevated_mode="bypass"` successfully bypasses subsequent commands.

## Tests

- `uv run pytest tests/test_tools/test_shell_approval_policy.py -k "elevated_mode" -v` (3 passed)
- `uv run ruff check src/agentos/tools/builtin/shell.py tests/test_tools/test_shell_approval_policy.py` (0 errors)
- `uv run mypy src/agentos/tools/builtin/shell.py tests/test_tools/test_shell_approval_policy.py --show-error-codes` (0 errors)
