### PR TITLE
fix(tools): return approval_pending on inline web approval timeout

### DIFF
--- a/src/agentos/application/approval_queue.py
+++ b/src/agentos/application/approval_queue.py
@@ -167,7 +167,13 @@ class ApprovalQueue:
         self._pending[approval_id] = entry
         return entry
 
-    async def wait(self, approval_id: str, timeout: float | None = None) -> bool:
+    async def wait(
+        self,
+        approval_id: str,
+        timeout: float | None = None,
+        *,
+        auto_deny: bool = True,
+    ) -> bool:
         entry = self.get(approval_id)
         if entry.resolved:
             return entry.approved
@@ -187,7 +193,9 @@ class ApprovalQueue:
             entry = self.get(approval_id)
             if entry.resolved:
                 return entry.approved
-        return self._deny_on_timeout_if_unresolved(approval_id)
+        if auto_deny:
+            return self._deny_on_timeout_if_unresolved(approval_id)
+        return False
 
     def _deny_on_timeout_if_unresolved(self, approval_id: str) -> bool:
         self._conn.execute("BEGIN IMMEDIATE")

--- a/src/agentos/tools/builtin/shell.py
+++ b/src/agentos/tools/builtin/shell.py
@@ -1505,7 +1505,7 @@ async def _check_exec_approval(
         approval_id = queue.request(namespace="exec", params=params)
         if _wait_for_inline_browser_approval(background):
             try:
-                await queue.wait(approval_id, timeout=_APPROVAL_RETRY_WAIT_SECONDS)
+                await queue.wait(approval_id, timeout=_APPROVAL_RETRY_WAIT_SECONDS, auto_deny=False)
             except TimeoutError:
                 pass
             entry = queue.get(approval_id)
@@ -1523,12 +1523,23 @@ async def _check_exec_approval(
                 )
                 _elevate_current_call.set(True)
                 return None
+            if not entry.resolved:
+                return {
+                    "status": "approval_pending",
+                    "approval_id": approval_id,
+                    "command": command,
+                    "warning": warning,
+                    "message": (
+                        "Approval is still pending after waiting "
+                        f"{int(_APPROVAL_RETRY_WAIT_SECONDS)}s. Ask the user to approve."
+                    ),
+                }
             return {
                 "status": "approval_denied",
                 "approval_id": approval_id,
                 "command": command,
                 "warning": warning,
-                "message": "Approval was denied or timed out.",
+                "message": "Approval was denied.",
             }
         status = "approval_required"
         message = (
@@ -1563,7 +1574,7 @@ async def _check_exec_approval(
         # back approval_pending — otherwise the model sees pending and pivots
         # to a different tool before the human finishes clicking approve.
         try:
-            await queue.wait(approval_id, timeout=_APPROVAL_RETRY_WAIT_SECONDS)
+            await queue.wait(approval_id, timeout=_APPROVAL_RETRY_WAIT_SECONDS, auto_deny=False)
         except TimeoutError:
             pass
         entry = queue.get(approval_id)

--- a/tests/test_gateway/test_approval_queue_persistence.py
+++ b/tests/test_gateway/test_approval_queue_persistence.py
@@ -107,6 +107,20 @@ async def test_approval_queue_wait_preserves_timeout_denies(tmp_path) -> None:
         queue.close()
 
 
+@pytest.mark.asyncio
+async def test_approval_queue_wait_auto_deny_false_leaves_unresolved(tmp_path) -> None:
+    db_path = tmp_path / "approval_queue.sqlite"
+    queue = ApprovalQueue(db_path=str(db_path), default_timeout=1.0, poll_interval=0.01)
+    approval_id = queue.request("exec", {"toolName": "exec_command", "command": "rm x"})
+    try:
+        assert await queue.wait(approval_id, timeout=0.02, auto_deny=False) is False
+        entry = queue.get(approval_id)
+        assert entry.resolved is False
+        assert entry.approved is False
+    finally:
+        queue.close()
+
+
 def test_approval_queue_resolve_does_not_overwrite_prior_resolution(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_tools/test_shell_approval_policy.py
+++ b/tests/test_tools/test_shell_approval_policy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import sys
 from pathlib import Path
@@ -10,6 +11,7 @@ from agentos.gateway.approval_queue import get_approval_queue, reset_approval_qu
 from agentos.sandbox.config import SandboxSettings
 from agentos.sandbox.integration import configure_runtime, reset_runtime
 from agentos.sandbox.intent_cache import get_intent_cache, reset_intent_cache
+from agentos.sandbox.types import DenialReason
 from agentos.tools.builtin import code_exec, filesystem, shell
 from agentos.tools.builtin.code_exec import execute_code
 from agentos.tools.builtin.shell_policy import PolicyResult
@@ -881,3 +883,129 @@ async def test_root_wipe_is_hard_blocked_at_the_exec_approval_boundary() -> None
         assert result["status"] == "blocked"
         assert result["reason"] == "sensitive_path"
         assert result["sensitive_path"] == "/"
+
+
+@pytest.mark.asyncio
+async def test_inline_browser_approval_timeout_returns_pending_without_denial_record(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #1563: Web UI approval wait timeout must return approval_pending and
+
+    not log DenialReason.HUMAN_REJECTED in runtime.ledger.
+    """
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.caller_kind = CallerKind.WEB
+    monkeypatch.setattr(shell, "_APPROVAL_RETRY_WAIT_SECONDS", 0.02)
+
+    monkeypatch.setattr(
+        shell,
+        "check_safe_bin",
+        lambda cmd: PolicyResult(
+            allowed=True, reason="command requires approval", needs_approval=True
+        ),
+    )
+
+    denials: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    async def _mock_record(*args: object, **kwargs: object) -> None:
+        denials.append((args, kwargs))
+
+    monkeypatch.setattr(shell, "_record_shell_denial", _mock_record)
+
+    # 1. Direct _check_exec_approval check
+    result = await shell._check_exec_approval(
+        "exec_command",
+        "rm target.txt",
+        None,
+        "command requires approval",
+        None,
+        False,
+    )
+    assert result is not None
+    assert result["status"] == "approval_pending"
+    assert result["command"] == "rm target.txt"
+    assert "still pending" in str(result["message"])
+    aid = str(result["approval_id"])
+    queue = get_approval_queue()
+    entry = queue.get(aid)
+    assert entry.resolved is False
+    assert entry.approved is False
+
+    # 2. End-to-end exec_command check
+    raw_result = await shell.exec_command("rm target.txt")
+    payload = json.loads(raw_result)
+    assert payload["status"] == "approval_pending"
+    assert payload["command"] == "rm target.txt"
+    assert len(denials) == 0
+
+
+@pytest.mark.asyncio
+async def test_inline_browser_approval_explicit_denial_returns_denied_with_human_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit operator rejection returns approval_denied and logs HUMAN_REJECTED."""
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.caller_kind = CallerKind.WEB
+    monkeypatch.setattr(shell, "_APPROVAL_RETRY_WAIT_SECONDS", 1.0)
+    monkeypatch.setattr(
+        shell,
+        "check_safe_bin",
+        lambda cmd: PolicyResult(
+            allowed=True, reason="command requires approval", needs_approval=True
+        ),
+    )
+
+    denials: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    async def _mock_record(*args: object, **kwargs: object) -> None:
+        denials.append((args, kwargs))
+
+    monkeypatch.setattr(shell, "_record_shell_denial", _mock_record)
+
+    async def resolve_denied() -> None:
+        await asyncio.sleep(0.02)
+        queue = get_approval_queue()
+        pending = queue.list_pending("exec")
+        if pending:
+            queue.resolve(pending[0]["id"], False)
+
+    task = asyncio.create_task(resolve_denied())
+    try:
+        raw_result = await shell.exec_command("rm target.txt")
+        payload = json.loads(raw_result)
+        assert payload["status"] == "approval_denied"
+        assert payload["message"] == "Approval was denied."
+        assert len(denials) == 1
+        assert denials[0][0][3] == DenialReason.HUMAN_REJECTED
+    finally:
+        await task
+
+
+@pytest.mark.asyncio
+async def test_retry_exec_approval_timeout_preserves_pending_without_auto_denial(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Retrying with approval_id when wait times out preserves approval_pending."""
+    queue = get_approval_queue()
+    approval_id = queue.request("exec", {"toolName": "exec_command", "command": "rm target.txt"})
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.caller_kind = CallerKind.WEB
+    monkeypatch.setattr(shell, "_APPROVAL_RETRY_WAIT_SECONDS", 0.02)
+
+    result = await shell._check_exec_approval(
+        "exec_command",
+        "rm target.txt",
+        None,
+        "command requires approval",
+        approval_id,
+        False,
+    )
+    assert result is not None
+    assert result["status"] == "approval_pending"
+    assert result["approval_id"] == approval_id
+    entry = queue.get(approval_id)
+    assert entry.resolved is False
+    assert entry.approved is False


### PR DESCRIPTION
Closes #1563

### Problem
When an agent turn originates from a Web UI session (`CallerKind.WEB`), `_check_exec_approval()` performs an inline wait for operator approval. If the operator took longer than the timeout without clicking "Approve" or "Deny":
1. `ApprovalQueue.wait()` auto-denied the approval in SQLite (`resolved = 1, approved = 0`), preventing subsequent operator approval.
2. `_check_exec_approval()` fell through to returning `status: "approval_denied"`.
3. `exec_command` erroneously logged `DenialReason.HUMAN_REJECTED` in `runtime.ledger`, falsely incrementing denial metrics even though the human never rejected the command.

### Solution
1. Added `auto_deny: bool = True` to `ApprovalQueue.wait()`, allowing callers to wait without marking unresolved records as denied on timeout.
2. In `shell._check_exec_approval()`, passed `auto_deny=False` and checked `if not entry.resolved: return {"status": "approval_pending", ...}`.
3. Added regression tests verifying that timeout returns `approval_pending` with zero ledger denials, explicit rejection still logs `HUMAN_REJECTED`, and `auto_deny=False` preserves unresolved queue entries.

