### PR TITLE
fix(tools): resolve exact sheet names before positional index in read_spreadsheet

### DIFF
--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -743,11 +743,6 @@ def _select_spreadsheet_sheets(
     if requested is None or requested == "":
         return sheets
 
-    if isinstance(requested, int) or (isinstance(requested, str) and requested.isdigit()):
-        index = int(requested) - 1
-        if 0 <= index < len(sheets):
-            return [sheets[index]]
-
     requested_name = str(requested)
     for name, rows, total_rows in sheets:
         if name == requested_name:
@@ -755,6 +750,11 @@ def _select_spreadsheet_sheets(
     for name, rows, total_rows in sheets:
         if name.lower() == requested_name.lower():
             return [(name, rows, total_rows)]
+
+    if isinstance(requested, int) or (isinstance(requested, str) and requested.isdigit()):
+        index = int(requested) - 1
+        if 0 <= index < len(sheets):
+            return [sheets[index]]
 
     available = ", ".join(name for name, _, _ in sheets)
     raise ToolError(f"Sheet not found: {requested_name}. Available sheets: {available}")

--- a/tests/test_tools/test_read_spreadsheet_sheet_selection.py
+++ b/tests/test_tools/test_read_spreadsheet_sheet_selection.py
@@ -1,0 +1,79 @@
+"""Sheet selection in read_spreadsheet.
+
+Regression coverage for #1569: _select_spreadsheet_sheets used to check the
+positional-index interpretation of the argument before looking for a sheet
+with that exact name, so a workbook containing a sheet literally named "1"
+could never reach it -- sheet="1" always resolved to positional index 0.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentos.tools.builtin.filesystem import _select_spreadsheet_sheets
+from agentos.tools.types import ToolError
+
+# (name, rows, total_rows) -- rows is a 1-indexed sparse map, matching what
+# _read_xlsx_sheets / _read_delimited_rows produce.
+_SHEETS: list[tuple[str, dict[int, list[str]], int]] = [
+    ("0", {1: ["a"]}, 1),
+    ("Summary", {1: ["b"]}, 1),
+    ("1", {1: ["c"]}, 1),
+]
+
+
+def test_numeric_sheet_name_is_reachable_by_exact_name() -> None:
+    """A sheet literally named "1" must not be shadowed by the positional
+    interpretation of "1" (which would otherwise resolve to index 0,
+    i.e. the sheet named "0").
+    """
+    result = _select_spreadsheet_sheets(_SHEETS, "1")
+
+    assert [name for name, _, _ in result] == ["1"]
+    assert result[0][1] == {1: ["c"]}
+
+
+def test_numeric_sheet_name_reachable_when_requested_as_int() -> None:
+    """The int form must resolve the same way as the string form -- a model
+    could pass either depending on how it serializes the tool call.
+    """
+    result = _select_spreadsheet_sheets(_SHEETS, 1)
+
+    assert [name for name, _, _ in result] == ["1"]
+
+
+def test_zero_named_sheet_is_reachable() -> None:
+    result = _select_spreadsheet_sheets(_SHEETS, "0")
+
+    assert [name for name, _, _ in result] == ["0"]
+    assert result[0][1] == {1: ["a"]}
+
+
+def test_positional_index_still_works_when_no_sheet_has_that_name() -> None:
+    """Fallback to positional index must survive the reorder for the
+    ordinary case -- no sheet named "2" exists, so "2" means "the 2nd sheet".
+    """
+    result = _select_spreadsheet_sheets(_SHEETS, "2")
+
+    assert [name for name, _, _ in result] == ["Summary"]
+
+
+def test_case_insensitive_name_match_still_beats_positional_fallback() -> None:
+    sheets: list[tuple[str, dict[int, list[str]], int]] = [
+        ("Q1", {1: ["x"]}, 1),
+        ("Q2", {1: ["y"]}, 1),
+    ]
+
+    result = _select_spreadsheet_sheets(sheets, "q1")
+
+    assert [name for name, _, _ in result] == ["Q1"]
+
+
+def test_unknown_sheet_raises_with_available_names() -> None:
+    with pytest.raises(ToolError, match="Sheet not found: nope"):
+        _select_spreadsheet_sheets(_SHEETS, "nope")
+
+
+def test_none_or_empty_returns_all_sheets() -> None:
+    assert _select_spreadsheet_sheets(_SHEETS, None) == _SHEETS
+    assert _select_spreadsheet_sheets(_SHEETS, "") == _SHEETS


### PR DESCRIPTION
## Linked issue
Fixes #1569 

## Summary
_select_spreadsheet_sheets checked "is this argument a positional index"
before "is there a sheet with this exact name". A workbook with a sheet
literally named "0" or "1" (unusual but valid) had that sheet
permanently unreachable: requesting sheet="1" always resolved to
positional index 0, never to the sheet actually named "1".

## Fix
Reordered the checks: exact name match, then case-insensitive name
match, then positional index fallback -- only reached when no sheet
name matches at all. Minimal reorder, no new logic.

## Tests
New file tests/test_tools/test_read_spreadsheet_sheet_selection.py,
7 tests: numeric-named sheet reachable by exact name (string and int
forms), "0"-named sheet reachable, positional fallback still works when
no name matches, case-insensitive match still beats positional
fallback, unknown-sheet error message, None/empty returns all sheets.

Also ran the full pre-existing filesystem/redaction suite for
regressions:
    uv run pytest tests/test_tools/test_filesystem_read_workspace.py tests/test_security/test_file_read_redaction.py tests/test_tools/test_read_spreadsheet_sheet_selection.py -v
    → 57 passed, 0 failed

Full gate clean:
    uv run ruff check src/agentos/tools/builtin/filesystem.py tests/test_tools/test_read_spreadsheet_sheet_selection.py
    uv run ruff format --check src/agentos/tools/builtin/filesystem.py tests/test_tools/test_read_spreadsheet_sheet_selection.py
    uv run mypy src/agentos/tools/builtin/filesystem.py tests/test_tools/test_read_spreadsheet_sheet_selection.py --show-error-codes

Note: ruff format also touched three unrelated pre-existing lines in
this file (string-wrap only) since the whole file must satisfy
ruff format --check. Verified via diff -- no logic touched.

Third-party origin: none.