### PR TITLE
fix(gateway): don't deny approvals on a per-call wait timeout before their overall lifespan expires

### DIFF
--- a/src/agentos/application/approval_queue.py
+++ b/src/agentos/application/approval_queue.py
@@ -187,6 +187,13 @@ class ApprovalQueue:
             entry = self.get(approval_id)
             if entry.resolved:
                 return entry.approved
+
+        if time.time() - entry.created_at < self._timeout:
+            # The caller's own timeout elapsed, but the approval's overall
+            # lifespan (created_at + default_timeout) hasn't -- leave it
+            # pending instead of denying it, so a human operator can still
+            # resolve it after this bounded wait call returns.
+            return False
         return self._deny_on_timeout_if_unresolved(approval_id)
 
     def _deny_on_timeout_if_unresolved(self, approval_id: str) -> bool:

--- a/tests/test_application/test_approval_queue_wait_timeout.py
+++ b/tests/test_application/test_approval_queue_wait_timeout.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from agentos.application.approval_queue import ApprovalQueue
+
+
+@pytest.mark.asyncio
+async def test_wait_per_call_timeout_leaves_approval_pending_when_lifetime_not_expired(
+    tmp_path,
+) -> None:
+    db_path = tmp_path / "approval_queue.sqlite"
+    queue = ApprovalQueue(default_timeout=300.0, db_path=str(db_path), poll_interval=0.01)
+    approval_id = queue.request("exec", {"toolName": "exec_command"})
+
+    result = await queue.wait(approval_id, timeout=0.05)
+
+    assert result is False
+    entry = queue.get(approval_id)
+    assert entry.resolved is False
+    assert entry.approved is False
+
+    # A human operator resolving after the caller's bounded wait returned
+    # must still succeed -- it must not have been permanently denied.
+    queue.resolve(approval_id, True)
+    resolved_entry = queue.get(approval_id)
+    assert resolved_entry.resolved is True
+    assert resolved_entry.approved is True
+    queue.close()
+
+
+@pytest.mark.asyncio
+async def test_wait_denies_once_the_overall_approval_lifetime_has_expired(tmp_path) -> None:
+    db_path = tmp_path / "approval_queue.sqlite"
+    queue = ApprovalQueue(default_timeout=300.0, db_path=str(db_path), poll_interval=0.01)
+    approval_id = queue.request("exec", {"toolName": "exec_command"})
+
+    # Simulate the approval having been created long ago, so its overall
+    # lifespan (created_at + default_timeout) has already elapsed.
+    queue._conn.execute(
+        "UPDATE approval_queue SET created_at = ? WHERE approval_id = ?",
+        (time.time() - 1000.0, approval_id),
+    )
+    queue._conn.commit()
+
+    result = await queue.wait(approval_id, timeout=0.05)
+
+    assert result is False
+    entry = queue.get(approval_id)
+    assert entry.resolved is True
+    assert entry.approved is False
+
+    with pytest.raises(ValueError, match="already resolved"):
+        queue.resolve(approval_id, True)
+    queue.close()
+
+
+@pytest.mark.asyncio
+async def test_wait_returns_immediately_once_resolved_during_the_call(tmp_path) -> None:
+    db_path = tmp_path / "approval_queue.sqlite"
+    queue = ApprovalQueue(default_timeout=300.0, db_path=str(db_path), poll_interval=0.01)
+    approval_id = queue.request("exec", {"toolName": "exec_command"})
+    queue.resolve(approval_id, True)
+
+    result = await queue.wait(approval_id, timeout=5.0)
+
+    assert result is True
+    queue.close()

--- a/tests/test_gateway/test_approval_queue_persistence.py
+++ b/tests/test_gateway/test_approval_queue_persistence.py
@@ -94,15 +94,30 @@ async def test_approval_queue_wait_same_process_event_fast_path(tmp_path) -> Non
 
 
 @pytest.mark.asyncio
-async def test_approval_queue_wait_preserves_timeout_denies(tmp_path) -> None:
+async def test_approval_queue_wait_denies_once_the_full_default_timeout_elapses(tmp_path) -> None:
+    db_path = tmp_path / "approval_queue.sqlite"
+    queue = ApprovalQueue(db_path=str(db_path), default_timeout=0.02, poll_interval=0.01)
+    approval_id = queue.request("exec", {"toolName": "exec_command", "command": "rm x"})
+    try:
+        assert await queue.wait(approval_id) is False
+        entry = queue.get(approval_id)
+        assert entry.resolved is True
+        assert entry.approved is False
+    finally:
+        queue.close()
+
+
+@pytest.mark.asyncio
+async def test_approval_queue_wait_leaves_approval_pending_when_only_the_per_call_timeout_elapses(
+    tmp_path,
+) -> None:
     db_path = tmp_path / "approval_queue.sqlite"
     queue = ApprovalQueue(db_path=str(db_path), default_timeout=1.0, poll_interval=0.01)
     approval_id = queue.request("exec", {"toolName": "exec_command", "command": "rm x"})
     try:
         assert await queue.wait(approval_id, timeout=0.02) is False
         entry = queue.get(approval_id)
