### PR TITLE
fix(browser): normalize allowed_domains entries (scheme, wildcard, tr…

### DIFF
--- a/agentos.toml.example
+++ b/agentos.toml.example
@@ -97,7 +97,11 @@
 # cdp_port = 0                    # 0 = managed. >0 = attach to Chrome started with
 #                                 #   --remote-debugging-port=<port>. Localhost only.
 # attach_confirmed = false        # must be true to let the agent drive your Chrome
-# allowed_domains = []            # [] = open web (SSRF still blocks private IPs)
+# allowed_domains = []            # [] = open web (SSRF still blocks private IPs).
+#                                 #   Entries are hostnames, e.g. ["example.com"] — a
+#                                 #   bare hostname already covers its subdomains.
+#                                 #   ".example.com" / "*.example.com" mean the same
+#                                 #   thing; a scheme or trailing path is stripped.
 # persist_profile = false         # true = keep cookies/login between sessions (on disk)
 # session_ttl_minutes = 15
 # max_sessions = 3

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -711,7 +711,7 @@ restrict_evaluate = false
 | `browser.binary_path` | `""` | Optional explicit path to `agent-browser`; otherwise found on `PATH`. |
 | `browser.cdp_port` | `0` | `0` = managed. `>0` = attach to your Chrome's debug port. Localhost only; a URL is never accepted. |
 | `browser.attach_confirmed` | `false` | Must be `true` for attach mode to run — it can drive signed-in sessions. |
-| `browser.allowed_domains` | `[]` | `[]` = open web (SSRF still blocks private ranges). A non-empty list bounds navigation in AgentOS and in the engine. |
+| `browser.allowed_domains` | `[]` | `[]` = open web (SSRF still blocks private ranges). A non-empty list bounds navigation in AgentOS and in the engine. Entries are hostnames, e.g. `["example.com"]` — a bare hostname already covers its subdomains. `.example.com` and `*.example.com` mean the same thing; a scheme (`https://`) or trailing path is stripped. An entry that isn't a hostname after stripping those raises at config time. |
 | `browser.persist_profile` | `false` | `true` keeps cookies/login between sessions (written to disk). |
 | `browser.session_ttl_minutes` | `15` | Idle sessions are reaped after this. Range 1-1440. |
 | `browser.max_sessions` | `3` | Concurrent browser sessions; oldest-idle evicted. Range 1-20. |

--- a/src/agentos/tools/agent_browser.py
+++ b/src/agentos/tools/agent_browser.py
@@ -32,6 +32,7 @@ import contextlib
 import hashlib
 import json
 import os
+import re
 import shutil
 import time
 from dataclasses import dataclass, field
@@ -69,6 +70,45 @@ _active_allowed_domains: tuple[str, ...] = ()
 _resolved_binary: str | None = None
 _binary_resolved: bool = False
 
+_HOSTNAME_RE = re.compile(r"[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?")
+
+
+def normalize_allowed_domain(raw: str) -> str:
+    """Canonicalise one ``browser.allowed_domains`` entry to a bare hostname.
+
+    ``_domain_allowed`` (in :mod:`agentos.tools.builtin.browser`) already
+    treats a bare hostname as covering that domain *and* its subdomains
+    (``host == d or host.endswith("." + d)``), so every conventional "this
+    domain and its subdomains" spelling — a leading ``.`` or ``*.``, a
+    ``scheme://`` prefix, a trailing path — converges on that same bare form
+    rather than silently matching nothing. This does not add pattern
+    matching: it only strips the wrapping an operator would reasonably write
+    around the hostname the existing exact/suffix check already wants.
+
+    Mirrors ``normalize_tool_profile``: canonicalise, or raise naming the
+    accepted format.
+    """
+    entry = raw.strip().lower()
+    if "://" in entry:
+        from urllib.parse import urlparse
+
+        entry = urlparse(entry).netloc
+    entry = entry.split("/", 1)[0]
+    entry = entry.rsplit("@", 1)[-1]
+    entry = entry.split(":", 1)[0]
+    if entry.startswith("*."):
+        entry = entry[2:]
+    elif entry.startswith("."):
+        entry = entry[1:]
+    entry = entry.rstrip(".")
+    if not entry or not _HOSTNAME_RE.fullmatch(entry):
+        raise ValueError(
+            f"invalid browser.allowed_domains entry {raw!r}: expected a hostname such "
+            "as 'example.com', or '.example.com' / '*.example.com' for a domain and "
+            "its subdomains (subdomains are already included for a bare hostname)"
+        )
+    return entry
+
 
 def configure_browser(config: Any | None = None) -> None:
     """Apply a ``BrowserConfig``-shaped object to process-wide runtime state."""
@@ -96,7 +136,9 @@ def configure_browser(config: Any | None = None) -> None:
     )
     _active_max_sessions = max(1, int(_get("max_sessions", DEFAULT_MAX_SESSIONS)))
     domains = _get("allowed_domains", ()) or ()
