### PR TITLE
fix(scheduler): fail cron.remove when the job id is missing

### DIFF
--- a/src/agentos/gateway/rpc_cron.py
+++ b/src/agentos/gateway/rpc_cron.py
@@ -1061,7 +1061,9 @@ async def _handle_cron_remove(params: dict | None, ctx: RpcContext) -> None:
     if not isinstance(params, dict) or "id" not in params:
         raise ValueError("params.id is required")
     scheduler = _require_scheduler(ctx)
-    await scheduler.remove_job(params["id"])
+    removed = await scheduler.remove_job(params["id"])
+    if not removed:
+        raise KeyError(f"Cron job not found: {params['id']}")
     return None
 
 

--- a/tests/test_cli/test_cron_remove_missing.py
+++ b/tests/test_cli/test_cron_remove_missing.py
@@ -1,0 +1,80 @@
+"""CLI cron remove must not invent success when the gateway says NOT_FOUND.
+
+Pairs with gateway/rpc_cron.py fix for https://github.com/use-agent-os/agent-os/issues/1598.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from typer.testing import CliRunner
+
+from agentos.cli.main import app
+
+runner = CliRunner()
+
+
+class _NotFoundOnRemoveGateway:
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    def __init__(self) -> None:
+        pass
+
+    async def connect(self, url: str, *, token=None) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+    async def call(self, method: str, params: dict | None = None) -> Any:
+        from agentos.cli.gateway_client import GatewayRPCError
+
+        type(self).calls.append((method, params or {}))
+        if method == "cron.remove":
+            raise GatewayRPCError(
+                method,
+                code="NOT_FOUND",
+                message=f"Cron job not found: {(params or {}).get('id')}",
+            )
+        return {}
+
+
+def test_cron_remove_missing_job_exits_nonzero(monkeypatch) -> None:
+    _NotFoundOnRemoveGateway.calls = []
+    monkeypatch.setattr(
+        "agentos.cli.gateway_client.GatewayClient",
+        _NotFoundOnRemoveGateway,
+    )
+
+    result = runner.invoke(
+        app,
+        ["cron", "remove", "missing-job-xyz", "--yes", "--json"],
+    )
+
+    assert result.exit_code != 0
+    err = json.loads(result.stderr)
+    assert err["error"]["code"] == "NOT_FOUND"
+    assert "missing-job-xyz" in err["error"]["message"]
+    # Must not emit the invented success payload on stdout.
+    assert "removed" not in (result.stdout or "")
+    assert ("cron.remove", {"id": "missing-job-xyz"}) in _NotFoundOnRemoveGateway.calls
+
+
+def test_cron_remove_success_still_reports_removed(monkeypatch) -> None:
+    class _OkRemoveGateway(_NotFoundOnRemoveGateway):
+        async def call(self, method: str, params: dict | None = None) -> Any:
+            type(self).calls.append((method, params or {}))
+            return None
+
+    _OkRemoveGateway.calls = []
+    monkeypatch.setattr("agentos.cli.gateway_client.GatewayClient", _OkRemoveGateway)
+
+    result = runner.invoke(
+        app,
+        ["cron", "remove", "job-1", "--yes", "--json"],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert payload == {"id": "job-1", "removed": True}

--- a/tests/test_gateway/test_rpc_cron_remove.py
+++ b/tests/test_gateway/test_rpc_cron_remove.py
@@ -1,0 +1,67 @@
+"""cron.remove must refuse missing jobs the same way status/update do.
+
+Regression for https://github.com/use-agent-os/agent-os/issues/1598 —
+scheduler.remove_job already returns False when the id is absent, but the
+RPC handler used to discard that bool and always report success. The CLI
+then invented ``{"removed": true}``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentos.gateway.rpc import RpcContext
+from agentos.gateway.rpc_cron import _handle_cron_remove
+
+
+class _FakeScheduler:
+    def __init__(self, *, existing: set[str] | None = None) -> None:
+        self.existing = set(existing or ())
+        self.removed: list[str] = []
+
+    async def remove_job(self, job_id: str) -> bool:
+        self.removed.append(job_id)
+        if job_id not in self.existing:
+            return False
+        self.existing.discard(job_id)
+        return True
+
+
+@pytest.mark.asyncio
+async def test_cron_remove_missing_job_raises_not_found() -> None:
+    scheduler = _FakeScheduler(existing=set())
+
+    with pytest.raises(KeyError, match="Cron job not found: missing-job"):
+        await _handle_cron_remove(
+            {"id": "missing-job"},
+            RpcContext(conn_id="test", cron_scheduler=scheduler),
+        )
+
+    assert scheduler.removed == ["missing-job"]
+
+
+@pytest.mark.asyncio
+async def test_cron_remove_existing_job_succeeds() -> None:
+    scheduler = _FakeScheduler(existing={"job-1"})
+
+    result = await _handle_cron_remove(
+        {"id": "job-1"},
+        RpcContext(conn_id="test", cron_scheduler=scheduler),
+    )
+
+    assert result is None
+    assert scheduler.removed == ["job-1"]
+    assert "job-1" not in scheduler.existing
+
+
+@pytest.mark.asyncio
+async def test_cron_remove_requires_id() -> None:
+    scheduler = _FakeScheduler(existing={"job-1"})
+
+    with pytest.raises(ValueError, match="params.id is required"):
+        await _handle_cron_remove(
+            {},
+            RpcContext(conn_id="test", cron_scheduler=scheduler),
+        )
+
+    assert scheduler.removed == []


### PR DESCRIPTION
## Summary
- **The bug:** `agentos cron remove <missing-id> --yes --json` exited 0 with `{"removed": true}` even when the job did not exist. `cron.status` / `cron.update` already hard-fail with `NOT_FOUND`.
- **Repro on main:** `cron status missing-job --json` → exit 2; `cron remove missing-job --yes --json` → exit 0 + `removed: true`.
- **The fix:** `scheduler.remove_job` already returns `False` for unknown ids. `_handle_cron_remove` now raises `KeyError(f"Cron job not found: …")` when that bool is false (same pattern as status/update). CLI success path unchanged; it only invents `removed: true` after a successful RPC.

Fixes #1598

## Test plan
- [x] `tests/test_gateway/test_rpc_cron_remove.py` — missing → KeyError; existing → ok; missing `id` → ValueError
- [x] `tests/test_cli/test_cron_remove_missing.py` — gateway NOT_FOUND → non-zero exit, no invented success stdout; real remove still `{"removed": true}`
- [ ] CI green on this PR