### PR TITLE
fix(intent): ignore rm inside a quoted argument

### DIFF
--- a/src/agentos/application/intent_cache.py
+++ b/src/agentos/application/intent_cache.py
@@ -183,6 +183,37 @@ def _rm_invocation_targets(tokens: list[str]) -> list[str]:
     return targets
 
 
+def _quoted_mask(command: str) -> list[bool]:
+    """Mark every index that falls inside a single- or double-quoted span.
+
+    Not a full shell parser — just enough to tell a command word from text
+    that merely contains one, e.g. the ``rm`` inside ``grep -rn "rm"
+    /etc/passwd`` is a grep pattern, not an invocation. A backslash right
+    before the current quote character escapes it inside double quotes
+    (matching ``shlex``/POSIX); single-quoted spans have no escape, same as
+    a real shell.
+    """
+    mask = [False] * len(command)
+    quote: str | None = None
+    i = 0
+    n = len(command)
+    while i < n:
+        ch = command[i]
+        if quote is not None:
+            mask[i] = True
+            if quote == '"' and ch == "\\" and i + 1 < n:
+                mask[i + 1] = True
+                i += 2
+                continue
+            if ch == quote:
+                quote = None
+        elif ch in ("'", '"'):
+            quote = ch
+            mask[i] = True
+        i += 1
+    return mask
+
+
 def _extract_rm_targets(command: str) -> list[tuple[str, frozenset[str]]]:
     """Pull every ``rm`` argument out, tagged with that invocation's flags.
 
@@ -192,12 +223,20 @@ def _extract_rm_targets(command: str) -> list[tuple[str, frozenset[str]]]:
     set, so the ``-rf`` on the second does not leak onto the first. Does not
     try to be a full shell parser — falls back to whitespace split on shlex
     errors (unbalanced quotes).
+
+    An ``rm`` occurrence is not anchored to the start of the command or to a
+    position right after a separator — ``sudo rm -rf X``, ``env FOO=1 rm -rf
+    X`` and ``time rm -rf X`` must all still match. Instead, a match is
+    skipped only when it falls inside a quoted span, so ``grep -rn "rm"
+    /etc/passwd`` or a commit message like ``git commit -m "rm the old
+    config"`` reads as text, not as a delete.
     """
     # Match each ``rm`` invocation, stopping at shell separators.
     # ``[^;\n&|]*`` captures everything from ``rm`` up to the next separator
     # or end-of-expression, so each ``rm`` is tokenized independently.
     pattern = re.compile(r"\brm\b([^;\n&|]*)")
-    matches = list(pattern.finditer(command))
+    quoted = _quoted_mask(command)
+    matches = [m for m in pattern.finditer(command) if not quoted[m.start()]]
     if not matches:
         return []
 

--- a/tests/test_application/test_intent_cache.py
+++ b/tests/test_application/test_intent_cache.py
@@ -50,6 +50,55 @@ class TestCompoundCommandSeparatorBypass:
         self._check_separator("\n")
 
 
+class TestQuotedRmWordIsNotAnInvocation:
+    """Regression tests for issue #1349.
+
+    ``_extract_rm_targets`` matched ``\\brm\\b`` anywhere in the command,
+    including inside a quoted argument, so a read-only command that merely
+    mentions the word ``rm`` in quotes registered a spurious delete intent.
+    Combined with ``sensitive_target_in_command`` (which calls through to
+    ``_extract_intents``), that false positive hard-blocked read-only
+    commands naming a sensitive path — a block only ``/elevated full``
+    could clear.
+
+    The fix must not anchor ``rm`` to a command position (start of string,
+    or right after a separator): prefixed invocations like ``sudo rm -rf``,
+    ``env FOO=1 rm -rf`` and ``time rm -rf`` have to stay detected. Only a
+    match that falls inside a quoted span is skipped.
+    """
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            'grep -rn "rm" /etc/passwd',
+            'git commit -m "rm the old config" /etc/hosts',
+            'echo "use rm carefully" >> /root/notes.md',
+            "grep -rn 'rm' /etc/passwd",
+        ],
+    )
+    def test_quoted_rm_word_yields_no_delete_intent(self, command: str) -> None:
+        assert _extract_intents(command) == []
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "sudo rm -rf /etc",
+            "env FOO=1 rm -rf /etc",
+            "time rm -rf /etc",
+        ],
+    )
+    def test_prefixed_rm_invocation_still_detected(self, command: str) -> None:
+        kinds = {kind for kind, _ in _extract_intents(command)}
+        assert kinds == {"delete:recursive+force"}
+
+    def test_quoted_rm_word_does_not_suppress_a_real_rm_later_in_the_command(
+        self,
+    ) -> None:
+        command = 'echo "rm test" ; rm -rf /tmp/x'
+        kinds = {kind for kind, _ in _extract_intents(command)}
+        assert kinds == {"delete:recursive+force"}
+
+
 class TestMultiTargetApproval:
     """Multi-target commands must require approval for all targets."""
 

