### PR TITLE
fix: gate_action's relative-cwd resolution can falsely block unrelated commands (post_denial_guard)

### DIFF
--- a/src/agentos/sandbox/integration.py
+++ b/src/agentos/sandbox/integration.py
@@ -257,10 +257,18 @@ def _resolve_session_id(runtime: SandboxRuntime, session_id: str | None) -> str:
 
 
 def _resolve_workspace(runtime: SandboxRuntime, cwd: str | None) -> Path:
-    if cwd:
-        p = Path(cwd)
-        if p.is_absolute():
-            return p
+    """Resolve ``cwd`` to an absolute path for gating/fingerprinting.
+
+    A relative ``cwd`` (e.g. from a tool's ``workdir`` argument) is joined
+    against ``ctx.workspace_dir``, not discarded — two calls that differ
+    only by which relative subdirectory they target must not collapse onto
+    the same resolved workspace, or they collapse onto the same
+    ``action_fingerprint`` too. That matters beyond logging: ``gate_execution``
+    consults the *previous* denial's fingerprint via ``post_denial_guard``
+    regardless of whether this new action even requires approval, so a
+    colliding fingerprint can auto-deny an unrelated request in a different
+    directory as a "repeated" one it never was.
+    """
     try:
         from agentos.tools.types import current_tool_context
 
@@ -268,10 +276,21 @@ def _resolve_workspace(runtime: SandboxRuntime, cwd: str | None) -> Path:
     except Exception:  # pragma: no cover - defensive
         ctx = None
     workspace_dir = getattr(ctx, "workspace_dir", None) if ctx is not None else None
+    base: Path | None = None
     if isinstance(workspace_dir, str) and workspace_dir:
         wp = Path(workspace_dir)
         if wp.is_absolute():
-            return wp
+            base = wp
+
+    if cwd:
+        p = Path(cwd)
+        if p.is_absolute():
+            return p
+        if base is not None:
+            return (base / p).resolve()
+
+    if base is not None:
+        return base
     if runtime.workspace.is_absolute():
         return runtime.workspace
     return Path.cwd()

