### PR TITLE
fix(sandbox): guard sensitive path scanner against RuntimeError on un…

### DIFF
--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -168,8 +168,15 @@ def _comparison_path_candidates(path: str) -> list[str]:
     if raw:
         candidates.append(raw.casefold() if os.name == "nt" else raw)
     if raw.startswith("~/"):
-        expanded_home = str(Path.home()).replace("\\", "/") + raw[1:]
-        candidates.append(expanded_home.casefold() if os.name == "nt" else expanded_home)
+        # Home may be indeterminate (minimal container, HOME/USERPROFILE
+        # unset) — the raw "~/..." candidate above still lets prefix/suffix
+        # matching work without it.
+        try:
+            expanded_home = str(Path.home()).replace("\\", "/") + raw[1:]
+        except (OSError, RuntimeError):
+            expanded_home = None
+        if expanded_home is not None:
+            candidates.append(expanded_home.casefold() if os.name == "nt" else expanded_home)
     return list(dict.fromkeys(candidates))
 
 
@@ -354,7 +361,15 @@ def sensitive_path_marker(
     # turns into an absolute sensitive path, and the narrow leaf-marker
     # fallback below would be the only check it ever faced.
     text = _expand_env_vars(str(path).strip())
-    raw = Path(text).expanduser()
+    try:
+        raw = Path(text).expanduser()
+    except (OSError, RuntimeError):
+        # `~<literal>` where <literal> isn't a resolvable user (e.g. a
+        # backslash-separated `~\.aws\credentials` on POSIX, where pathlib
+        # reads the whole tail as a username) or home is indeterminate.
+        # Fall through unexpanded rather than let a security scan crash —
+        # is_sensitive_path()'s own candidates still catch the sensitive case.
+        raw = Path(text)
     if (
         text
         and not text.startswith("~")

--- a/tests/test_sandbox/test_sensitive_paths.py
+++ b/tests/test_sandbox/test_sensitive_paths.py
@@ -26,6 +26,37 @@ def test_sensitive_path_in_text_matches_native_separator_paths() -> None:
     assert sensitive_path_in_text(f"type {key_path}") == "~/.ssh"
 
 
+def test_backslash_tilde_paths_do_not_raise_and_are_recognized() -> None:
+    """Issue #1503: on POSIX, ``Path("~\\.aws\\credentials").expanduser()``
+    treats the backslash tail as a literal username and raises RuntimeError
+    ("Could not determine home directory") trying to resolve it via
+    ``pwd.getpwnam``. That must not escape the scanner as an unhandled
+    exception, and the path should still be recognized once its backslashes
+    are read as separators."""
+    assert sensitive_path_marker(r"~\.aws\credentials") == "~/.aws"
+    assert sensitive_path_marker(r"~\.ssh\id_rsa") == "~/.ssh"
+    assert sensitive_path_in_text(r"cat ~\.aws\credentials") == "~/.aws"
+
+
+def test_sensitive_path_marker_survives_an_indeterminate_home(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #1503: a minimal/headless environment where HOME/USERPROFILE is
+    unset or indeterminate makes ``Path.home()`` raise RuntimeError. That must
+    not crash the scanner — string-level candidates still catch a `~/...`
+    sensitive path even when the real home directory can't be resolved."""
+
+    def _boom() -> Path:
+        raise RuntimeError("Could not determine home directory")
+
+    monkeypatch.setattr(Path, "home", staticmethod(_boom))
+
+    assert sensitive_path_marker("~/.aws/credentials") == "~/.aws"
+    assert sensitive_path_marker("~/.ssh/id_rsa") == "~/.ssh"
+    assert sensitive_path_marker("/etc/passwd") == "/etc"
+    assert sensitive_path_marker("relative/file.txt") is None
+
+
 def test_active_workspace_under_root_is_not_blocked_by_root_prefix() -> None:
     workspace = Path("/root/.agentos/workspace")
 


### PR DESCRIPTION
Summary
Two expansions in sensitive_paths.py could raise RuntimeError unguarded, unlike every other expansion in the module (_expand, _workspace_contains) which already catches (OSError, RuntimeError):
sensitive_path_marker's Path(text).expanduser() — a backslash tilde path like ~\.aws\credentials makes pathlib read the tail as a literal username on POSIX and try pwd.getpwnam on it, raising "Could not determine home directory"
_comparison_path_candidates's bare Path.home() call — raises the same way whenever HOME/USERPROFILE is unset or indeterminate (minimal containers, headless environments)
An exception escaping a security scan is worse than a wrong verdict — it turns the check into a tool crash instead of a decision
Both call sites now fall back to the unexpanded text on failure, matching the existing pattern elsewhere in the module
The string-level candidates built alongside the expanded ones (a bare backslash-to-slash swap, and the raw ~/... form) still let prefix/suffix matching recognize the sensitive path without needing the real home directory resolved — ~\.aws\credentials still returns "~/.aws", not just "no crash"
Fixes #1503 

Test plan
 Added a regression test for the exact repro (~\.aws\credentials, ~\.ssh\id_rsa, and sensitive_path_in_text) — no exception, correct marker returned
 Added a test with Path.home() monkeypatched to raise RuntimeError, simulating an indeterminate-home environment — scanner still returns correct verdicts for ~/..., absolute, and relative paths
 uv run pytest tests/test_sandbox/test_sensitive_paths.py -q — 62 passed
 uv run pytest tests/test_sandbox -q — 106 passed, 26 skipped
 uv run ruff check / uv run mypy clean on changed files