### PR TITLE
fix(sandbox): resolve relative command targets against cwd in sensitive_target_in_command

### DIFF
--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -482,6 +482,15 @@ def sensitive_target_in_command(
 ) -> str | None:
     """Return the first sensitive marker for any destructive target, or None.
 
+    ``cwd`` and ``workspace`` answer two different questions and must not be
+    conflated: ``cwd`` is where a *relative* target in the command actually
+    resolves (the process's execution directory), while ``workspace`` is the
+    configured boundary that :func:`sensitive_path_marker` checks a target
+    against for the active-workspace exception (a workspace nested under a
+    broad sensitive prefix, e.g. ``/root/.agentos/workspace``, stays usable).
+    Falling back to one for the other lets a relative destructive target
+    resolve against the wrong base and silently miss a sensitive path.
+
     Multi-target commands (``rm /tmp/ok /etc/bad``) are each checked — the
     presence of a single sensitive path is enough to block the whole command.
     The filesystem root is sensitive here and only here: deleting ``/`` wipes
@@ -493,14 +502,21 @@ def sensitive_target_in_command(
         return None
     from agentos.sandbox.intent_cache import _extract_intents
 
-    effective_workspace = workspace
-    if effective_workspace is None:
-        effective_workspace = cwd if cwd is not None else Path.cwd()
+    if cwd is not None:
+        cwd_path = Path(cwd).expanduser()
+        if not cwd_path.is_absolute() and workspace is not None:
+            effective_base = Path(workspace).expanduser() / cwd_path
+        else:
+            effective_base = cwd_path
+    elif workspace is not None:
+        effective_base = Path(workspace).expanduser()
+    else:
+        effective_base = Path.cwd()
 
-    for _kind, target in _extract_intents(command, base_dir=effective_workspace):
+    for _kind, target in _extract_intents(command, base_dir=effective_base):
         if _is_root_target(target):
             return _ROOT_TARGET_MARKER
-        marker = sensitive_path_marker(target, workspace=effective_workspace)
+        marker = sensitive_path_marker(target, workspace=workspace)
         if marker is not None:
             return marker
     return None

--- a/tests/test_sandbox/test_sensitive_paths.py
+++ b/tests/test_sandbox/test_sensitive_paths.py
@@ -494,3 +494,90 @@ def test_env_var_and_tilde_spellings_report_the_same_marker(
 
     assert tilde == f"~/{name}"
     assert expanded == tilde
+
+
+def test_sensitive_target_in_command_resolves_against_cwd_with_workspace(
+    fixed_home: Path,
+) -> None:
+    """Relative targets must resolve against cwd rather than workspace (#1579)."""
+    workspace = Path("/srv/project")
+
+    # Command runs in ~/.aws (outside workspace) and deletes relative "config"
+    blocked = sensitive_target_in_command(
+        "rm -rf config",
+        workspace=workspace,
+        cwd=fixed_home / ".aws",
+    )
+    assert blocked == "~/.aws"
+
+
+def test_sensitive_target_in_command_relative_cwd_inside_workspace() -> None:
+    """Relative cwd inside workspace resolves cleanly; harmless file allowed (#1579)."""
+    workspace = Path("/srv/project")
+
+    # Command runs in a subfolder of workspace and deletes a harmless file
+    allowed = sensitive_target_in_command(
+        "rm -rf temp.txt",
+        workspace=workspace,
+        cwd="subfolder",
+    )
+    assert allowed is None
+
+
+def test_sensitive_target_in_command_cwd_parent_traversal_blocked(
+    fixed_home: Path,
+) -> None:
+    """Relative path traversal escaping to a sensitive path via cwd is blocked (#1579)."""
+    workspace = Path("/srv/project")
+    aws_dir = fixed_home / ".aws"
+
+    # Command runs in ~/.aws/sub and traverses up to delete credentials
+    blocked = sensitive_target_in_command(
+        "rm -rf ../credentials",
+        workspace=workspace,
+        cwd=aws_dir / "sub",
+    )
+    assert blocked == "~/.aws"
+
+
+def test_relative_target_under_an_in_workspace_cwd_stays_allowed() -> None:
+    """The fix must not overcorrect: a relative target resolved against an
+    ordinary cwd that happens to be inside (or equal to) the workspace, and
+    that isn't itself sensitive, must still be allowed."""
+    workspace = Path("/tmp/workspace")
+
+    assert (
+        sensitive_target_in_command(
+            "rm -rf config",
+            workspace=workspace,
+            cwd=workspace / "subdir",
+        )
+        is None
+    )
+
+
+def test_workspace_exception_still_applies_with_cwd_correctly_separated() -> None:
+    """The active-workspace exception (a workspace nested under a broad
+    sensitive prefix like /root) must keep working once cwd and workspace
+    are resolved independently, for both a relative and an absolute target
+    run from inside that workspace."""
+    workspace = Path("/root/.agentos/workspace")
+
+    assert (
+        sensitive_target_in_command(
+            "rm scratch.txt",
+            workspace=workspace,
+            cwd=workspace,
+        )
+        is None
+    )
+    assert (
+        sensitive_target_in_command(
+            f"rm {workspace / 'scratch.txt'}",
+            workspace=workspace,
+            cwd=workspace,
+        )
+        is None
+    )
+
+


### PR DESCRIPTION
Fixes #1579

## Summary
In `src/agentos/sandbox/sensitive_paths.py`, `sensitive_target_in_command` conflated the workspace containment boundary with the command's execution directory:
```python
effective_workspace = workspace
if effective_workspace is None:
    effective_workspace = cwd if cwd is not None else Path.cwd()
for _kind, target in _extract_intents(command, base_dir=effective_workspace):
    ...
    marker = sensitive_path_marker(target, workspace=effective_workspace)
Whenever workspace was passed (such as during shell tool execution approval in _check_exec_approval), cwd was discarded. Relative paths in destructive commands (e.g. rm -rf config) were normalized against workspace instead of the process's working directory cwd (workdir). If a command executed with workdir="~/.aws", config resolved to <workspace>/config, which was inside the workspace and not blocked, bypassing the sensitive-path hard block.

This PR:

1. Distinguishes between the command's working directory (effective_base) and the containment boundary (workspace).
2. Normalizes cwd (handling both absolute paths and relative paths under workspace) and passes it as base_dir to _extract_intents.
3. Passes workspace=workspace to sensitive_path_marker.
4. Adds regression tests in tests/test_sandbox/test_sensitive_paths.py covering cwd outside workspace, relative subdirectories inside workspace, and parent directory traversal from cwd.

Tests
# 1. New regression tests
pytest tests/test_sandbox/test_sensitive_paths.py -k "sensitive_target_in_command" -q
# Result: 3 passed, 60 deselected in 0.68s
# 2. Ruff lint check
ruff check src/agentos/sandbox/sensitive_paths.py tests/test_sandbox/test_sensitive_paths.py
# Result: All checks passed!
# 3. Mypy type check
mypy src/agentos/sandbox/sensitive_paths.py --show-error-codes
# Result: Success: no issues found in 1 source file
