### PR TITLE
fix(channels/discord): approval sessionKey check uses entry name, not literal "discord"

### DIFF
--- a/src/agentos/channels/discord.py
+++ b/src/agentos/channels/discord.py
@@ -90,6 +90,7 @@ FATAL_ERROR_CLASSES: tuple[str, ...] = (
 class DiscordChannelConfig(BaseModel):
     """Pydantic config for Discord channel adapter."""
 
+    name: str = "discord"
     token: str
     application_id: str = ""
     default_channel_id: str = ""
@@ -729,7 +730,7 @@ class DiscordChannel:
                 session_mode = parts[3]
                 session_peer = parts[4]
                 expected_peer = channel_id if session_mode in ("group", "channel") else user_id
-                if session_channel != "discord" or session_peer != expected_peer:
+                if session_channel != self.config.name or session_peer != expected_peer:
                     log.warning(
                         "discord.component_mismatch",
                         session_key=session_key,

--- a/tests/test_channels/test_discord_approval_entry_name.py
+++ b/tests/test_channels/test_discord_approval_entry_name.py
@@ -1,0 +1,85 @@
+"""Regression test: Discord approval sessionKey binding hardcodes "discord".
+
+``_handle_discord_component_interaction`` checks
+``session_channel != "discord"`` -- a hardcoded literal -- instead of the
+configured channel entry's actual name, unlike the Telegram and MSTeams
+handlers which correctly compare against ``self.config.name``.
+
+Session keys embed the *configured entry name* (``ChannelManager.
+_build_session_key`` -> ``session.keys.build_group_key(channel=entry.name,
+...)``), which is a required field with no default
+(``ConfiguredChannelEntry.name: str``) -- every real deployment sets it
+explicitly, and any multi-account Discord setup necessarily has at least
+one entry not literally named "discord" (dict keys must be unique). For
+any such entry, every approve/deny click is wrongly rejected as a
+"mismatch" even though it is the correct, intended approver -- the pending
+tool-call approval is never resolved.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agentos.channels.discord import DiscordChannel, DiscordChannelConfig
+from agentos.gateway.approval_queue import get_approval_queue, reset_approval_queue
+from agentos.session.keys import build_group_key
+
+
+@pytest.fixture(autouse=True)
+def _clean_approval_queue():
+    reset_approval_queue()
+    yield
+    reset_approval_queue()
+
+
+async def test_discord_approval_resolves_for_a_non_default_named_entry() -> None:
+    """A Discord entry configured as e.g. "discord-support" (not literally
+    "discord") must still be able to resolve its own pending approvals.
+    """
+    queue = get_approval_queue()
+    session_key = build_group_key(agent_id="main", channel="discord-support", peer_id="chan123")
+    approval_id = queue.request(
+        "exec",
+        {"argv": ["rm", "-rf"], "action_kind": "exec", "sessionKey": session_key},
+    )
+
+    channel = DiscordChannel(DiscordChannelConfig(token="test-token", name="discord-support"))
+    channel.policy = replace(channel.policy, allowlist=frozenset(), allowlist_enabled=False)
+
+    post_calls: list[tuple[str, dict]] = []
+
+    async def fake_post(path, json=None, headers=None, **kwargs):
+        post_calls.append((path, json))
+
+        class FakeResp:
+            def raise_for_status(self) -> None:
+                pass
+
+            def json(self) -> dict:
+                return {"id": "999"}
+
+        return FakeResp()
+
+    channel._get_client = lambda: AsyncMock(post=fake_post)  # type: ignore[method-assign]
+
+    data = {
+        "type": 3,
+        "id": "int123",
+        "token": "token123",
+        "channel_id": "chan123",
+        "user": {"id": "usr123"},
+        "message": {"content": "Approval requested"},
+        "data": {"custom_id": f"approve:{approval_id}"},
+    }
+
+    await channel._handle_discord_component_interaction(data)
+
+    entry = queue.get(approval_id)
+    assert entry.resolved is True, (
+        "approval was never resolved -- the sessionKey check wrongly treated "
+        "a correctly-matching entry name as a mismatch"
+    )
+    assert entry.approved is True


### PR DESCRIPTION
## Linked issue
Fixes #1600 

## Summary
`_handle_discord_component_interaction`'s sessionKey binding check compared
the session key's channel segment against the hardcoded literal `"discord"`:

    if session_channel != "discord" or session_peer != expected_peer:

`telegram.py` and `msteams.py` implement the identical check correctly,
against `self.config.name`. Session keys embed the *configured entry name*
(`ChannelManager._build_session_key` -> `session.keys.build_group_key
(channel=entry.name, ...)`), and `ConfiguredChannelEntry.name` is a
required field with no default -- every deployment sets it explicitly.
Any multi-account Discord setup (two bot tokens/servers) necessarily has
at least one entry not literally named `"discord"` (dict keys must be
unique, same pattern as the Slack multi-account fix in #1022).

For any such entry, every Approve/Deny click on a pending gated tool call
(shell exec, plugin) is logged as `discord.component_mismatch` and
silently dropped -- the correct, intended approver is rejected and the
tool call never resolves.

Root cause: `DiscordChannelConfig` never declared a `name` field.
`registry.py`'s generic config builder only wires `entry.name` into an
adapter's config when that config class opts in
(`if "name" in config_fields and hasattr(entry, "name")`) -- Slack,
Telegram, and MSTeams all opt in; Discord didn't have the field to opt in
with.

## Fix
- Added `name: str = "discord"` to `DiscordChannelConfig` (default
  preserves current behavior for anyone who didn't set an explicit name).
- Changed the hardcoded `"discord"` comparison to `self.config.name`.
- No registry.py changes needed -- adding the field alone makes the
  existing generic wiring pick it up.

## Tests
New file `tests/test_channels/test_discord_approval_entry_name.py`:
builds a real `ApprovalQueue` entry with a session key constructed via the
actual `session.keys.build_group_key()` helper for a `"discord-support"`-
named entry, and asserts it resolves correctly. Verified failing against
unfixed code first (session mismatch logged, approval never resolved).

Existing `test_discord_component_interaction_handling` (default-named
entry) re-run and still passes -- no behavior change for the common case.

Commands run:
uv run ruff check src/agentos/channels/discord.py tests/test_channels/test_discord_approval_entry_name.py
uv run ruff format --check src/agentos/channels/discord.py tests/test_channels/test_discord_approval_entry_name.py
uv run mypy src/agentos/channels/discord.py tests/test_channels/test_discord_approval_entry_name.py --show-error-codes
uv run pytest tests/test_channels/ tests/unit/chat/ -q

Results: ruff clean, ruff format clean, mypy clean, 428/428 passed
(427 pre-existing + 1 new).

Third-party origin: none.