### PR TITLE
fix(tools): match grep_search include glob against relative path

### DIFF
--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -1048,8 +1048,12 @@ async def grep_search(
                     continue
                 if not fp.is_file():
                     continue
-                if include and not fnmatch.fnmatch(fp.name, include):
-                    continue
+                if include:
+                    rel_include = fp.relative_to(base).as_posix()
+                    if not fnmatch.fnmatch(fp.name, include) and not fnmatch.fnmatch(
+                        rel_include, include
+                    ):
+                        continue
                 search_file(fp)
 
         return results

--- a/tests/test_tools/test_grep_search_include.py
+++ b/tests/test_tools/test_grep_search_include.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from agentos.tools.builtin import filesystem as fs
+from agentos.tools.types import CallerKind, ToolContext, current_tool_context
+
+
+@contextmanager
+def tool_context(workspace: Path) -> Iterator[None]:
+    token = current_tool_context.set(
+        ToolContext(
+            caller_kind=CallerKind.CLI,
+            channel_kind="cli",
+            channel_id="cli:test",
+            workspace_dir=str(workspace),
+            workspace_strict=True,
+        )
+    )
+    try:
+        yield
+    finally:
+        current_tool_context.reset(token)
+
+
+def _make_tree(root: Path) -> None:
+    (root / "tests").mkdir()
+    (root / "tests" / "test_basic.py").write_text("def test_x(): pass\n", encoding="utf-8")
+    (root / "src").mkdir()
+    (root / "src" / "utils.py").write_text("def test_x(): pass\n", encoding="utf-8")
+    (root / "src" / "pkg").mkdir()
+    (root / "src" / "pkg" / "helpers.py").write_text("def test_x(): pass\n", encoding="utf-8")
+    (root / "test_basic.py").write_text("def test_x(): pass\n", encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_include_with_path_qualified_glob_matches_relative_path(tmp_path: Path) -> None:
+    _make_tree(tmp_path)
+    with tool_context(tmp_path):
+        out = await fs.grep_search("def test_x", path=str(tmp_path), include="tests/*.py")
+
+    assert "No matches" not in out
+    assert str(tmp_path / "tests" / "test_basic.py") in out
+    assert str(tmp_path / "src" / "utils.py") not in out
+    assert str(tmp_path / "test_basic.py") not in out
+
+
+@pytest.mark.asyncio
+async def test_include_with_bare_filename_glob_still_matches_by_basename(tmp_path: Path) -> None:
+    _make_tree(tmp_path)
+    with tool_context(tmp_path):
+        out = await fs.grep_search("def test_x", path=str(tmp_path), include="*.py")
+
+    assert str(tmp_path / "tests" / "test_basic.py") in out
+    assert str(tmp_path / "src" / "utils.py") in out
+    assert str(tmp_path / "test_basic.py") in out
+
+
+@pytest.mark.asyncio
+async def test_include_with_double_star_path_glob_matches_nested_paths(tmp_path: Path) -> None:
+    _make_tree(tmp_path)
+    with tool_context(tmp_path):
+        out = await fs.grep_search("def test_x", path=str(tmp_path), include="src/**/*.py")
+
+    assert str(tmp_path / "src" / "pkg" / "helpers.py") in out
+    assert str(tmp_path / "tests" / "test_basic.py") not in out
+
+
+@pytest.mark.asyncio
+async def test_include_path_glob_that_matches_nothing_reports_no_matches(tmp_path: Path) -> None:
+    _make_tree(tmp_path)
+    with tool_context(tmp_path):
+        out = await fs.grep_search("def test_x", path=str(tmp_path), include="docs/*.py")
+
+    assert "No matches" in out


### PR DESCRIPTION
Fixes #1571

## The bug

In `src/agentos/tools/builtin/filesystem.py`, `grep_search`'s `include` filter only ever compared
against the bare filename:

```python
if include and not fnmatch.fnmatch(fp.name, include):
    continue
```

`fp.name` never contains a directory separator, so any path-qualified glob (`"tests/*.py"`,
`"src/**/*.py"`, `"components/*.tsx"`) evaluates to `False` for every candidate file, and the tool
always reports `No matches for '<pattern>'` even when the pattern exists under that directory.
`glob_search` in the same file already resolves against the relative path
(`fp.relative_to(base).as_posix()`), so this is an inconsistency between the two tools rather than a
one-off oversight.

## The fix

Match `include` against both the bare filename (unchanged, preserves existing `"*.py"`-style usage)
and the path relative to the search root:

```python
if include:
    rel_include = fp.relative_to(base).as_posix()
    if not fnmatch.fnmatch(fp.name, include) and not fnmatch.fnmatch(
        rel_include, include
    ):
        continue
```

Nothing else in `grep_search` changed.

## Tests

`tests/test_tools/test_grep_search_include.py` (4 cases, all offline, no network/credentials):

- `test_include_with_path_qualified_glob_matches_relative_path` — `include="tests/*.py"` finds the
  file under `tests/` and excludes sibling files outside it (the exact repro from the issue).
- `test_include_with_bare_filename_glob_still_matches_by_basename` — `include="*.py"` still matches
  every `.py` file regardless of directory, confirming the existing behavior isn't broken.
- `test_include_with_double_star_path_glob_matches_nested_paths` — `include="src/**/*.py"` matches a
  file nested two levels deep and excludes files outside `src/`.
- `test_include_path_glob_that_matches_nothing_reports_no_matches` — a glob with no matching files
  still returns the `No matches` message.

Without the fix, `test_include_with_path_qualified_glob_matches_relative_path` and
`test_include_with_double_star_path_glob_matches_nested_paths` fail (both assert `"No matches"` is
*not* returned, exactly reproducing the bug). The other two pass either way by design — they guard
that bare-filename matching and the "truly no match" case keep working.

## Verification

Self-test (upstream `filesystem.py` swapped in temporarily, new tests re-run):

```
$ uv run pytest -q tests/test_tools/test_grep_search_include.py
2 failed, 2 passed in 1.23s
FAILED tests/test_tools/test_grep_search_include.py::test_include_with_path_qualified_glob_matches_relative_path
FAILED tests/test_tools/test_grep_search_include.py::test_include_with_double_star_path_glob_matches_nested_paths
```

With the fix:

```
$ uv run pytest -q tests/test_tools/test_grep_search_include.py
4 passed in 1.18s

$ uv run pytest -q
6 failed, 10172 passed, 34 skipped, 4 warnings, 3 errors in 246.83s
```

The 6 failures / 3 errors are pre-existing on `upstream/main` and unrelated to this change (pilot
router ONNX encoder assets, a machine-timezone hygiene check, and wheelhouse packaging tests that need
built ML assets not present in this environment) — same set, same count, before and after this diff.

```
$ uv run ruff check .
All checks passed!

$ uv run mypy --show-error-codes src
Success: no issues found in 625 source files
```

## One adjacent case, deliberately left alone

`fnmatch` has no special "match zero or more directories" semantics for `**` the way shell `globstar`
or newer `pathlib.Path.full_match` do, so `include="src/**/*.py"` won't match a file directly in
`src/` (depth 0) — only nested at least one directory deeper, as covered by the test. Getting fully
shell-`globstar`-equivalent semantics would need a small glob-translation helper of its own; happy to
follow up separately if that's wanted, but it's out of scope for the reported bug (which is about
path-qualified `include` not matching at all).
