### PR TITLE
fix(tools): safely handle CSV fields exceeding default 128KB limit in read_spreadsheet

### DIFF
--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -11,6 +11,7 @@ import json
 import os
 import posixpath
 import re
+import sys
 import zipfile
 from pathlib import Path
 from xml.etree import ElementTree as ET
@@ -588,12 +589,32 @@ async def read_spreadsheet(
     )
 
 
+def _ensure_csv_field_size_limit() -> None:
+    """Ensure csv.field_size_limit is set to the maximum supported by the runtime platform.
+
+    On 64-bit Unix platforms sys.maxsize fits in a C long, while on 64-bit Windows
+    C long is 32-bit and sys.maxsize raises OverflowError. We step down until the
+    underlying C runtime accepts the limit.
+    """
+    limit = sys.maxsize
+    while True:
+        try:
+            csv.field_size_limit(limit)
+            break
+        except OverflowError:
+            limit = int(limit / 10)
+
+
 def _read_delimited_rows(path: Path, delimiter: str) -> list[tuple[str, list[list[str]]]]:
     try:
         text = path.read_text(encoding="utf-8-sig")
     except UnicodeDecodeError as exc:
         raise ToolError(f"Cannot read spreadsheet as UTF-8 text: {path}") from exc
-    rows = [list(row) for row in csv.reader(io.StringIO(text), delimiter=delimiter)]
+    _ensure_csv_field_size_limit()
+    try:
+        rows = [list(row) for row in csv.reader(io.StringIO(text), delimiter=delimiter)]
+    except csv.Error as exc:
+        raise ToolError(f"Cannot parse spreadsheet {path.name}: {exc}") from exc
     return [(path.name, rows)]
 
 

--- a/tests/test_tools/test_csv_multiline_fields.py
+++ b/tests/test_tools/test_csv_multiline_fields.py
@@ -121,3 +121,57 @@ def test_unicode_line_separator_inside_field_not_treated_as_row_break(
     assert len(rows) == 2, f"Expected 2 rows for {label!r}, got {len(rows)}"
     assert rows[0] == ["a", "b"]
     assert rows[1] == [f"x{sep}y", "z"]
+
+
+# ── Large fields exceeding default 128KB limit (#1580) ──────────────────
+
+
+def test_csv_field_larger_than_128kb_succeeds(tmp_path: Path) -> None:
+    """Fields exceeding standard library 131,072-char limit must parse (#1580)."""
+    large_payload = "A" * 150_000
+    csv_content = f"id,payload\n1,{large_payload}\n"
+    csv_file = tmp_path / "large.csv"
+    csv_file.write_text(csv_content, encoding="utf-8")
+
+    [(_, rows)] = _read_delimited_rows(csv_file, ",")
+
+    assert len(rows) == 2
+    assert rows[0] == ["id", "payload"]
+    assert rows[1] == ["1", large_payload]
+
+
+@pytest.mark.asyncio
+async def test_read_spreadsheet_large_field_end_to_end(tmp_path: Path) -> None:
+    """read_spreadsheet must return formatted output for CSV with large fields (#1580)."""
+    from agentos.tools.builtin.filesystem import read_spreadsheet
+
+    large_payload = "X" * 140_000
+    csv_file = tmp_path / "large_e2e.csv"
+    csv_file.write_text(f"col1,col2\nval1,{large_payload}\n", encoding="utf-8")
+
+    result = await read_spreadsheet(str(csv_file))
+    assert "Sheet: large_e2e.csv (2 rows x 2 columns)" in result
+    assert "val1" in result
+    assert large_payload in result
+
+
+def test_csv_error_translated_to_tool_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """csv.Error during delimited row parsing must raise ToolError (#1580)."""
+    import csv
+
+    from agentos.tools.types import ToolError
+
+    csv_file = tmp_path / "corrupt.csv"
+    csv_file.write_text("a,b\n1,2\n", encoding="utf-8")
+
+    def _failing_reader(*args: object, **kwargs: object) -> object:
+        raise csv.Error("simulated csv parser error")
+
+    monkeypatch.setattr(csv, "reader", _failing_reader)
+
+    with pytest.raises(
+        ToolError, match="Cannot parse spreadsheet corrupt.csv: simulated csv parser error"
+    ):
+        _read_delimited_rows(csv_file, ",")


### PR DESCRIPTION
Fixes #1580

- [x] This pull request fully resolves the linked issue, or the description says what remains.

## Summary

In `_read_delimited_rows` within `src/agentos/tools/builtin/filesystem.py`, CSV/TSV parsing uses Python's standard library `csv.reader`. By default, Python caps field sizes at 131,072 characters (`csv.field_size_limit()`). When encountering cells exceeding 128 KB (such as embedded JSON payloads, base64 strings, logs, or long text columns), `csv.reader` raised an unhandled `_csv.Error: field larger than field limit (131072)` which crashed the tool execution executor.

This PR:
1. Adds `_ensure_csv_field_size_limit()` to safely maximize `csv.field_size_limit` across platforms, stepping down from `sys.maxsize` on 64-bit Windows (where C `long` is 32-bit and `sys.maxsize` raises `OverflowError`) to ensure the largest possible field size is supported.
2. Ensures `_ensure_csv_field_size_limit()` is active in `_read_delimited_rows`.
3. Wraps `csv.reader` row parsing in `try ... except csv.Error as exc:` to translate any CSV parsing failures into a clean, actionable `ToolError(f"Cannot parse spreadsheet {path.name}: {exc}")`.
4. Adds unit and regression tests in `tests/test_tools/test_csv_multiline_fields.py` for fields >128 KB, end-to-end `read_spreadsheet` formatting, and `csv.Error` translation.

## Tests

Ran unit test suite, linter, and type checker:

```powershell
# 1. New and existing regression tests
pytest tests/test_tools/test_csv_multiline_fields.py -q
# Result: 15 passed in 4.36s

# 2. Related filesystem workspace tests
pytest tests/test_tools/test_filesystem_read_workspace.py tests/test_security/test_file_read_redaction.py -q
# Result: 46 passed, 4 skipped in 7.61s

# 3. Ruff lint check
ruff check src/agentos/tools/builtin/filesystem.py tests/test_tools/test_csv_multiline_fields.py
# Result: All checks passed!

# 4. Mypy type check
mypy src/agentos/tools/builtin/filesystem.py --show-error-codes
# Result: Success: no issues found in 1 source file
