### PR TITLE
fix(tools): check exact sheet name before positional index in read_spreadsheet

### DIFF
--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -743,15 +743,19 @@ def _select_spreadsheet_sheets(
     if requested is None or requested == "":
         return sheets
 
+    requested_name = str(requested)
+    # A sheet literally named "1" has to win over the positional reading of
+    # "1". Testing the index first made every numeric sheet name unreachable
+    # and silently returned whichever sheet sat at that 1-based position.
+    for name, rows, total_rows in sheets:
+        if name == requested_name:
+            return [(name, rows, total_rows)]
+
     if isinstance(requested, int) or (isinstance(requested, str) and requested.isdigit()):
         index = int(requested) - 1
         if 0 <= index < len(sheets):
             return [sheets[index]]
 
-    requested_name = str(requested)
-    for name, rows, total_rows in sheets:
-        if name == requested_name:
-            return [(name, rows, total_rows)]
     for name, rows, total_rows in sheets:
         if name.lower() == requested_name.lower():
             return [(name, rows, total_rows)]

--- a/tests/test_tools/test_read_spreadsheet_xlsx.py
+++ b/tests/test_tools/test_read_spreadsheet_xlsx.py
@@ -468,3 +468,59 @@ def test_read_xlsx_sheets_reading_does_not_scale_with_sheet_count(tmp_path: Path
     # ratio on a shared, noisy CI box.
     assert twenty_sheets < 1.0
     assert twenty_sheets < max(one_sheet * 5, one_sheet + 0.5)
+
+
+def _single_cell_sheet_xml(text: str) -> str:
+    return (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+        "<sheetData>"
+        f'<row r="1"><c r="A1" t="inlineStr"><is><t>{text}</t></is></c></row>'
+        "</sheetData>"
+        "</worksheet>"
+    )
+
+
+@pytest.mark.asyncio
+async def test_read_spreadsheet_reaches_a_sheet_named_like_an_index(tmp_path: Path) -> None:
+    """A workbook may name a sheet "1" (a year, a step, a code). Selecting it
+    by that name must return that sheet, not whichever sheet happens to sit
+    at 1-based position 1."""
+    target = tmp_path / "numeric-names.xlsx"
+    target.write_bytes(
+        _build_xlsx_bytes(
+            {
+                "Summary": _single_cell_sheet_xml("summary-cell"),
+                "1": _single_cell_sheet_xml("one-cell"),
+            }
+        )
+    )
+
+    with tool_context(tmp_path):
+        out = await fs.read_spreadsheet(str(target), sheet="1")
+
+    assert "one-cell" in out
+    assert "summary-cell" not in out
+
+
+@pytest.mark.asyncio
+async def test_read_spreadsheet_selects_by_position_when_no_sheet_has_that_name(
+    tmp_path: Path,
+) -> None:
+    """The positional reading of a numeric argument stays available -- it is
+    only outranked by an exact name match, never removed."""
+    target = tmp_path / "numeric-names.xlsx"
+    target.write_bytes(
+        _build_xlsx_bytes(
+            {
+                "Summary": _single_cell_sheet_xml("summary-cell"),
+                "1": _single_cell_sheet_xml("one-cell"),
+            }
+        )
+    )
+
+    with tool_context(tmp_path):
+        out = await fs.read_spreadsheet(str(target), sheet="2")
+
+    assert "one-cell" in out
+    assert "summary-cell" not in out

--- a/tests/test_tools/test_select_spreadsheet_sheets.py
+++ b/tests/test_tools/test_select_spreadsheet_sheets.py
@@ -1,0 +1,82 @@
+"""Sheet selection in read_spreadsheet.
+
+Regression coverage for #1569: ``_select_spreadsheet_sheets`` tested the
+positional-index reading of the argument before looking for a sheet with that
+exact name, so a workbook holding a sheet literally named "1" could never be
+reached -- ``sheet="1"`` always resolved to the first sheet instead.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentos.tools.builtin.filesystem import _select_spreadsheet_sheets
+from agentos.tools.types import ToolError
+
+# (name, rows, total_rows); rows is the 1-indexed sparse map that
+# _read_xlsx_sheets / _read_delimited_rows produce.
+SHEETS: list[tuple[str, dict[int, list[str]], int]] = [
+    ("Summary", {1: ["a"]}, 1),
+    ("1", {1: ["b"]}, 1),
+    ("0", {1: ["c"]}, 1),
+]
+
+
+def test_exact_numeric_sheet_name_wins_over_positional_index() -> None:
+    assert _select_spreadsheet_sheets(SHEETS, "1") == [("1", {1: ["b"]}, 1)]
+
+
+def test_sheet_named_zero_is_reachable() -> None:
+    # "0" is never a valid 1-based index, so it could only ever have fallen
+    # through to the name match -- but it must resolve to the sheet, not to
+    # the "Sheet not found" error.
+    assert _select_spreadsheet_sheets(SHEETS, "0") == [("0", {1: ["c"]}, 1)]
+
+
+def test_positional_index_still_used_when_no_exact_name_matches() -> None:
+    assert _select_spreadsheet_sheets(SHEETS, "2") == [("1", {1: ["b"]}, 1)]
+
+
+def test_out_of_range_numeric_name_still_matches_by_name() -> None:
+    sheets: list[tuple[str, dict[int, list[str]], int]] = [("2024", {1: ["x"]}, 1)]
+
+    assert _select_spreadsheet_sheets(sheets, "2024") == [("2024", {1: ["x"]}, 1)]
+
+
+def test_int_request_resolves_the_same_way_as_the_string_form() -> None:
+    # The tool declares sheet as a string, but the helper accepts int too;
+    # the same argument must not mean two different sheets depending on how
+    # the caller typed it.
+    assert _select_spreadsheet_sheets(SHEETS, 1) == _select_spreadsheet_sheets(SHEETS, "1")
+
+
+def test_int_request_falls_back_to_position_when_no_sheet_has_that_name() -> None:
+    assert _select_spreadsheet_sheets(SHEETS, 3) == [("0", {1: ["c"]}, 1)]
+
+
+def test_selection_preserves_the_total_rows_element() -> None:
+    # The selected entry has to keep its (name, rows, total_rows) shape --
+    # _format_spreadsheet unpacks all three downstream.
+    sheets: list[tuple[str, dict[int, list[str]], int]] = [("Data", {1: ["x"], 9: ["y"]}, 9)]
+
+    (selected,) = _select_spreadsheet_sheets(sheets, "Data")
+
+    assert selected == ("Data", {1: ["x"], 9: ["y"]}, 9)
+
+
+def test_none_and_empty_string_return_all_sheets() -> None:
+    assert _select_spreadsheet_sheets(SHEETS, None) == SHEETS
+    assert _select_spreadsheet_sheets(SHEETS, "") == SHEETS
+
+
+def test_exact_name_match_still_wins_for_non_numeric_names() -> None:
+    assert _select_spreadsheet_sheets(SHEETS, "Summary") == [("Summary", {1: ["a"]}, 1)]
+
+
+def test_case_insensitive_fallback_still_applies() -> None:
+    assert _select_spreadsheet_sheets(SHEETS, "summary") == [("Summary", {1: ["a"]}, 1)]
+
+
+def test_unmatched_sheet_name_raises_tool_error_listing_available_sheets() -> None:
+    with pytest.raises(ToolError, match="Sheet not found: missing"):
+        _select_spreadsheet_sheets(SHEETS, "missing")


### PR DESCRIPTION
Fixes #1569

> Rebased onto current `main` after #1152 landed (sheets became
> `(name, rows, total_rows)` with sparse row maps). The first version of this PR was written against
> the older 2-tuple shape; it has been rewritten as a smaller change on top of the new one.

## The bug

`_select_spreadsheet_sheets` tests the positional-index reading of `sheet` *before* it looks for a
sheet with that exact name:

```python
if isinstance(requested, int) or (isinstance(requested, str) and requested.isdigit()):
    index = int(requested) - 1
    if 0 <= index < len(sheets):
        return [sheets[index]]

requested_name = str(requested)
for name, rows, total_rows in sheets:
    if name == requested_name:
        return [(name, rows, total_rows)]
```

So on a workbook whose sheets are `["Summary", "1"]`, `read_spreadsheet(path, sheet="1")` computes
`index = 0` and returns **`Summary`** — the sheet actually named `"1"` is unreachable, and the name
loop below it is dead for any digit-string that happens to be a valid position. Numeric sheet names
are ordinary in real workbooks (years `2024`, step numbers `1`/`2`, product codes), and the failure is
silent: the model gets a different sheet's data with no error to notice.

## The fix

Move the positional-index block below the exact-name match. That is the whole change — no new
matching logic, no restructure:

```python
requested_name = str(requested)
# A sheet literally named "1" has to win over the positional reading of
# "1". Testing the index first made every numeric sheet name unreachable
# and silently returned whichever sheet sat at that 1-based position.
for name, rows, total_rows in sheets:
    if name == requested_name:
        return [(name, rows, total_rows)]

if isinstance(requested, int) or (isinstance(requested, str) and requested.isdigit()):
    index = int(requested) - 1
    if 0 <= index < len(sheets):
        return [sheets[index]]
```

Positional selection stays fully available — it is only outranked by an exact name match, never
removed. The case-insensitive fallback below is untouched; for a digit request it can only ever match
what the exact loop already matched, so its position relative to the index block is not observable.

**One interpretation stated explicitly:** because the name lookup uses `str(requested)`, an `int`
argument now resolves the same way its string form does (`1` and `"1"` both find a sheet named `"1"`,
and both fall back to position 1 when no such sheet exists). The tool declares `sheet` as a string and
`_select_spreadsheet_sheets` has exactly one caller, so nothing in-tree passes an `int` today; making
the two spellings agree seemed better than having them disagree. Happy to gate the name lookup behind
`isinstance(requested, str)` instead if you'd rather `int` stay strictly positional.

## Tests

**`tests/test_tools/test_select_spreadsheet_sheets.py`** — 11 unit cases on the selector (offline, no
I/O, deterministic), against a `["Summary", "1", "0"]` workbook:

- `test_exact_numeric_sheet_name_wins_over_positional_index` — the issue's repro.
- `test_sheet_named_zero_is_reachable` — `"0"` is never a valid 1-based index, so it must resolve by
  name rather than error.
- `test_positional_index_still_used_when_no_exact_name_matches` — `"2"` still means "2nd sheet".
- `test_out_of_range_numeric_name_still_matches_by_name` — a `"2024"` sheet in a 1-sheet workbook.
- `test_int_request_resolves_the_same_way_as_the_string_form` and
  `test_int_request_falls_back_to_position_when_no_sheet_has_that_name` — pins the interpretation above.
- `test_selection_preserves_the_total_rows_element` — the selected entry keeps its full
  `(name, rows, total_rows)` shape, which `_format_spreadsheet` unpacks downstream.
- Plus guards for `None`/`""`, non-numeric exact names, the case-insensitive fallback, and the
  `Sheet not found` error listing available sheets.

**`tests/test_tools/test_read_spreadsheet_xlsx.py`** — 2 end-to-end cases through the public tool,
using the file's existing `_build_xlsx_bytes` helper on a real `.xlsx`:

- `test_read_spreadsheet_reaches_a_sheet_named_like_an_index` — `sheet="1"` on a
  `{"Summary", "1"}` workbook returns the `"1"` sheet's cell and not `Summary`'s.
- `test_read_spreadsheet_selects_by_position_when_no_sheet_has_that_name` — `sheet="2"` still
  resolves positionally.

Without the fix, exactly 2 tests fail — one unit (`test_exact_numeric_sheet_name_wins_over_positional_index`)
and one end-to-end (`test_read_spreadsheet_reaches_a_sheet_named_like_an_index`). The other 28 pass
either way by design: they guard the behavior this reorder must *not* change.

## Verification

Self-test (upstream `filesystem.py` swapped back in, tests unchanged):

```
$ uv run pytest -q tests/test_tools/test_read_spreadsheet_xlsx.py tests/test_tools/test_select_spreadsheet_sheets.py
2 failed, 28 passed in 3.13s
FAILED tests/test_tools/test_read_spreadsheet_xlsx.py::test_read_spreadsheet_reaches_a_sheet_named_like_an_index
FAILED tests/test_tools/test_select_spreadsheet_sheets.py::test_exact_numeric_sheet_name_wins_over_positional_index
```

With the fix:

```
$ uv run pytest -q tests/test_tools/test_read_spreadsheet_xlsx.py tests/test_tools/test_select_spreadsheet_sheets.py
30 passed in 3.04s

$ uv run pytest -q
6 failed, 10256 passed, 34 skipped, 4 warnings, 3 errors in 249.18s
```

The 6 failures / 3 errors are pre-existing on `upstream/main` and unrelated to this change (pilot
router ONNX encoder assets, a machine-timezone hygiene check, and wheelhouse packaging tests that need
built ML assets absent from this environment) — same set, same count, before and after this diff.

```
$ uv run ruff check .
All checks passed!

$ uv run mypy --show-error-codes src
Success: no issues found in 625 source files
```

## Relationship to the other PRs on this issue

#1609 and #1615 target the same issue and reorder the same block. Both test the private selector only;
the distinct coverage here is the two end-to-end cases through `read_spreadsheet` on a real `.xlsx`
(the surface a user actually hits) plus the `total_rows` shape guard, which pins that a selected sheet
survives #1152's tuple contract intact. Rank them together as you see fit — flagging it so no one has
to diff three branches to find the difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tbgoh4XkHPqGdEVwfjsuhx
