### PR TITLE
fix(tools): recognize more null-schema shapes when collapsing nullable unions

### DIFF
--- a/src/agentos/tools/schema_sanitize.py
+++ b/src/agentos/tools/schema_sanitize.py
@@ -46,7 +46,19 @@ _SCHEMA_LIST_KEYS = ("allOf", "anyOf", "oneOf", "prefixItems")
 
 
 def _is_null_schema(node: Any) -> bool:
-    return isinstance(node, Mapping) and node.get("type") == "null"
+    if not isinstance(node, Mapping):
+        return False
+    if "type" in node:
+        node_type = node["type"]
+        if node_type is None or node_type == "null":
+            return True
+        if isinstance(node_type, list) and node_type and all(t == "null" for t in node_type):
+            return True
+    if "const" in node and node["const"] is None:
+        return True
+    if node.get("enum") == [None]:
+        return True
+    return False
 
 
 def _collect_defs(schema: Mapping[str, Any]) -> dict[str, Any]:

--- a/tests/test_tools/test_schema_sanitize.py
+++ b/tests/test_tools/test_schema_sanitize.py
@@ -41,6 +41,62 @@ def test_nullable_union_collapses_to_the_concrete_branch() -> None:
     assert "collapsed_nullable_union" in fixes
 
 
+def test_nullable_union_collapses_when_null_branch_uses_a_type_list() -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "filter": {"anyOf": [{"type": "string"}, {"type": ["null"]}]},
+        },
+    }
+
+    cleaned, fixes = sanitize_input_schema(schema)
+
+    assert cleaned["properties"]["filter"] == {"type": "string"}
+    assert "collapsed_nullable_union" in fixes
+
+
+def test_nullable_union_collapses_when_null_branch_has_type_none() -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "filter": {"anyOf": [{"type": "string"}, {"type": None}]},
+        },
+    }
+
+    cleaned, fixes = sanitize_input_schema(schema)
+
+    assert cleaned["properties"]["filter"] == {"type": "string"}
+    assert "collapsed_nullable_union" in fixes
+
+
+def test_nullable_union_collapses_when_null_branch_is_a_const_null() -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "filter": {"anyOf": [{"type": "string"}, {"const": None}]},
+        },
+    }
+
+    cleaned, fixes = sanitize_input_schema(schema)
+
+    assert cleaned["properties"]["filter"] == {"type": "string"}
+    assert "collapsed_nullable_union" in fixes
+
+
+def test_nullable_union_collapses_when_null_branch_is_an_enum_of_null() -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "filter": {"anyOf": [{"type": "string"}, {"enum": [None]}]},
+        },
+    }
+
+    cleaned, fixes = sanitize_input_schema(schema)
+
+    assert cleaned["properties"]["filter"] == {"type": "string"}
+    assert "collapsed_nullable_union" in fixes
+
+
 def test_union_with_two_real_branches_is_left_alone() -> None:
     schema = {
         "type": "object",


### PR DESCRIPTION
Fixes #1573

## The bug

`_is_null_schema` in `src/agentos/tools/schema_sanitize.py`, used to collapse `anyOf`/`oneOf` unions
that only exist to permit `null` (the shape Pydantic emits for `Optional[...]`), only recognized one
spelling of "this branch means null":

```python
def _is_null_schema(node: Any) -> bool:
    return isinstance(node, Mapping) and node.get("type") == "null"
```

JSON Schema has several other ways to say the same thing — `"type": ["null"]` (a single-entry type
array), `"type": null`, `"const": null`, and `"enum": [null]` — all of which some MCP server or
schema generator can emit. None of these are recognized, so the union is left un-collapsed and goes
out to the provider as-is, which Anthropic rejects at the top of `input_schema`, taking every other
tool in the request down with it.

## The fix

Recognize all four null-schema spellings in `_is_null_schema`, in addition to the existing one:

```python
def _is_null_schema(node: Any) -> bool:
    if not isinstance(node, Mapping):
        return False
    if "type" in node:
        node_type = node["type"]
        if node_type is None or node_type == "null":
            return True
        if isinstance(node_type, list) and node_type and all(t == "null" for t in node_type):
            return True
    if "const" in node and node["const"] is None:
        return True
    if node.get("enum") == [None]:
        return True
    return False
```

`_is_null_schema` is only used to decide which `anyOf`/`oneOf` branch to drop (line 125); the
unrelated `"type": [...]` collapsing on a schema's own `type` key (`collapsed_type_array`) is a
separate code path and untouched.

## Tests

`tests/test_tools/test_schema_sanitize.py` (4 new cases, offline, deterministic), mirroring the
existing `test_nullable_union_collapses_to_the_concrete_branch` for each of the issue's four shapes:

- `test_nullable_union_collapses_when_null_branch_uses_a_type_list` — `{"type": ["null"]}`
- `test_nullable_union_collapses_when_null_branch_has_type_none` — `{"type": None}`
- `test_nullable_union_collapses_when_null_branch_is_a_const_null` — `{"const": None}`
- `test_nullable_union_collapses_when_null_branch_is_an_enum_of_null` — `{"enum": [None]}`

Each asserts the union collapses to the concrete branch and `"collapsed_nullable_union"` is reported,
exactly like the pre-existing `"type": "null"` case. All 4 fail without the fix (each null-schema
variant is left un-collapsed) and pass with it; the other 17 tests in the file pass either way by
design, guarding behavior this change doesn't touch.

## Verification

Self-test (upstream `schema_sanitize.py` swapped in temporarily):

```
$ uv run pytest -q tests/test_tools/test_schema_sanitize.py
4 failed, 17 passed in 1.21s
FAILED tests/test_tools/test_schema_sanitize.py::test_nullable_union_collapses_when_null_branch_uses_a_type_list
FAILED tests/test_tools/test_schema_sanitize.py::test_nullable_union_collapses_when_null_branch_has_type_none
FAILED tests/test_tools/test_schema_sanitize.py::test_nullable_union_collapses_when_null_branch_is_a_const_null
FAILED tests/test_tools/test_schema_sanitize.py::test_nullable_union_collapses_when_null_branch_is_an_enum_of_null
```

With the fix:

```
$ uv run pytest -q tests/test_tools/test_schema_sanitize.py
21 passed in 1.18s

$ uv run pytest -q
6 failed, 10247 passed, 34 skipped, 4 warnings, 3 errors in 245.94s
```

The 6 failures / 3 errors are pre-existing on `upstream/main`, unrelated to this change (pilot router
ONNX encoder assets, a machine-timezone hygiene check, and wheelhouse packaging tests needing built ML
assets not present in this environment) — same set before and after this diff.

```
$ uv run ruff check .
All checks passed!

$ uv run mypy --show-error-codes src
Success: no issues found in 625 source files
```
