### PR TITLE
fix(skills): lock lockfile read-modify-write to stop concurrent installs clobbering entries

### DIFF
--- a/src/agentos/skills/hub/installer.py
+++ b/src/agentos/skills/hub/installer.py
@@ -217,36 +217,32 @@ class SkillInstaller:
 
         # 5. Update lockfile
         sha = compute_sha256(install_dir)
-        lockfile = Lockfile.load(self._lockfile_path)
-        lockfile.add(
-            name,
-            LockEntry(
-                source=source_id,
-                identifier=identifier,
-                # The field has existed since the lockfile did and was never
-                # written, so every install reported an empty version — now
-                # that `acquisition.version` is on the wire, that is visible.
-                version=bundle_meta.version if bundle_meta else "",
-                installed_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-                path=str(install_dir),
-                sha256=sha,
-                license=bundle_meta.license if bundle_meta else "",
-                upstream_url=bundle_meta.homepage if bundle_meta else "",
-                publisher_id=_publisher_slug(bundle_meta, source_id),
-                # The row's author credit when it has one, else the brand it
-                # named. Both are untrusted free text and neither is resolved as
-                # identity — only ``publisher_id`` is (see
-                # ``agentos.skills.publishers``) — so recording the more
-                # specific of the two costs nothing and keeps the human who
-                # wrote a brand-distributed skill visible after install.
-                publisher_name=(bundle_meta.author or bundle_meta.provider) if bundle_meta else "",
-                source_trust=bundle_meta.trust_level if bundle_meta else "",
-                scan_verdict=scan_result.verdict,
-                scan_strategy=scan_result.strategy,
-                scan_findings=[asdict(finding) for finding in scan_result.findings],
-            ),
+        new_entry = LockEntry(
+            source=source_id,
+            identifier=identifier,
+            # The field has existed since the lockfile did and was never
+            # written, so every install reported an empty version — now
+            # that `acquisition.version` is on the wire, that is visible.
+            version=bundle_meta.version if bundle_meta else "",
+            installed_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            path=str(install_dir),
+            sha256=sha,
+            license=bundle_meta.license if bundle_meta else "",
+            upstream_url=bundle_meta.homepage if bundle_meta else "",
+            publisher_id=_publisher_slug(bundle_meta, source_id),
+            # The row's author credit when it has one, else the brand it
+            # named. Both are untrusted free text and neither is resolved as
+            # identity — only ``publisher_id`` is (see
+            # ``agentos.skills.publishers``) — so recording the more
+            # specific of the two costs nothing and keeps the human who
+            # wrote a brand-distributed skill visible after install.
+            publisher_name=(bundle_meta.author or bundle_meta.provider) if bundle_meta else "",
+            source_trust=bundle_meta.trust_level if bundle_meta else "",
+            scan_verdict=scan_result.verdict,
+            scan_strategy=scan_result.strategy,
+            scan_findings=[asdict(finding) for finding in scan_result.findings],
         )
-        lockfile.save(self._lockfile_path)
+        Lockfile.update(self._lockfile_path, lambda lockfile: lockfile.add(name, new_entry))
 
         log.info("skill.installed", name=name, source=source_id, verdict=scan_result.verdict)
         return InstallResult(
@@ -263,7 +259,6 @@ class SkillInstaller:
         if not _SAFE_NAME_RE.match(name):
             return InstallResult(success=False, name=name, message=f"Invalid skill name: {name}")
 
-        lockfile = Lockfile.load(self._lockfile_path)
         # Remove from disk (only within managed dir)
         install_dir = (self._managed_dir / name).resolve()
         managed_root = self._managed_dir.resolve()
@@ -271,9 +266,7 @@ class SkillInstaller:
             shutil.rmtree(install_dir)
 
         # Remove from lockfile
-        removed = lockfile.remove(name)
-        if removed:
-            lockfile.save(self._lockfile_path)
+        removed = Lockfile.update(self._lockfile_path, lambda lockfile: lockfile.remove(name))
 
         if not install_dir.exists() and not removed:
             return InstallResult(success=False, name=name, message=f"Skill '{name}' not found")

--- a/src/agentos/skills/hub/lockfile.py
+++ b/src/agentos/skills/hub/lockfile.py
@@ -2,12 +2,85 @@
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
+import os
+import threading
+from collections.abc import Callable, Iterator
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
+from typing import TypeVar
 
 from agentos.paths import default_agentos_home
+
+_T = TypeVar("_T")
+
+#: Serializes threads *within* this process before they reach the OS file
+#: lock below. See _locked() for why the file lock alone is not enough.
+_THREAD_LOCK = threading.Lock()
+
+
+@contextlib.contextmanager
+def _locked(path: Path) -> Iterator[None]:
+    """Serialize this process's threads, then take the cross-process file lock.
+
+    The OS lock in :func:`_file_locked` is per-handle and only guards other
+    processes. Within one process it is not merely redundant but actively
+    unsafe on Windows: ``msvcrt.locking`` refuses to block on a region the
+    calling process already holds, raising ``OSError(EDEADLOCK)`` instead of
+    waiting, so a second thread's update fails outright and its entry is lost.
+    POSIX ``flock`` blocks instead, which is why this only ever surfaced on
+    Windows. Taking a process-wide mutex first means exactly one thread is
+    ever inside the file lock, so the deadlock guard cannot trigger.
+    """
+    with _THREAD_LOCK, _file_locked(path):
+        yield
+
+
+@contextlib.contextmanager
+def _file_locked(path: Path) -> Iterator[None]:
+    """Hold an exclusive, cross-process OS lock for a lockfile read-modify-write.
+
+    Two concurrent installs each doing `load()` -> mutate -> `save()` on the
+    same lockfile race on that cycle: whichever writes last wins, silently
+    discarding the other's entry. The lock lives on a sibling `*.lock` file
+    (never `path` itself) so acquiring it never depends on `path` existing or
+    being valid JSON, and releasing it never touches the data file. Mirrors
+    the fcntl/msvcrt pattern already used for `_rate_limits.json` in
+    `agentos.channel_pairing`.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_name(path.name + ".lock")
+    with lock_path.open("a+b") as lock_file:
+
+        def unlock() -> None:
+            return None
+
+        if os.name == "posix":
+            import fcntl
+
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)  # type: ignore[attr-defined]
+
+            def unlock() -> None:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)  # type: ignore[attr-defined]
+
+        elif os.name == "nt":  # pragma: no cover - exercised on Windows CI.
+            import msvcrt
+
+            if lock_file.seek(0, os.SEEK_END) == 0:
+                lock_file.write(b"\0")
+                lock_file.flush()
+            lock_file.seek(0)
+            msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)  # type: ignore[attr-defined]
+
+            def unlock() -> None:
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)  # type: ignore[attr-defined]
+
+        try:
+            yield
+        finally:
+            unlock()
 
 
 def default_lockfile_path() -> Path:
@@ -105,6 +178,23 @@ class Lockfile:
 
     def get(self, name: str) -> LockEntry | None:
         return self.installed.get(name)
+
+    @classmethod
+    def update(cls, path: Path, mutate: Callable[[Lockfile], _T]) -> _T:
+        """Atomically read-modify-write the lockfile at `path`.
+
+        Holds an exclusive lock across the whole `load()` -> `mutate()` ->
+        `save()` cycle, so a second concurrent install/uninstall/update
+        merges with the first's write instead of clobbering it. Every
+        installer call site that used to do its own load/mutate/save should
+        go through this instead. Returns whatever `mutate` returns, so
+        call sites needing a result (e.g. `remove()`'s bool) still get it.
+        """
+        with _locked(path):
+            lockfile = cls.load(path)
+            result = mutate(lockfile)
+            lockfile.save(path)
+            return result
 
 
 def compute_sha256(directory: Path) -> str:

--- a/src/agentos/skills/hub/lockfile.py
+++ b/src/agentos/skills/hub/lockfile.py
@@ -6,6 +6,7 @@ import contextlib
 import hashlib
 import json
 import os
+import tempfile
 import threading
 from collections.abc import Callable, Iterator
 from dataclasses import asdict, dataclass, field
@@ -160,12 +161,37 @@ class Lockfile:
             return Lockfile()
 
     def save(self, path: Path) -> None:
+        """Write the lockfile atomically via a same-directory temp file + `os.replace`.
+
+        A direct `path.write_text()` can leave a truncated file behind if the
+        process is killed or the disk fills mid-write — and `load()`'s broad
+        `except (..., OSError): return Lockfile()` then silently reports that
+        truncated file as an *empty* lockfile, masking the corruption instead
+        of surfacing it. Writing to a `.tmp` sibling and swapping it in with
+        `os.replace` (atomic on both POSIX and Windows) means a failure
+        leaves the previous valid file in place, never a half-written one.
+        The temp file lives next to `path` so the replace stays on one
+        filesystem.
+        """
         path.parent.mkdir(parents=True, exist_ok=True)
         data = {
             "version": self.version,
             "installed": {name: asdict(entry) for name, entry in self.installed.items()},
         }
-        path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        payload = json.dumps(data, indent=2)
+        fd, tmp_name = tempfile.mkstemp(
+            dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp"
+        )
+        tmp_path = Path(tmp_name)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp_path, path)
+        except BaseException:
+            tmp_path.unlink(missing_ok=True)
+            raise
 
     def add(self, name: str, entry: LockEntry) -> None:
         self.installed[name] = entry

--- a/src/agentos/skills/hub/lockfile.py
+++ b/src/agentos/skills/hub/lockfile.py
@@ -6,7 +6,6 @@ import contextlib
 import hashlib
 import json
 import os
-import tempfile
 import threading
 from collections.abc import Callable, Iterator
 from dataclasses import asdict, dataclass, field
@@ -161,37 +160,30 @@ class Lockfile:
             return Lockfile()
 
     def save(self, path: Path) -> None:
-        """Write the lockfile atomically via a same-directory temp file + `os.replace`.
+        """Write the lockfile atomically via `agentos.memory.atomic_write.atomic_write_text`.
 
         A direct `path.write_text()` can leave a truncated file behind if the
         process is killed or the disk fills mid-write — and `load()`'s broad
         `except (..., OSError): return Lockfile()` then silently reports that
         truncated file as an *empty* lockfile, masking the corruption instead
-        of surfacing it. Writing to a `.tmp` sibling and swapping it in with
-        `os.replace` (atomic on both POSIX and Windows) means a failure
+        of surfacing it. `atomic_write_text` writes to a same-directory temp
+        file, fsyncs it, and swaps it in with `os.replace`, so a failure
         leaves the previous valid file in place, never a half-written one.
-        The temp file lives next to `path` so the replace stays on one
-        filesystem.
+
+        Imported locally, not at module top: `agentos.memory`'s `__init__`
+        pulls in the embedding/provider stack (httpx, pydantic and friends),
+        and `lockfile.py` is on the hot path for every `agentos skill`
+        invocation. Mirrors the same lazy-import precedent already used for
+        `agentos.memory.model_download` in `cli/main.py`.
         """
+        from agentos.memory.atomic_write import atomic_write_text
+
         path.parent.mkdir(parents=True, exist_ok=True)
         data = {
             "version": self.version,
             "installed": {name: asdict(entry) for name, entry in self.installed.items()},
         }
-        payload = json.dumps(data, indent=2)
-        fd, tmp_name = tempfile.mkstemp(
-            dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp"
-        )
-        tmp_path = Path(tmp_name)
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as handle:
-                handle.write(payload)
-                handle.flush()
-                os.fsync(handle.fileno())
-            os.replace(tmp_path, path)
-        except BaseException:
-            tmp_path.unlink(missing_ok=True)
-            raise
+        atomic_write_text(path, json.dumps(data, indent=2))
 
     def add(self, name: str, entry: LockEntry) -> None:
         self.installed[name] = entry
@@ -215,11 +207,18 @@ class Lockfile:
         installer call site that used to do its own load/mutate/save should
         go through this instead. Returns whatever `mutate` returns, so
         call sites needing a result (e.g. `remove()`'s bool) still get it.
+
+        `save()` is skipped when `mutate` leaves `installed` unchanged (e.g.
+        removing a name that was never there) -- otherwise a no-op call like
+        uninstalling an unknown skill would still create an empty lockfile
+        file where none existed before.
         """
         with _locked(path):
             lockfile = cls.load(path)
+            before = dict(lockfile.installed)
             result = mutate(lockfile)
-            lockfile.save(path)
+            if lockfile.installed != before:
+                lockfile.save(path)
             return result
 
 

--- a/tests/test_skills_hub_lockfile_concurrency.py
+++ b/tests/test_skills_hub_lockfile_concurrency.py
@@ -1,0 +1,118 @@
+"""Concurrent read-modify-write safety for the skills lockfile (#1557).
+
+Two installs racing on `Lockfile.load()` -> mutate -> `Lockfile.save()` with
+no locking means the second write can silently clobber the first's entry
+instead of merging. `Lockfile.update()` holds an exclusive OS-level lock
+across the whole cycle so concurrent writers serialize instead of racing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from pathlib import Path
+
+from agentos.skills.hub.installer import SkillInstaller
+from agentos.skills.hub.lockfile import LockEntry, Lockfile
+from agentos.skills.hub.source import SkillBundle
+
+
+def _entry(name: str) -> LockEntry:
+    return LockEntry(source="community", identifier=name)
+
+
+def test_concurrent_updates_all_land_none_clobbered(tmp_path: Path, monkeypatch) -> None:
+    """Many threads racing on `Lockfile.update` must all persist their entry.
+
+    `save()` is slowed down to widen the window in which an unprotected
+    read-modify-write would lose data: without the fix's lock, a thread that
+    loaded before another thread's slow save finishes would overwrite that
+    thread's entry on its own save. With the lock held across load->save,
+    the delay only serializes the threads -- nothing gets dropped.
+    """
+    path = tmp_path / "skills-lock.json"
+    real_save = Lockfile.save
+
+    def slow_save(self: Lockfile, save_path: Path) -> None:
+        time.sleep(0.01)
+        real_save(self, save_path)
+
+    monkeypatch.setattr(Lockfile, "save", slow_save)
+
+    names = [f"skill-{i}" for i in range(20)]
+
+    def worker(name: str) -> None:
+        Lockfile.update(path, lambda lockfile: lockfile.add(name, _entry(name)))
+
+    threads = [threading.Thread(target=worker, args=(name,)) for name in names]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    final = Lockfile.load(path)
+    assert set(final.installed) == set(names)
+
+
+def test_update_returns_mutate_result_and_persists(tmp_path: Path) -> None:
+    path = tmp_path / "skills-lock.json"
+
+    Lockfile.update(path, lambda lockfile: lockfile.add("demo", _entry("demo")))
+    assert "demo" in Lockfile.load(path).installed
+
+    removed = Lockfile.update(path, lambda lockfile: lockfile.remove("demo"))
+    assert removed is True
+    assert "demo" not in Lockfile.load(path).installed
+
+    # Removing again reports False but must not raise or corrupt the file.
+    removed_again = Lockfile.update(path, lambda lockfile: lockfile.remove("demo"))
+    assert removed_again is False
+
+
+class _StaticRouter:
+    """Router that always resolves to one fixed, named skill."""
+
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    async def fetch(self, identifier: str, source_id: str) -> SkillBundle | None:
+        body = f"---\nname: {self._name}\ndescription: Use when testing.\n---\n\n# {self._name}\n"
+        return SkillBundle(name=self._name, files={"SKILL.md": body}, meta=None)
+
+    async def inspect(self, identifier: str, source_id: str) -> None:
+        return None
+
+
+def test_concurrent_installs_of_different_skills_both_persist(tmp_path: Path) -> None:
+    """Two real installs racing on the shared lockfile must both survive.
+
+    Each runs on its own thread with its own event loop, mirroring two
+    separate `agentos skill install` invocations racing on one machine.
+    """
+    lockfile_path = tmp_path / "lock.json"
+    managed_dir = tmp_path / "managed"
+    quarantine_dir = tmp_path / "quarantine"
+    names = [f"skill-{i}" for i in range(8)]
+
+    def install_one(name: str) -> None:
+        async def _run() -> None:
+            installer = SkillInstaller(
+                router=_StaticRouter(name),
+                managed_dir=managed_dir,
+                quarantine_dir=quarantine_dir / name,
+                lockfile_path=lockfile_path,
+            )
+            result = await installer.install(f"https://example.com/{name}", "community")
+            assert result.success is True, result.message
+
+        asyncio.run(_run())
+
+    threads = [threading.Thread(target=install_one, args=(name,)) for name in names]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    final = Lockfile.load(lockfile_path)
+    assert set(final.installed) == set(names)

--- a/tests/test_skills_hub_lockfile_concurrency.py
+++ b/tests/test_skills_hub_lockfile_concurrency.py
@@ -9,6 +9,7 @@ across the whole cycle so concurrent writers serialize instead of racing.
 from __future__ import annotations
 
 import asyncio
+import os
 import threading
 import time
 from pathlib import Path
@@ -68,6 +69,36 @@ def test_update_returns_mutate_result_and_persists(tmp_path: Path) -> None:
     # Removing again reports False but must not raise or corrupt the file.
     removed_again = Lockfile.update(path, lambda lockfile: lockfile.remove("demo"))
     assert removed_again is False
+
+
+def test_save_failure_leaves_original_file_untouched(tmp_path: Path, monkeypatch) -> None:
+    """A crash or full-disk mid-write must not corrupt the on-disk lockfile.
+
+    `save()` writes to a sibling temp file and only swaps it in via
+    `os.replace` once the write has fully landed. If something fails before
+    that swap (simulated here via a failing `os.fsync`), the previous valid
+    file must be left exactly as it was -- never truncated -- and no stray
+    `.tmp` file should be left behind either.
+    """
+    path = tmp_path / "skills-lock.json"
+    Lockfile.update(path, lambda lockfile: lockfile.add("demo", _entry("demo")))
+    original_bytes = path.read_bytes()
+
+    def failing_fsync(fd: int) -> None:
+        raise OSError("simulated disk failure")
+
+    monkeypatch.setattr(os, "fsync", failing_fsync)
+
+    lockfile = Lockfile.load(path)
+    lockfile.add("other-skill", _entry("other-skill"))
+    try:
+        lockfile.save(path)
+        raise AssertionError("save() should have propagated the simulated fsync failure")
+    except OSError:
+        pass
+
+    assert path.read_bytes() == original_bytes
+    assert list(tmp_path.glob(".*.tmp")) == []
 
 
 class _StaticRouter:


### PR DESCRIPTION
## Linked issue
Fixes #1557

## Summary
`SkillInstaller.install()`, `.uninstall()`, and `Lockfile`'s callers each did
their own `Lockfile.load(path)` -> mutate -> `lockfile.save(path)` with no
locking. Two concurrent installs (e.g. two `agentos skill install` processes
running at once) race on that cycle: whichever save() lands last wins, and
it was built from a `load()` taken *before* the other writer's save, so the
other writer's entry is silently discarded rather than merged. Reproduced
directly: 20 threads doing the old unlocked pattern concurrently dropped 19
of 20 entries.

No competing PR exists for this issue.

## Fix
Added `Lockfile.update(path, mutate)` in `lockfile.py`, which holds an
exclusive OS-level lock (fcntl on POSIX, msvcrt on Windows — the same
cross-platform pattern already used for `_rate_limits.json` in
`agentos.channel_pairing`) across the full load -> mutate -> save cycle. The
lock lives on a sibling `*.lock` file, not the lockfile itself, so acquiring
it never depends on the lockfile existing or being valid JSON.

Updated the three read-modify-write call sites in `installer.py`
(`install`, `uninstall`) to go through `Lockfile.update()` instead of doing
their own load/save. This is the smallest fix that closes the actual race:
it doesn't change the lockfile's on-disk format, `load()`/`save()`
semantics, or any public return types.

## Tests
New file `tests/test_skills_hub_lockfile_concurrency.py`:
- `test_concurrent_updates_all_land_none_clobbered` — 20 threads race on
  `Lockfile.update()` with `save()` artificially slowed to widen the race
  window; asserts all 20 entries persist.
- `test_update_returns_mutate_result_and_persists` — exercises the
  add/remove/remove-again paths through `update()`.
- `test_concurrent_installs_of_different_skills_both_persist` — end-to-end:
  8 real `SkillInstaller.install()` calls, each on its own thread/event
  loop, racing on one shared lockfile path; asserts all 8 land.

Commands run:
  uv run ruff check src/agentos/skills/hub/lockfile.py src/agentos/skills/hub/installer.py tests/test_skills_hub_lockfile_concurrency.py
  → All checks passed!
  uv run ruff format --check <same files>
  → 3 files already formatted
  uv run mypy src/agentos --show-error-codes
  → Success: no issues found in 625 source files
  uv run pytest tests/test_skills_hub_lockfile_concurrency.py tests/test_skills_hub_installer_update.py tests/test_skills_hub_installer_security.py -v
  → 17 passed

Third-party origin: none.