--- a/tests/test_sandbox/test_sensitive_paths.py
+++ b/tests/test_sandbox/test_sensitive_paths.py
@@ -131,6 +131,36 @@ def test_every_rm_in_a_compound_command_is_checked() -> None:
     )
 
 
+def test_quoted_rm_word_does_not_hard_block_a_read_only_command() -> None:
+    """Issue #1349: a read-only command that merely mentions ``rm`` inside a
+    quoted argument must not be treated as a delete of a sensitive path.
+
+    ``_extract_intents`` (via ``_extract_rm_targets``) previously matched
+    ``\\brm\\b`` anywhere in the command, including inside quotes, so
+    ``grep -rn "rm" /etc/passwd`` registered a spurious delete intent on
+    ``/etc/passwd`` and was hard-blocked — a block only ``/elevated full``
+    can clear, so the operator could not approve their way past it.
+    """
+    for command in (
+        'grep -rn "rm" /etc/passwd',
+        'git commit -m "rm the old config" /etc/hosts',
+        'echo "use rm carefully" >> /root/notes.md',
+    ):
+        assert sensitive_target_in_command(command) is None, command
+
+
+def test_prefixed_rm_invocations_are_still_hard_blocked() -> None:
+    """Issue #1349 caveat: the fix must not anchor ``rm`` to a command
+    position, or ``sudo``/``env``/``time``-prefixed invocations would stop
+    being detected."""
+    for command in (
+        "sudo rm -rf /etc",
+        "env FOO=1 rm -rf /etc",
+        "time rm -rf /etc",
+    ):
+        assert sensitive_target_in_command(command) == "/etc", command
+
+
 def test_sensitive_reads_in_a_later_segment_are_blocked_at_the_tool_boundary() -> None:
     """Issue #676: the delete-intent scan only sees ``rm`` targets, so a
     non-destructive second segment (``cat /root/.bash_history``) is caught by


### PR DESCRIPTION
Summary
_extract_rm_targets matched \brm\b anywhere in the command, including inside a quoted string, so grep -rn "rm" /etc/passwd registered a spurious delete intent on /etc/passwd
sensitive_target_in_command calls through to _extract_intents, so that false positive hard-blocked the read-only command — a block documented as surviving normal approval, where only /elevated full clears it, leaving the operator unable to approve past it
Fixed by adding _quoted_mask, a small quote-state scanner that flags which positions in the command fall inside a single- or double-quoted span; _extract_rm_targets now skips any rm match that starts inside one
The match is deliberately not anchored to a command position — sudo rm -rf X, env FOO=1 rm -rf X, and time rm -rf X all still have to be detected, so only quoting (not position) suppresses a match
Separate from #1015 (the under-blocking counterpart, about verbs the extractor should recognize) — kept independent per review guidance
Fixes #1349 

Test plan
 Added TestQuotedRmWordIsNotAnInvocation in test_intent_cache.py: the three false-positive commands from the issue yield [], the three prefixed commands (sudo/env/time) stay detected, and a quoted "rm" doesn't suppress a real rm later in the same command
 Added matching tests in test_sensitive_paths.py at the sensitive_target_in_command level — both the false-positive commands returning None and the prefixed commands still returning /etc
 uv run pytest tests/test_application/test_intent_cache.py tests/test_sandbox/test_sensitive_paths.py tests/test_tools/test_shell_approval_policy.py -q — 191 passed
 uv run ruff check / uv run mypy clean on changed files