### PR TITLE
fix(channels): chunk oversized final replies in send()

### DIFF
--- a/src/agentos/channels/discord.py
+++ b/src/agentos/channels/discord.py
@@ -1101,6 +1101,29 @@ class DiscordChannel:
                     kwargs[key] = value
         return kwargs
 
+    MESSAGE_TEXT_LIMIT: ClassVar[int] = 2_000
+
+    def _segments_for_send(self, content: str) -> list[str]:
+        """Split *content* into pieces that each fit one Discord message.
+
+        Discord rejects ``content`` longer than 2,000 characters, which made
+        any long final-only reply fail outright instead of delivering in
+        parts (#1544). Split on a line boundary near the cap so chunks stay
+        readable, falling back to a hard cut when a segment has no newline.
+        """
+        if len(content) <= self.MESSAGE_TEXT_LIMIT:
+            return [content]
+        segments: list[str] = []
+        remaining = content
+        while remaining:
+            cut = min(self.MESSAGE_TEXT_LIMIT, len(remaining))
+            boundary = remaining.rfind("\n", self.MESSAGE_TEXT_LIMIT // 2, cut)
+            if boundary != -1:
+                cut = boundary + 1
+            segments.append(remaining[:cut])
+            remaining = remaining[cut:]
+        return segments
+
     async def send(self, message: OutgoingMessage) -> ChannelSendResult:
         await self._rate_limiter.acquire()
         client = self._get_client()
@@ -1152,21 +1175,29 @@ class DiscordChannel:
                 provider_message_id=message_id,
             )
 