-    _active_allowed_domains = tuple(str(d).strip().lower() for d in domains if str(d).strip())
+    _active_allowed_domains = tuple(
+        normalize_allowed_domain(str(d)) for d in domains if str(d).strip()
+    )
 
     # Binary path may have changed; drop the resolution cache.
     _resolved_binary = None

--- a/src/agentos/tools/builtin/browser.py
+++ b/src/agentos/tools/builtin/browser.py
@@ -104,7 +104,9 @@ def configure_browser(config: Any | None = None) -> None:
         return default if value is None else value
 
     domains = _get("allowed_domains", ()) or ()
-    _allowed_domains = tuple(str(d).strip().lower() for d in domains if str(d).strip())
+    _allowed_domains = tuple(
+        agent_browser.normalize_allowed_domain(str(d)) for d in domains if str(d).strip()
+    )
     _restrict_evaluate = bool(_get("restrict_evaluate", False))
     _allow_unsafe_evaluate = bool(_get("allow_unsafe_evaluate", False))
     _snapshot_max_chars = max(1000, int(_get("snapshot_max_chars", _DEFAULT_SNAPSHOT_MAX_CHARS)))

--- a/tests/test_tools/test_browser_adapter.py
+++ b/tests/test_tools/test_browser_adapter.py
@@ -192,6 +192,58 @@ class TestArgBuilding:
         agent_browser.configure_browser(_config(binary_path=""))
         assert "--session-name" not in _argv_for()
 
