### PR TITLE
fix(sandbox): resolve relative workdir and include env in _sandbox_request_for

### DIFF
--- a/src/agentos/tools/builtin/shell.py
+++ b/src/agentos/tools/builtin/shell.py
@@ -759,7 +759,7 @@ async def exec_command(
             status = approval_response.get("status")
             if status == "approval_denied":
                 await _record_shell_denial(
-                    "exec_command", command, workdir, DenialReason.HUMAN_REJECTED
+                    "exec_command", command, workdir, DenialReason.HUMAN_REJECTED, env=env
                 )
             return json.dumps(approval_response)
 
@@ -779,7 +779,7 @@ async def exec_command(
         decision, policy, request = await gate_action(
             action_kind="shell.exec",
             argv=("exec_command", command),
-            cwd=Path(workdir) if workdir else None,
+            cwd=Path(cwd) if cwd else None,
             env=merged_env,
         )
         if isinstance(decision, DenialResult):
@@ -937,7 +937,7 @@ async def background_process(
         decision, policy, request = await gate_action(
             action_kind="shell.background",
             argv=("background_process", command),
-            cwd=Path(workdir) if workdir else None,
+            cwd=Path(cwd) if cwd else None,
             env=dict(os.environ),
         )
         if isinstance(decision, DenialResult):
@@ -1276,7 +1276,10 @@ async def process(
 
 
 def _sandbox_request_for(
-    tool_name: str, command: str, workdir: str | None
+    tool_name: str,
+    command: str,
+    workdir: str | None,
+    env: dict[str, str] | None = None,
 ) -> tuple[SandboxRequest, SandboxPolicy, str] | None:
     """Build a SandboxRequest for the current shell command.
 
@@ -1288,17 +1291,12 @@ def _sandbox_request_for(
         return None
     action_kind = "shell.background" if tool_name == "background_process" else "shell.exec"
     ctx = current_tool_context.get()
-    workspace = None
-    if workdir:
-        p = Path(workdir)
-        if p.is_absolute():
-            workspace = p
-    if workspace is None and ctx is not None and ctx.workspace_dir:
-        wp = Path(ctx.workspace_dir)
-        if wp.is_absolute():
-            workspace = wp
-    if workspace is None:
-        workspace = runtime.workspace if runtime.workspace.is_absolute() else Path.cwd()
+    effective_cwd = _effective_workdir(workdir)
+    workspace = (
+        Path(effective_cwd)
+        if effective_cwd
+        else (runtime.workspace if runtime.workspace.is_absolute() else Path.cwd())
+    )
 
     level = (
         select_level(action_kind)
@@ -1306,18 +1304,24 @@ def _sandbox_request_for(
         else runtime.effective.default_level
     )
     policy = build_policy(level, action_kind, workspace, runtime.settings, trusted=True)
+    subprocess_env = build_subprocess_env(extra=env)
     request = build_request(
         action_kind=action_kind,
         argv=(tool_name, command),
         cwd=workspace,
         policy=policy,
+        env=subprocess_env,
     )
     session_id = str(ctx.session_key) if ctx and ctx.session_key else "default"
     return request, policy, session_id
 
 
 async def _record_shell_denial(
-    tool_name: str, command: str, workdir: str | None, reason: DenialReason
+    tool_name: str,
+    command: str,
+    workdir: str | None,
+    reason: DenialReason,
+    env: dict[str, str] | None = None,
 ) -> None:
     """Record a shell-layer denial into the sandbox ledger for §8.3/§8.5.
 
@@ -1328,7 +1332,7 @@ async def _record_shell_denial(
     runtime = get_runtime()
     if runtime is None:
         return
-    built = _sandbox_request_for(tool_name, command, workdir)
+    built = _sandbox_request_for(tool_name, command, workdir, env=env)
     if built is None:
         return
     request, _, session_id = built

--- a/tests/test_tools/test_shell_approval_policy.py
+++ b/tests/test_tools/test_shell_approval_policy.py
@@ -881,3 +881,51 @@ async def test_root_wipe_is_hard_blocked_at_the_exec_approval_boundary() -> None
         assert result["status"] == "blocked"
         assert result["reason"] == "sensitive_path"
         assert result["sensitive_path"] == "/"
+
+
+def test_sandbox_request_for_resolves_relative_workdir(tmp_path: Path) -> None:
+    """Relative workdir in _sandbox_request_for must resolve against workspace (#1562)."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    sub = ws / "subfolder"
+    sub.mkdir()
+
+    configure_runtime(SandboxSettings(sandbox=False), workspace=ws)
+    token = current_tool_context.set(
+        ToolContext(workspace_dir=str(ws), session_key="agent:main:test")
+    )
+    try:
+        built = shell._sandbox_request_for("exec_command", "echo test", "subfolder")
+        assert built is not None
+        req, _, session_id = built
+        assert req.cwd == sub.resolve()
+        assert session_id == "agent:main:test"
+    finally:
+        current_tool_context.reset(token)
+
+
+def test_sandbox_request_for_populates_env_and_matches_fingerprint(tmp_path: Path) -> None:
+    """_sandbox_request_for must include execution environment for fingerprinting (#1562)."""
+    from agentos.sandbox.governance import action_fingerprint
+
+    ws = tmp_path / "ws"
+    ws.mkdir()
+
+    configure_runtime(SandboxSettings(sandbox=False), workspace=ws)
+    token = current_tool_context.set(
+        ToolContext(workspace_dir=str(ws), session_key="agent:main:test")
+    )
+    try:
+        custom_env = {"FOO": "bar"}
+        built = shell._sandbox_request_for("exec_command", "echo test", None, env=custom_env)
+        assert built is not None
+        req, _, _ = built
+        assert "PATH" in req.env
+        assert req.env.get("FOO") == "bar"
+
+        # Fingerprint must be consistent and include PATH
+        fp = action_fingerprint(req)
+        assert len(fp) == 32
+    finally:
+        current_tool_context.reset(token)
+


### PR DESCRIPTION
Fixes #1562


## Summary

In `src/agentos/tools/builtin/shell.py`, `_sandbox_request_for` builds the `SandboxRequest` passed to `_record_shell_denial` for denial recording in the ledger and cache purging (§8.3, §8.5).

Two defects caused the resulting `action_fingerprint(request)` to mismatch the fingerprint generated during command execution or approval:
1. **Empty `env`**: `build_request` received no `env`, leaving `request.env = {}`. Because `action_fingerprint` hashes `critical_env = {k: request.env[k] for k in ("PATH",) if k in request.env}`, the denial fingerprint lacked `PATH` and never matched the execution fingerprint generated via `gate_action`.
2. **Dropped relative `workdir`**: `_sandbox_request_for` only checked `if p.is_absolute()`, ignoring relative workdir paths (e.g. `'tests'`, `'./build'`) and defaulting `cwd` to the workspace root while `exec_command` executed in the resolved subfolder.

This PR:
1. Resolves `workdir` in `_sandbox_request_for` via `_effective_workdir(workdir)`.
2. Populates `request.env` via `build_subprocess_env(extra=env)`.
3. Passes `env` from `exec_command` through `_record_shell_denial` into `_sandbox_request_for`.
4. Passes the resolved `Path(cwd)` to `gate_action` in `exec_command` and `background_process`.
5. Adds regression tests in `tests/test_tools/test_shell_approval_policy.py`.

## Tests

```powershell
# 1. New regression tests
pytest tests/test_tools/test_shell_approval_policy.py -k "test_sandbox_request_for" -q
# Result: 2 passed in 4.03s

# 2. Ruff lint check
ruff check src/agentos/tools/builtin/shell.py tests/test_tools/test_shell_approval_policy.py
# Result: All checks passed!

# 3. Mypy type check
mypy src/agentos/tools/builtin/shell.py --show-error-codes
# Result: Success: no issues found in 1 source file

