### PR TITLE
fix(tools): record shell hard-blocks in the sandbox denial ledger

### DIFF
--- a/src/agentos/tools/builtin/shell.py
+++ b/src/agentos/tools/builtin/shell.py
@@ -733,16 +733,20 @@ async def exec_command(
 
     # Denylist: hard-block, never bypassable
     if not result.allowed:
+        await _record_shell_denial("exec_command", command, cwd, DenialReason.POLICY_DENIED)
         raise ToolError(result.reason)
 
     sensitive_block = _sensitive_shell_block("exec_command", command, workdir=cwd)
     if sensitive_block is not None:
+        await _record_shell_denial("exec_command", command, cwd, DenialReason.POLICY_DENIED)
         return sensitive_block
     lockdown_block = _workspace_lockdown_shell_block("exec_command", command, cwd)
     if lockdown_block is not None:
+        await _record_shell_denial("exec_command", command, cwd, DenialReason.POLICY_DENIED)
         return json.dumps(lockdown_block, ensure_ascii=False)
     deny_block = _workspace_write_deny_shell_block("exec_command", command, cwd)
     if deny_block is not None:
+        await _record_shell_denial("exec_command", command, cwd, DenialReason.POLICY_DENIED)
         return json.dumps(deny_block, ensure_ascii=False)
 
     # Warnlist: two-step approval flow
@@ -895,15 +899,27 @@ async def background_process(
     result = check_safe_bin(command)
     cwd = _effective_workdir(workdir)
     if not result.allowed:
+        await _record_shell_denial(
+            "background_process", command, cwd, DenialReason.POLICY_DENIED
+        )
         raise ToolError(result.reason)
     sensitive_block = _sensitive_shell_block("background_process", command, workdir=cwd)
     if sensitive_block is not None:
+        await _record_shell_denial(
+            "background_process", command, cwd, DenialReason.POLICY_DENIED
+        )
         return sensitive_block
     lockdown_block = _workspace_lockdown_shell_block("background_process", command, cwd)
     if lockdown_block is not None:
+        await _record_shell_denial(
+            "background_process", command, cwd, DenialReason.POLICY_DENIED
+        )
         return json.dumps(lockdown_block, ensure_ascii=False)
     deny_block = _workspace_write_deny_shell_block("background_process", command, cwd)
     if deny_block is not None:
+        await _record_shell_denial(
+            "background_process", command, cwd, DenialReason.POLICY_DENIED
+        )
         return json.dumps(deny_block, ensure_ascii=False)
     if result.needs_approval:
         prior_elevation = _approval_elevation_state()

--- a/tests/test_tools/test_shell_approval_policy.py
+++ b/tests/test_tools/test_shell_approval_policy.py
@@ -8,7 +8,7 @@ import pytest
 
 from agentos.gateway.approval_queue import get_approval_queue, reset_approval_queue
 from agentos.sandbox.config import SandboxSettings
-from agentos.sandbox.integration import configure_runtime, reset_runtime
+from agentos.sandbox.integration import configure_runtime, get_runtime, reset_runtime
 from agentos.sandbox.intent_cache import get_intent_cache, reset_intent_cache
 from agentos.tools.builtin import code_exec, filesystem, shell
 from agentos.tools.builtin.code_exec import execute_code
@@ -857,6 +857,130 @@ async def test_bypass_does_not_override_safe_bin_hard_denies() -> None:
 
     with pytest.raises(ToolError, match="command blocked by policy"):
         await shell.exec_command("Clear-Disk")
+
+
+@pytest.mark.asyncio
+async def test_denylist_hard_block_is_recorded_in_sandbox_ledger(tmp_path: Path) -> None:
+    """Issue #1513: a denylist hit raises ToolError immediately, never
+    reaching ``_record_shell_denial`` — so an agent repeatedly probing
+    denylisted binaries never tripped the §8.5 threshold this ledger exists
+    to enforce."""
+    configure_runtime(
+        SandboxSettings(sandbox=False, security_grading=False, allow_legacy_mode=True),
+        workspace=tmp_path,
+    )
+    runtime = get_runtime()
+    assert runtime is not None
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    session_id = str(ctx.session_key)
+
+    assert await runtime.ledger.count_session(session_id) == 0
+    with pytest.raises(ToolError, match="command blocked by policy"):
+        await shell.exec_command("Clear-Disk")
+    assert await runtime.ledger.count_session(session_id) == 1
+
+
+@pytest.mark.asyncio
+async def test_denylist_hard_block_is_recorded_for_background_process(
+    tmp_path: Path,
+) -> None:
+    """Issue #1513: the same gap existed in ``background_process``."""
+    configure_runtime(
+        SandboxSettings(sandbox=False, security_grading=False, allow_legacy_mode=True),
+        workspace=tmp_path,
+    )
+    runtime = get_runtime()
+    assert runtime is not None
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    session_id = str(ctx.session_key)
+
+    with pytest.raises(ToolError, match="command blocked by policy"):
+        await shell.background_process("Clear-Disk")
+    assert await runtime.ledger.count_session(session_id) == 1
+
+
+@pytest.mark.asyncio
+async def test_sensitive_path_hard_block_is_recorded_in_sandbox_ledger(
+    tmp_path: Path,
+) -> None:
+    """Issue #1513: ``_sensitive_shell_block`` returns early without ever
+    calling ``_record_shell_denial``."""
+    configure_runtime(
+        SandboxSettings(sandbox=False, security_grading=False, allow_legacy_mode=True),
+        workspace=tmp_path,
+    )
+    runtime = get_runtime()
+    assert runtime is not None
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    session_id = str(ctx.session_key)
+
+    result = await shell.exec_command("cat ~/.ssh/id_rsa")
+    payload = json.loads(result)
+    assert payload["status"] == "blocked"
+    assert payload["reason"] == "sensitive_path"
+    assert await runtime.ledger.count_session(session_id) == 1
+
+
+@pytest.mark.asyncio
+async def test_workspace_lockdown_hard_block_is_recorded_in_sandbox_ledger(
+    tmp_path: Path,
+) -> None:
+    """Issue #1513: ``_workspace_lockdown_shell_block`` returns early without
+    ever calling ``_record_shell_denial``."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside.txt"
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.interaction_mode = InteractionMode.UNATTENDED
+    ctx.elevated = "bypass"
+    ctx.workspace_dir = str(workspace)
+    ctx.workspace_lockdown = True  # type: ignore[attr-defined]
+    session_id = str(ctx.session_key)
+    configure_runtime(
+        SandboxSettings(sandbox=False, security_grading=False, allow_legacy_mode=True),
+        workspace=workspace,
+    )
+    runtime = get_runtime()
+    assert runtime is not None
+
+    result = await shell.exec_command(f'echo ok > "{outside}"')
+    payload = json.loads(result)
+    assert payload["status"] == "blocked"
+    assert payload["reason"] == "workspace_lockdown"
+    assert await runtime.ledger.count_session(session_id) == 1
+
+
+@pytest.mark.asyncio
+async def test_workspace_write_deny_glob_hard_block_is_recorded_in_sandbox_ledger(
+    tmp_path: Path,
+) -> None:
+    """Issue #1513: ``_workspace_write_deny_shell_block`` returns early
+    without ever calling ``_record_shell_denial``."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.interaction_mode = InteractionMode.UNATTENDED
+    ctx.elevated = "bypass"
+    ctx.workspace_dir = str(workspace)
+    ctx.workspace_write_deny_globs = ["reports/*.txt"]  # type: ignore[attr-defined]
+    session_id = str(ctx.session_key)
+    configure_runtime(
+        SandboxSettings(sandbox=False, security_grading=False, allow_legacy_mode=True),
+        workspace=workspace,
+    )
+    runtime = get_runtime()
+    assert runtime is not None
+
+    result = await shell.exec_command("echo ok > reports/out.txt", workdir=str(workspace))
+    payload = json.loads(result)
+    assert payload["status"] == "blocked"
+    assert payload["reason"] == "workspace_write_deny"
+    assert await runtime.ledger.count_session(session_id) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Summary
exec_command and background_process only called _record_shell_denial from the approval-queue's approval_denied branch
The denylist hit (check_safe_bin), _sensitive_shell_block, _workspace_lockdown_shell_block, and _workspace_write_deny_shell_block all raise or return early without ever reaching it
This inverted the ledger's intent: record_denial increments the per-session total threshold_reached() reads for the §8.5 auto-pause, so an agent repeatedly probing sensitive paths or denylisted binaries never tripped the threshold, while an operator declining one warned command did — the hardest blocks were the ones missing from the audit trail
Added a _record_shell_denial(..., DenialReason.POLICY_DENIED) call at each of the four hard-block sites in both exec_command and background_process, using the already-resolved cwd
Scope kept tight: no changes to the approval-queue path, and no changes to the separate workdir/cwd bug on the existing approval_denied lines (tracked and fixed independently in #1510)
Fixes #1513

Test plan
 Verified manually end-to-end against all three real block types (denylist, sensitive path, workspace lockdown) — ledger count incremented 0 → 1 → 2 → 3 as expected
 Added 5 regression tests: denylist hard-block recorded for both exec_command and background_process, sensitive-path hard-block, workspace-lockdown hard-block, and workspace-write-deny-glob hard-block — each asserting the session's ledger count increments exactly once
 uv run pytest tests/test_tools/test_shell_approval_policy.py -q — 74 passed
 uv run pytest tests/test_tools -k shell -q — 133 passed, 5 skipped
 uv run ruff check / uv run mypy clean on changed files