### PR TITLE
fix(tools): capture quoted shell write targets containing spaces

### DIFF
--- a/src/agentos/tools/builtin/shell.py
+++ b/src/agentos/tools/builtin/shell.py
@@ -339,7 +339,19 @@ _FD_DUP_PATTERN = re.compile(r"\d*>&\s*(?:\d+-?|-)(?=$|[\s|&;<>)])")
 # ``n>>``, ``&>``, ``&>>``, ``>&file`` and the noclobber override ``>|``. The
 # operator is deliberately *not* anchored to a word boundary — ``echo x>file`` is
 # valid shell and must be caught just like ``echo x > file``.
-_REDIRECTION_PATTERN = re.compile(r"(?:&>{1,2}|\d*>{1,2}&?)\|?\s*(['\"]?)([^'\"\s|&;<>()]+)\1")
+#
+# The quoted and unquoted cases need different bodies: a quoted target
+# (group 2) accepts anything but its own quote character, so a path
+# containing a space is captured whole; an unquoted target (group 3) keeps
+# the original restrictive class, since space there is a real argument
+# boundary and swallowing it would eat the rest of the command. A single
+# shared class that excludes whitespace unconditionally (the previous
+# design) made a quoted ``"/path with spaces.txt"`` invisible to this
+# scanner regardless of platform, which let workspace lockdown fail open
+# for any write target whose path happened to contain a space (#1230).
+_REDIRECTION_PATTERN = re.compile(
+    r"""(?:&>{1,2}|\d*>{1,2}&?)\|?\s*(?:(['"])([^'"]+)\1|([^'"\s|&;<>()]+))"""
+)
 
 # ``tee`` is the other write primitive this parser covers, and it needs the same
 # treatment as the redirection operators: ``echo x|tee /etc/passwd`` is valid