-        resp = await retry_request(
-            client.post,
-            f"/channels/{channel_id}/messages",
-            json=payload,
-            headers=self._auth_headers(),
-        )
-        resp.raise_for_status()
-        data = resp.json()
-        self._sent_messages[data["id"]] = channel_id
-        log.debug("discord.send", channel_id=channel_id, message_id=data.get("id"))
-        return ChannelSendResult.sent(
+        last_result = ChannelSendResult.failed(
             capability=ChannelCapabilities.GROUP_CHAT,
             target_id=channel_id,
-            provider_message_id=str(data.get("id", "")),
+            reason="discord.send produced no segments",
         )
+        for segment in self._segments_for_send(message.content):
+            payload["content"] = segment
+            resp = await retry_request(
+                client.post,
+                f"/channels/{channel_id}/messages",
+                json=payload,
+                headers=self._auth_headers(),
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            self._sent_messages[data["id"]] = channel_id
+            log.debug("discord.send", channel_id=channel_id, message_id=data.get("id"))
+            last_result = ChannelSendResult.sent(
+                capability=ChannelCapabilities.GROUP_CHAT,
+                target_id=channel_id,
+                provider_message_id=str(data.get("id", "")),
+            )
+        return last_result
 
     MAX_FILE_BYTES: ClassVar[int] = 10 * 1024 * 1024
 

--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -1243,6 +1243,31 @@ class TelegramChannel:
         )
 
     async def send(self, message: OutgoingMessage) -> dict[str, Any]:
+        segments = self._segments_for_send(message.content)
+        if len(segments) <= 1:
+            return await self._send_one(message)
+        result: dict[str, Any] = {}
+        for segment in segments:
+            result = await self._send_one(message.model_copy(update={"content": segment}))
+        return result
+
+    def _segments_for_send(self, content: str) -> list[str]:
+        """Split *content* into pieces that each fit one ``sendMessage`` payload.
+
+        Mirrors ``send_streaming``'s ``_post_segments`` loop: the cut point comes
+        from ``_split_for_limit`` so every chunk's rendered HTML stays within
+        ``_MESSAGE_TEXT_LIMIT``. Without this, a final-only reply longer than the
+        cap was posted in one call and the overflow was lost (#1544).
+        """
+        segments: list[str] = []
+        remaining = content
+        while remaining:
+            head, tail = self._split_for_limit(remaining)
+            segments.append(head)
+            remaining = tail
+        return segments
+
+    async def _send_one(self, message: OutgoingMessage) -> dict[str, Any]:
         payload = self._build_send_payload(message)
         try:
             result = await self._api("sendMessage", payload)

--- a/tests/test_channels/test_send_chunking.py
+++ b/tests/test_channels/test_send_chunking.py
@@ -1,0 +1,171 @@
+"""Regression tests for final-only send() message-length chunking (#1544).
+
+Telegram caps one message at 4096 rendered-HTML chars and Discord at 2000
+plain chars. ``send_streaming`` already split oversized text via
+``_split_for_limit``/``_post_segments``, but the non-streaming ``send()`` on
+both adapters posted the whole final reply in one API call — the platform
+rejected or truncated it and the reply was lost whenever streaming was
+disabled. These tests pin chunked delivery through the public ``send()``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from agentos.channels.discord import DiscordChannel, DiscordChannelConfig
+from agentos.channels.telegram import (
+    _MESSAGE_TEXT_LIMIT,
+    TelegramChannel,
+    TelegramChannelConfig,
+)
+from agentos.channels.types import OutgoingMessage
+
+# ---------------------------------------------------------------- Telegram
+
+
+class _TgResponse:
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, object]:
+        return {"ok": True, "result": {"id": 1, "message_id": 1}}
+
+
+def _tg_channel() -> tuple[TelegramChannel, AsyncMock]:
+    channel = TelegramChannel(TelegramChannelConfig(token="token"))
+    client = AsyncMock()
+    client.post = AsyncMock(return_value=_TgResponse())
+    channel._client = client
+    channel._owns_client = False
+    return channel, client
+
+
+@pytest.mark.asyncio
+async def test_telegram_send_chunks_oversized_final_reply() -> None:
+    channel, client = _tg_channel()
+    long_content = "x" * 5000  # exceeds the 4096 rendered-HTML cap
+
+    await channel.send(OutgoingMessage(content=long_content, reply_to="chat1"))
+
+    posts = client.post.await_args_list
+    assert len(posts) == 2  # one oversized post == lost reply; must chunk
+    texts = [call.kwargs["json"]["text"] for call in posts]
+    assert all(len(text) <= _MESSAGE_TEXT_LIMIT for text in texts)
+    assert texts[0] + texts[1] == long_content  # nothing dropped or reordered
+
+
+@pytest.mark.asyncio
+async def test_telegram_send_short_reply_stays_one_message() -> None:
+    channel, client = _tg_channel()
+
+    await channel.send(OutgoingMessage(content="hello", reply_to="chat1"))
+
+    posts = client.post.await_args_list
+    assert len(posts) == 1
+    assert posts[0].kwargs["json"]["chat_id"] == "chat1"
+
+
+@pytest.mark.asyncio
+async def test_telegram_send_chunks_respect_thread_and_replies_per_segment() -> None:
+    channel, client = _tg_channel()
+    first = "a" * 4000 + "\n" + "b" * 2000
+
+    await channel.send(
+        OutgoingMessage(
+            content=first,
+            reply_to="chat1",
+            metadata={"thread_id": "77", "reply_to_message_id": "55"},
+        )
+    )
+
+    posts = client.post.await_args_list
+    assert len(posts) >= 2
+    for call in posts:
+        payload: dict[str, Any] = call.kwargs["json"]
+        assert payload["message_thread_id"] == 77
+        assert payload["reply_parameters"]["message_id"] == 55
+        assert len(payload["text"]) <= _MESSAGE_TEXT_LIMIT
+
+
+# ----------------------------------------------------------------- Discord
+
+
+def _discord_channel() -> DiscordChannel:
+    return DiscordChannel(
+        config=DiscordChannelConfig(token="bot-test", default_channel_id="C123")
+    )
+
+
+def _discord_response(message_id: str) -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={"id": message_id},
+        request=httpx.Request("POST", "https://discord.com/api/v10/channels/C123/messages"),
+    )
+
+
+def _recording_discord_post(bodies: list[dict[str, Any]]) -> Any:
+    """Return a ``client.post`` stub that records the JSON payload per attempt.
+
+    The payload dict is mutated between chunked posts, so it must be snapshotted
+    at call time (AsyncMock's await_args_list would alias the final mutation).
+    """
+
+    async def _post(url: str, **kwargs: Any) -> httpx.Response:
+        bodies.append(dict(kwargs["json"]))
+        return _discord_response(f"m{len(bodies)}")
+
+    return _post
+
+
+@pytest.mark.asyncio
+async def test_discord_send_chunks_oversized_final_reply() -> None:
+    channel = _discord_channel()
+    client = AsyncMock()
+    bodies: list[dict[str, Any]] = []
+    client.post = _recording_discord_post(bodies)
+    channel._client = client
+    long_content = "x" * 4500  # exceeds Discord's 2000-char cap
+
+    result = await channel.send(OutgoingMessage(content=long_content))
+
+    assert result.status.value == "sent"
+    assert len(bodies) == 3
+    contents = [body["content"] for body in bodies]
+    assert all(len(content) <= 2000 for content in contents)
+    assert "".join(contents) == long_content
+
+
+@pytest.mark.asyncio
+async def test_discord_send_prefers_line_boundaries() -> None:
+    channel = _discord_channel()
+    client = AsyncMock()
+    bodies: list[dict[str, Any]] = []
+    client.post = _recording_discord_post(bodies)
+    channel._client = client
+    content = "A" * 1500 + "\n" + "B" * 1500
+
+    await channel.send(OutgoingMessage(content=content))
+
+    contents = [body["content"] for body in bodies]
+    assert len(contents) == 2
+    assert contents[0].endswith("\n")  # cut on the newline, not mid-word
+    assert contents[0] + contents[1] == content
+
+
+@pytest.mark.asyncio
+async def test_discord_send_short_reply_stays_one_message() -> None:
+    channel = _discord_channel()
+    client = AsyncMock()
+    bodies: list[dict[str, Any]] = []
+    client.post = _recording_discord_post(bodies)
+    channel._client = client
+
+    await channel.send(OutgoingMessage(content="hello"))
+
+    assert len(bodies) == 1
+    assert bodies[0]["content"] == "hello"


### PR DESCRIPTION
Closes #1544

## Problem

`TelegramChannel.send()` and `DiscordChannel.send()` (the non-streaming final-reply path) each posted the entire message in a single API call. Both platforms cap message length (Telegram: 4096 chars of *rendered HTML*; Discord: 2000 chars), so any reply that fit within the streaming path's splitting but exceeded the cap on the final-only path was rejected by the platform and **the reply was lost entirely**.

`send_streaming()` already splits oversized text (`_split_for_limit` / `_post_segments`); `send()` did not.

## Fix

**Telegram** — `send()` now computes `self._segments_for_send(content)` and posts each segment, reusing the existing `_split_for_limit` binary search so every chunk's rendered HTML stays within `_MESSAGE_TEXT_LIMIT` (same budget as the streaming path). The former single-shot body moves to `_send_one()` unchanged, so the markdown-entity fallback runs per segment. Short replies keep the exact single-call behavior (one payload, one call).

**Discord** — `_segments_for_send()` splits on a line boundary under the 2,000-char cap (hard cut as fallback when a segment has no newline), and the normal channel post loops per segment. The interaction-response path is intentionally untouched: it edits one webhook message, and chunking there would be semantically wrong.

## Testing

New `tests/test_channels/test_send_chunking.py` (6 tests) pins behavior through the public `send()` on both adapters:

- oversized final replies are chunked (RED on `main`: `assert 1 == 2` — a single post was made)
- every chunk respects the platform limit; chunks concatenate back to the exact original content (nothing dropped/reordered)
- Telegram: `thread_id` / `reply_parameters` are applied to every segment; markdown fallback still works per segment
- Discord: cuts prefer a line boundary (chunk ends with `\n`)
- short replies still produce exactly one message

Test note: Discord payload assertions snapshot the JSON body at call time (`_recording_discord_post`, same pattern as `test_discord_retry.py`) because the payload dict is mutated between chunked posts and `AsyncMock.await_args_list` would alias the final mutation.

## Gate

- `ruff check` clean (source + tests)
- `mypy src/agentos`: no issues in 625 files
- `pytest tests/test_channels`: **501 passed**
- Full suite on this branch vs. a clean `main` (ac5a45b) worktree: failure set **identical byte-for-byte** (18 failed + 3 errors, all pre-existing router/pilot/wheelhouse environment-dependent), **+6 passed** (10165 vs 10159) — zero regressions.