-        assert entry.resolved is True
-        assert entry.approved is False
+        assert entry.resolved is False
     finally:
         queue.close()
 


### PR DESCRIPTION
Fixes #1568

## The bug

`ApprovalQueue.wait(approval_id, timeout=X)` treats `timeout` as a bounded wait for the *caller*, but
in `src/agentos/application/approval_queue.py` it unconditionally denies the approval once that local
deadline passes:

```python
while True:
    remaining = deadline - time.monotonic()
    if remaining <= 0:
        break
    ...
return self._deny_on_timeout_if_unresolved(approval_id)
```

`_deny_on_timeout_if_unresolved` writes `resolved = 1, approved = 0` straight to SQLite. So a caller
polling with a short per-call timeout (e.g. a Web UI request doing `wait(id, timeout=10.0)` on an
approval whose real lifespan is the 300s default) permanently denies the approval the moment its own
10s poll times out — even though the approval is nowhere near actually expiring. When the human
operator later clicks "Approve", `resolve()` raises `ValueError: Approval already resolved`.

## The fix

`wait()`'s per-call deadline is a local wait bound, not the approval's actual expiry. Only deny once
the approval's overall lifespan (`created_at + default_timeout`) has genuinely elapsed; otherwise
leave it pending so a later `wait()` call or a human `resolve()` can still land normally:

```python
if time.time() - entry.created_at < self._timeout:
    # The caller's own timeout elapsed, but the approval's overall
    # lifespan (created_at + default_timeout) hasn't -- leave it
    # pending instead of denying it, so a human operator can still
    # resolve it after this bounded wait call returns.
    return False
return self._deny_on_timeout_if_unresolved(approval_id)
```

`wait()` still returns `False` either way (the caller's own wait did time out), the difference is
purely whether the approval itself gets permanently resolved in SQLite.

## Tests

`tests/test_application/test_approval_queue_wait_timeout.py` (3 new cases, offline, deterministic):

- `test_wait_per_call_timeout_leaves_approval_pending_when_lifetime_not_expired` — a 300s-lifespan
  approval waited on with `timeout=0.05` returns `False` but stays unresolved, and a subsequent
  `resolve()` still succeeds (the exact repro from the issue).
- `test_wait_denies_once_the_overall_approval_lifetime_has_expired` — with `created_at` pushed back
  1000s (past a 300s default lifespan), the same short `wait(timeout=0.05)` call now does deny, and a
  later `resolve()` correctly raises `ValueError: Approval already resolved` — preserves the original,
  intended timeout-denial behavior once the approval has actually expired.
- `test_wait_returns_immediately_once_resolved_during_the_call` — guards the already-resolved fast
  path, untouched by this change.

`tests/test_gateway/test_approval_queue_persistence.py` had an existing test,
`test_approval_queue_wait_preserves_timeout_denies`, that asserted the buggy behavior directly (a 1.0s
default lifespan approval waited on with `timeout=0.02` was asserted to become permanently `resolved`).
I updated it in place:

- Renamed to `test_approval_queue_wait_denies_once_the_full_default_timeout_elapses` and changed it to
  call `wait(approval_id)` with no override (so the per-call and overall timeouts are the same 0.02s)
  — it still verifies that a genuine full-timeout expiry denies, which is real, intended behavior this
  PR does not change.
- Added `test_approval_queue_wait_leaves_approval_pending_when_only_the_per_call_timeout_elapses`,
  which is the old test's exact scenario (1.0s lifespan, `timeout=0.02` override) but with the
  corrected expectation (`entry.resolved is False`).

Without the fix, `test_wait_per_call_timeout_leaves_approval_pending_when_lifetime_not_expired` and
`test_approval_queue_wait_leaves_approval_pending_when_only_the_per_call_timeout_elapses` fail (that's
the bug). The rest pass either way by design.

## Verification

Self-test (upstream `approval_queue.py` swapped in temporarily):

```
$ uv run pytest -q tests/test_application/test_approval_queue_wait_timeout.py
1 failed, 2 passed in 0.22s
FAILED tests/test_application/test_approval_queue_wait_timeout.py::test_wait_per_call_timeout_leaves_approval_pending_when_lifetime_not_expired
```

With the fix:

```
$ uv run pytest -q tests/test_gateway/test_approval_queue_persistence.py tests/test_application/test_approval_queue_wait_timeout.py
11 passed in 1.56s

$ uv run pytest -q
6 failed, 10189 passed, 34 skipped, 4 warnings, 3 errors in 245.70s
```

The 6 failures / 3 errors are pre-existing on `upstream/main`, unrelated to this change (pilot router
ONNX encoder assets, a machine-timezone hygiene check, and wheelhouse packaging tests needing built ML
assets not present in this environment) — same set before and after this diff.

```
$ uv run ruff check .
All checks passed!

$ uv run mypy --show-error-codes src
Success: no issues found in 625 source files
```
