### PR TITLE
fix(channels): Slack entry name never reaches the adapter, breaking approvals

### DIFF
--- a/src/agentos/channels/registry.py
+++ b/src/agentos/channels/registry.py
@@ -229,4 +229,6 @@ def _build_generic_channel(
         return cast("ManagedChannel", channel_class(config=config_class(**config_kwargs)))
 
     kwargs = {key: value for key, value in data.items() if key in accepted}
+    if "name" in accepted and hasattr(entry, "name"):
+        kwargs["name"] = entry.name
     return cast("ManagedChannel", channel_class(**kwargs))

--- a/src/agentos/channels/slack.py
+++ b/src/agentos/channels/slack.py
@@ -104,7 +104,7 @@ class SlackChannel:
 
     token: str
     slack_channel_id: str
-    channel_id: str = "slack"
+    name: str = "slack"
     sender_id: str = "slack-user"
     bot_user_id: str | None = None
     reply_in_thread: bool = False
@@ -916,7 +916,7 @@ class SlackChannel:
                 session_mode = parts[3]
                 session_peer = parts[4]
                 expected_peer = channel_id if session_mode in ("group", "channel") else user_id
-                if session_channel != self.channel_id or session_peer != expected_peer:
+                if session_channel != self.name or session_peer != expected_peer:
                     log.warning(
                         "slack.interactive_mismatch",
                         session_key=session_key,

--- a/tests/test_channels/test_slack_approval_entry_name.py
+++ b/tests/test_channels/test_slack_approval_entry_name.py
@@ -1,0 +1,85 @@
+"""Regression test: a Slack channel entry's configured ``name`` never
+reaches ``SlackChannel``, breaking approval sessionKey binding for any
+entry not literally named "slack".
+
+Root cause is in the registry, not slack.py's approval-check logic itself:
+``_build_generic_channel``'s flat/kwargs path (used for adapters like
+``SlackChannel`` that take plain constructor kwargs rather than a nested
+``*ChannelConfig`` object) has no equivalent of the ``name`` re-injection
+the config-wrapped path already does. ``entry.name`` is unconditionally
+excluded from the dumped data (``_COMMON_ENTRY_FIELDS``) and never added
+back for the flat path, so ``SlackChannel.name`` is permanently stuck at
+its default regardless of how the operator configures the entry.
+
+Any multi-account Slack setup (the exact scenario #1022 already
+established as a real, supported use case) necessarily has at least one
+entry not literally named "slack" (entry names are the dict key in
+``ChannelManager._channels`` and must be unique). For any such entry,
+every Approve/Deny click is wrongly rejected as a "mismatch".
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentos.channels.registry import build_managed_channel
+from agentos.channels.slack import SlackChannel
+from agentos.gateway.approval_queue import get_approval_queue, reset_approval_queue
+from agentos.gateway.config import SlackChannelEntry
+from agentos.session.keys import build_group_key
+
+
+@pytest.fixture(autouse=True)
+def _clean_approval_queue():
+    reset_approval_queue()
+    yield
+    reset_approval_queue()
+
+
+def test_registry_wires_entry_name_into_slack_channel() -> None:
+    """The entry's configured name must reach the built adapter -- this is
+    exactly what already happens for Discord/Telegram/MSTeams via their
+    nested ``*ChannelConfig`` classes; Slack's flat constructor path must
+    get the same treatment.
+    """
+    entry = SlackChannelEntry(name="slack-support", token="xoxb-fake", slack_channel_id="C12345")
+
+    channel = build_managed_channel(entry)
+
+    assert isinstance(channel, SlackChannel)
+    assert channel.name == "slack-support"
+
+
+async def test_slack_approval_resolves_for_a_non_default_named_entry() -> None:
+    """A Slack entry configured as e.g. "slack-support" (not literally
+    "slack") must still be able to resolve its own pending approvals.
+    """
+    queue = get_approval_queue()
+    session_key = build_group_key(agent_id="main", channel="slack-support", peer_id="C12345")
+    approval_id = queue.request(
+        "exec",
+        {"argv": ["rm", "-rf"], "action_kind": "exec", "sessionKey": session_key},
+    )
+
+    entry = SlackChannelEntry(name="slack-support", token="xoxb-fake", slack_channel_id="C12345")
+    channel = build_managed_channel(entry)
+    assert isinstance(channel, SlackChannel)
+
+    payload = {
+        "actions": [{"value": f"approve:{approval_id}"}],
+        "user": {"id": "usr123"},
+        "channel": {"id": "C12345"},
+        "team": {"id": "T123"},
+        "message": {"text": "Approval requested"},
+        # No response_url -- keeps this test focused on the binding check,
+        # not Slack's outbound "update the original message" call.
+    }
+
+    await channel._handle_slack_interactive(payload)
+
+    entry_after = queue.get(approval_id)
+    assert entry_after.resolved is True, (
+        "approval was never resolved -- the sessionKey check wrongly treated "
+        "a correctly-matching entry name as a mismatch"
+    )
+    assert entry_after.approved is True


### PR DESCRIPTION
## Linked issue
Fixes #1606 

## Summary
`SlackChannel` is the only channel adapter that takes flat constructor
kwargs instead of a nested `*ChannelConfig` object. `_build_generic_channel`
handles that path with plain `kwargs = {k: v for k, v in data.items() if
k in accepted}` -- no equivalent of the `name` re-injection the
config-wrapped path already does for Discord/Telegram/MSTeams. Since
`entry.name` is unconditionally excluded from `data` up front
(`_COMMON_ENTRY_FIELDS`), Slack's entry-name field (previously named
`channel_id`, default `"slack"`) can **never** receive the operator's
configured name -- confirmed through the real `build_managed_channel()`
pipeline, not by inspection alone:

    entry.name          = 'slack-support'
    channel.channel_id  = 'slack'

Any multi-account Slack setup (already established as a real, supported
scenario in #1022 -- entry names are unique `ChannelManager._channels`
dict keys) necessarily has at least one entry not literally named
`"slack"`. For any such entry, `_handle_slack_interactive`'s approval
sessionKey check compares against this permanently-`"slack"` field, so
every Approve/Deny click is logged as `slack.interactive_mismatch` and
the pending gated tool call (shell exec, plugin) never resolves. Same
symptom class as the Discord fix in #1600, different root cause --
that one was a missing field, this one is a structurally unreachable one.

## Fix
- `registry.py`: the flat/kwargs build path now re-injects `entry.name`
  the same way the config-wrapped path already does.
- `slack.py`: renamed the dead `channel_id` field to `name` (its only use
  site was this same approval check -- confirmed no other references
  anywhere in source, including all test files) and updated the check to
  use it.

## Tests
New file `tests/test_channels/test_slack_approval_entry_name.py`, two
tests, both using the real `build_managed_channel()` pipeline (not
hand-mocked field assignment):
- the built adapter's `name` actually equals the entry's configured name
- a real `ApprovalQueue` entry with a session key built via the actual
  `session.keys.build_group_key()` helper for a `"slack-support"`-named
  entry resolves correctly

Both verified failing against unfixed code first.

Commands run:
uv run ruff check src/agentos/channels/slack.py src/agentos/channels/registry.py tests/test_channels/test_slack_approval_entry_name.py
uv run ruff format --check src/agentos/channels/slack.py src/agentos/channels/registry.py tests/test_channels/test_slack_approval_entry_name.py
uv run mypy src/agentos/channels/slack.py src/agentos/channels/registry.py tests/test_channels/test_slack_approval_entry_name.py --show-error-codes
uv run pytest tests/test_channels/ tests/unit/chat/ -q

Results: ruff clean, ruff format clean, mypy clean, 430/430 passed
(428 pre-existing + 2 new).

Note: `ruff format` on the full `registry.py` also wants to collapse an
unrelated list comprehension in `discover_channel_names` (pre-existing on
`main`, confirmed present before this change) -- left untouched to keep
this diff scoped to the fix.

Third-party origin: none.