--- a/tests/test_sandbox/test_gate_action_relative_cwd.py
+++ b/tests/test_sandbox/test_gate_action_relative_cwd.py
@@ -1,0 +1,149 @@
+"""Regression tests for the ``_resolve_workspace`` relative-cwd bug.
+
+``gate_action`` resolves the caller's ``cwd`` via ``_resolve_workspace``,
+which used to accept only an already-absolute path and silently discard
+anything relative — falling back to ``ctx.workspace_dir`` (the workspace
+root) instead of joining the relative path onto it.
+
+That resolved workspace feeds ``action_fingerprint`` (via
+``SandboxRequest.cwd``), and ``gate_execution`` consults the *previous*
+denial's fingerprint through ``post_denial_guard`` on every call —
+regardless of whether the new call even requires approval. So two calls
+that differ only by which relative subdirectory they target, and whose
+tool-specific ``argv_factory`` doesn't otherwise encode the directory
+(as `git.py`'s tools deliberately don't, to keep ``git status`` in two
+repos from looking like different intents by path alone), used to
+collapse onto the *same* fingerprint. Denying one would then silently
+auto-deny the other as a "repeated" request it never was.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agentos.sandbox.config import SandboxSettings
+from agentos.sandbox.integration import configure_runtime, gate_action, reset_runtime
+from agentos.sandbox.policy import LevelHints
+from agentos.sandbox.types import DenialReason, DenialResult
+from agentos.tools.types import CallerKind, ToolContext, current_tool_context
+
+
+class _FakeApprovalQueue:
+    """Minimal ``_ApprovalQueueLike`` fake: replays a fixed approve/deny
+    sequence, one entry per ``wait`` call."""
+
+    def __init__(self, decisions: list[bool]) -> None:
+        self._decisions = decisions
+        self.calls = 0
+
+    def request(self, namespace: str = "exec", params: dict | None = None) -> str:
+        return f"approval-{self.calls}"
+
+    async def wait(self, approval_id: str, timeout: float | None = None) -> bool:
+        decision = self._decisions[self.calls]
+        self.calls += 1
+        return decision
+
+    def resolve(self, approval_id: str, approved: bool) -> None:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    reset_runtime()
+    yield
+    reset_runtime()
+
+
+def _configure_graded_runtime(workspace: Path, queue: _FakeApprovalQueue) -> None:
+    configure_runtime(
+        SandboxSettings(
+            sandbox=True, security_grading=True, backend="noop", allow_legacy_mode=True
+        ),
+        workspace=workspace,
+        approval_queue=queue,
+    )
+
+
+@pytest.mark.asyncio
+async def test_denial_in_one_relative_subdir_does_not_block_a_different_one(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "repoA").mkdir()
+    (tmp_path / "repoB").mkdir()
+    token = current_tool_context.set(
+        ToolContext(caller_kind=CallerKind.CLI, session_key="s1", workspace_dir=str(tmp_path))
+    )
+    try:
+        # First call is denied by the human; second (unrelated) call is
+        # approved — proving it actually reached the approval gate instead
+        # of being blind-blocked by the post-denial guard.
+        queue = _FakeApprovalQueue([False, True])
+        _configure_graded_runtime(tmp_path, queue)
+        hints = LevelHints(trusted_source=False)  # forces require_approval=True
+
+        first, _, _ = await gate_action(
+            action_kind="test.action",
+            argv=("git", "status"),
+            cwd=Path("repoA"),
+            hints=hints,
+            session_id="s1",
+        )
+        assert isinstance(first, DenialResult)
+        assert first.reason == DenialReason.HUMAN_REJECTED
+
+        second, _, _ = await gate_action(
+            action_kind="test.action",
+            argv=("git", "status"),
+            cwd=Path("repoB"),
+            hints=hints,
+            session_id="s1",
+        )
+        assert not isinstance(second, DenialResult), (
+            f"repoB was blocked as a repeat of repoA's denial: {second}"
+        )
+        # The queue was actually consulted a second time — not short-circuited.
+        assert queue.calls == 2
+    finally:
+        current_tool_context.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_repeating_the_same_relative_subdir_still_triggers_the_guard(
+    tmp_path: Path,
+) -> None:
+    """Sanity check the other direction: the post-denial guard must still
+    fire for a genuine blind retry in the *same* directory."""
+    (tmp_path / "repoA").mkdir()
+    token = current_tool_context.set(
+        ToolContext(caller_kind=CallerKind.CLI, session_key="s1", workspace_dir=str(tmp_path))
+    )
+    try:
+        queue = _FakeApprovalQueue([False, True])
+        _configure_graded_runtime(tmp_path, queue)
+        hints = LevelHints(trusted_source=False)
+
+        first, _, _ = await gate_action(
+            action_kind="test.action",
+            argv=("git", "status"),
+            cwd=Path("repoA"),
+            hints=hints,
+            session_id="s1",
+        )
+        assert isinstance(first, DenialResult)
+
+        second, _, _ = await gate_action(
+            action_kind="test.action",
+            argv=("git", "status"),
+            cwd=Path("repoA"),
+            hints=hints,
+            session_id="s1",
+        )
+        assert isinstance(second, DenialResult)
+        assert second.reason == DenialReason.REPEATED_SAME_INTENT
+        # Blocked by the guard before ever re-consulting the queue.
+        assert queue.calls == 1
+    finally:
+        current_tool_context.reset(token)


### PR DESCRIPTION
## Linked issue

Fixes #1595

- [x] This pull request fully resolves the linked issue.

## Summary

`_resolve_workspace()` in `sandbox/integration.py` — the helper `gate_action()`
uses to resolve every sandboxed action's `cwd` — only accepted an already
absolute `cwd`, silently discarding a relative one (e.g. a tool's
`workdir="subproject"` argument) in favor of the workspace root.

That resolved `cwd` feeds `action_fingerprint()`. `gate_execution()` runs
`post_denial_guard()` on **every** call, before ever checking
`policy.require_approval` — it auto-denies a request whose fingerprint
matches the session's last-denied fingerprint. Several `@sandboxed`-decorated
tools take a relative `workdir` that isn't otherwise encoded in their
fingerprint (`git.py`'s tools use a fixed or path-only `argv_factory`), so
`cwd` is the only thing distinguishing two different-directory calls. With
the bug, denying `git_status(workdir="repoA")` silently auto-denied an
unrelated `git_status(workdir="repoB")` as `REPEATED_SAME_INTENT` — a
request the human never saw.

Fixed by joining a relative `cwd` onto `ctx.workspace_dir`, matching
`_effective_workdir()`'s semantics used elsewhere in the codebase, instead
of discarding it.

## Tests

- denying an action in one relative subdir must not block an unrelated
  action in a different relative subdir (fails against the prior code with
  the exact false `REPEATED_SAME_INTENT` denial; passes with the fix)
- a genuine repeat in the *same* relative subdir still triggers the guard
  (no regression on the intended behavior)

    ruff check src tests                  # All checks passed!
    mypy src/agentos --show-error-codes   # Success: no issues found
    pytest tests/test_sandbox/test_gate_action_relative_cwd.py -q   # 2 passed
    pytest tests/ -q   # 9824 passed; same 18 failures/3 errors on unmodified
                        # main too (SSL cert issues on live pricing lookups,
                        # unrelated ONNX/pilot-fixture issues in this checkout)