@@ -347,16 +359,21 @@ _REDIRECTION_PATTERN = re.compile(r"(?:&>{1,2}|\d*>{1,2}&?)\|?\s*(['\"]?)([^'\"\
 # space. The lookbehind keeps ``mytee``/``notee`` out while still matching a
 # fully qualified ``/usr/bin/tee``. Options may be short (``-a``), long
 # (``--append``) or long with a value (``--output-error=warn``); all of them are
-# skipped so the first non-option word is the real target.
+# skipped so the first non-option word is the real target. See
+# _REDIRECTION_PATTERN above for why the quoted and unquoted bodies differ.
 _TEE_PATTERN = re.compile(
-    r"(?<![\w-])tee(?:\s+-{1,2}[A-Za-z][\w-]*(?:=[^\s|&;]+)?)*\s+(['\"]?)([^'\"\s|&;]+)\1"
+    r"(?<![\w-])tee(?:\s+-{1,2}[A-Za-z][\w-]*(?:=[^\s|&;]+)?)*\s+"
+    r"""(?:(['"])([^'"]+)\1|([^'"\s|&;]+))"""
 )
 
 
 def _shell_write_targets(command: str) -> list[str]:
     scanned = _FD_DUP_PATTERN.sub(" ", command)
-    targets: list[str] = [match.group(2) for match in _REDIRECTION_PATTERN.finditer(scanned)]
-    targets.extend(match.group(2) for match in _TEE_PATTERN.finditer(scanned))
+    targets: list[str] = []
+    for pattern in (_REDIRECTION_PATTERN, _TEE_PATTERN):
+        for match in pattern.finditer(scanned):
+            target = match.group(2) if match.group(2) is not None else match.group(3)
+            targets.append(target)
     return targets
 
 

--- a/tests/test_tools/test_shell_approval_policy.py
+++ b/tests/test_tools/test_shell_approval_policy.py
@@ -524,6 +524,109 @@ def test_shell_write_targets_ignores_words_ending_in_tee(command: str) -> None:
     assert shell._shell_write_targets(command) == []
 
 
+@pytest.mark.parametrize(
+    "template",
+    [
+        'echo ok > "{target}"',
+        "echo ok > '{target}'",
+        'echo ok >> "{target}"',
+        'echo ok 2> "{target}"',
+        'echo ok &> "{target}"',
+    ],
+)
+def test_shell_write_targets_detects_quoted_redirection_with_spaces(template: str) -> None:
+    target = "/tmp/my outside dir/file with spaces.txt"
+    assert shell._shell_write_targets(template.format(target=target)) == [target]
+
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        'echo ok|tee "{target}"',
+        "echo ok | tee -a '{target}'",
+        'echo ok | tee --output-error=warn "{target}"',
+    ],
+)
+def test_shell_write_targets_detects_quoted_tee_target_with_spaces(template: str) -> None:
+    target = "/tmp/my outside dir/file with spaces.txt"
+    assert shell._shell_write_targets(template.format(target=target)) == [target]
+
+
+def test_shell_write_targets_quoted_redirection_survives_fd_dup_scan() -> None:
+    command = 'echo ok > "AT&T report.txt"'
+    assert shell._shell_write_targets(command) == ["AT&T report.txt"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "template",
+    [
+        'echo ok > "{target}"',
+        "echo ok > '{target}'",
+    ],
+)
+async def test_workspace_lockdown_blocks_quoted_redirection_target_with_spaces(
+    tmp_path: Path,
+    template: str,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside_dir = tmp_path / "my outside dir"
+    outside_dir.mkdir()
+    outside = outside_dir / "file with spaces.txt"
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.interaction_mode = InteractionMode.UNATTENDED
+    ctx.elevated = "bypass"
+    ctx.workspace_dir = str(workspace)
+    ctx.workspace_lockdown = True  # type: ignore[attr-defined]
+
+    result = await shell._check_exec_approval(
+        "exec_command",
+        template.format(target=outside),
+        str(workspace),
+        "command requires approval",
+        None,
+        False,
+    )
+
+    assert result is not None
+    assert result["status"] == "blocked"
+    assert result["reason"] == "workspace_lockdown"
+    assert result["resolved_path"] == str(outside)
+
+
+@pytest.mark.asyncio
+async def test_workspace_lockdown_blocks_quoted_tee_target_with_spaces(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside_dir = tmp_path / "my outside dir"
+    outside_dir.mkdir()
+    outside = outside_dir / "file with spaces.txt"
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.interaction_mode = InteractionMode.UNATTENDED
+    ctx.elevated = "bypass"
+    ctx.workspace_dir = str(workspace)
+    ctx.workspace_lockdown = True  # type: ignore[attr-defined]
+
+    result = await shell._check_exec_approval(
+        "exec_command",
+        f'echo ok | tee "{outside}"',
+        str(workspace),
+        "command requires approval",
+        None,
+        False,
+    )
+
+    assert result is not None
+    assert result["status"] == "blocked"
+    assert result["reason"] == "workspace_lockdown"
+    assert result["resolved_path"] == str(outside)
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "template",


### PR DESCRIPTION
Summary
_REDIRECTION_PATTERN and _TEE_PATTERN in shell.py excluded whitespace from the target group even when the target was quoted, so > "/tmp/my dir/x.txt" matched no write targets at all
With no targets found, _workspace_lockdown_shell_block and the write-deny-glob check both failed open — any command redirecting or piping into a quoted path containing a space bypassed workspace lockdown entirely, on every platform (not just Windows)
Fixed by giving quoted and unquoted targets separate regex bodies: a quoted target now accepts any character but its own quote mark, while an unquoted target keeps the original restrictive class (space there is still a real argument boundary)
Fixes #1230 

Test plan
 Added unit tests for quoted redirection/tee targets containing spaces (single and double quotes)
 Added a test confirming a quoted target containing & survives the _FD_DUP_PATTERN pre-pass
 Added block-envelope-level tests confirming _check_exec_approval returns status: blocked, reason: workspace_lockdown for quoted targets outside the workspace
 uv run pytest tests/test_tools/test_shell_approval_policy.py -q — 81 passed
 uv run pytest tests/test_tools -k shell -q — 140 passed
 uv run ruff check / uv run mypy clean on changed files