+    @pytest.mark.parametrize(
+        "entry",
+        [
+            "example.com",
+            ".example.com",
+            "https://example.com",
+            "example.com/",
+            "*.example.com",
+        ],
+    )
+    def test_allowed_domains_entries_normalize_to_a_bare_hostname(self, entry: str) -> None:
+        """Issue #1478: every conventional spelling reaches the engine as the
+        same bare hostname, not the raw operator spelling."""
+        agent_browser.configure_browser(_config(binary_path="", allowed_domains=[entry]))
+        argv = _argv_for()
+        assert argv[argv.index("--allowed-domains") + 1] == "example.com"
+
+    def test_invalid_allowed_domains_entry_raises_naming_the_format(self) -> None:
+        with pytest.raises(ValueError, match="allowed_domains"):
+            agent_browser.configure_browser(_config(binary_path="", allowed_domains=["*bad*"]))
+
+
+class TestNormalizeAllowedDomain:
+    """Issue #1478: ``normalize_allowed_domain`` in isolation."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("example.com", "example.com"),
+            ("EXAMPLE.COM", "example.com"),
+            ("  example.com  ", "example.com"),
+            (".example.com", "example.com"),
+            ("*.example.com", "example.com"),
+            ("https://example.com", "example.com"),
+            ("http://example.com", "example.com"),
+            ("example.com/", "example.com"),
+            ("example.com/some/path", "example.com"),
+            ("https://example.com:8443/p", "example.com"),
+            ("example.com.", "example.com"),
+        ],
+    )
+    def test_normalizes_to_bare_hostname(self, raw: str, expected: str) -> None:
+        assert agent_browser.normalize_allowed_domain(raw) == expected
+
+    @pytest.mark.parametrize(
+        "raw",
+        ["not a host!", "*example.com", "exa*mple.com", "https://", "/", "*"],
+    )
+    def test_raises_naming_the_accepted_format(self, raw: str) -> None:
+        with pytest.raises(ValueError, match="allowed_domains"):
+            agent_browser.normalize_allowed_domain(raw)
+
 
 class TestEnvScrub:
     def test_scrubbed_env_excludes_agentos_and_provider_secrets(

--- a/tests/test_tools/test_browser_tool.py
+++ b/tests/test_tools/test_browser_tool.py
@@ -216,6 +216,39 @@ class TestAllowlist:
         result = await _call(action="navigate", url="https://docs.example.com/x")
         assert result["success"] is True
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "entry",
+        [
+            "example.com",
+            ".example.com",
+            "https://example.com",
+            "example.com/",
+            "*.example.com",
+        ],
+    )
+    async def test_every_conventional_spelling_allows_the_domain_and_subdomains(
+        self, fake_binary: str, no_dns: None, entry: str
+    ) -> None:
+        """Issue #1478: every conventional spelling of "this domain and its
+        subdomains" must normalize to the same bare hostname, not match nothing."""
+        browser_mod.configure_browser(_config(fake_binary, allowed_domains=[entry]))
+        apex = await _call(action="navigate", url="https://example.com/p")
+        assert apex["success"] is True, entry
+        sub = await _call(action="navigate", url="https://www.example.com/p")
+        assert sub["success"] is True, entry
+
+    def test_invalid_allowed_domains_entry_raises_at_config_time(
+        self, fake_binary: str
+    ) -> None:
+        """Issue #1478: an entry that cannot be reduced to a hostname must fail
+        closed at configure_browser, naming the accepted format — not silently
+        match nothing at navigate time."""
+        with pytest.raises(ValueError, match="allowed_domains"):
+            browser_mod.configure_browser(
+                _config(fake_binary, allowed_domains=["not a host!"])
+            )
+
 
 class TestSecretGuard:
     @pytest.mark.asyncio


### PR DESCRIPTION
Summary
_domain_allowed always compared against a bare hostname (host == d or host.endswith("." + d)), but configure_browser only lowercased and stripped each allowed_domains entry — it never reduced a leading ./*., a scheme, or a trailing path to that bare form, so four of the five conventional "this domain and its subdomains" spellings matched nothing at all
The refusal message named the very domain the operator wrote as being in the allowlist, so it read as a tool bug rather than a config-format mistake
Added normalize_allowed_domain (agent_browser.py), shaped like the existing normalize_tool_profile: canonicalise to a bare hostname (strip scheme, userinfo, port, trailing path, leading *./.) or raise naming the accepted format
A bare hostname already covers its own subdomains under the existing exact/suffix check, so this is normalization, not a new pattern-matching feature — scope kept deliberately narrow per review guidance
Both configure_browser implementations — the AgentOS-side allowlist check in browser.py and the engine --allowed-domains arg builder in agent_browser.py — now go through the same helper, so they can't diverge
Documented the accepted format in agentos.toml.example and docs/configuration.md, which previously said nothing beyond the empty-list default
Fixes #1478 

Test plan
 The reviewer's exact 5-entry matrix (example.com, .example.com, https://example.com, example.com/, *.example.com) all resolve to the same bare hostname and permit both the apex and a subdomain
 An entry that can't be reduced to a hostname ("not a host!", "*bad*", "https://", "/") raises ValueError at configure_browser time, naming the accepted format
 normalize_allowed_domain unit-tested in isolation: case, whitespace, port, trailing dot, userinfo, malformed scheme
 uv run pytest tests/test_tools/test_browser_adapter.py tests/test_tools/test_browser_tool.py tests/test_tools/test_browser_visibility.py -q — 98 passed
 uv run ruff check / uv run mypy clean on changed files