### PR TITLE
fix(provider): reset selector index and validate admission on override_model

### DIFF
--- a/src/agentos/provider/selector.py
+++ b/src/agentos/provider/selector.py
@@ -282,6 +282,11 @@ class ModelSelector:
         if fallbacks is not None:
             self._config.fallbacks = list(fallbacks)
             self._chain = [self._chain[0], *fallbacks]
+            if self._admitted_index is not None and self._admitted_index != 0:
+                self._admitted_index = None
+        self._index = 0
+        if self._admitted_index is not None and self._admitted_index >= len(self._chain):
+            self._admitted_index = None
 
     def sync_primary(self, cfg: ProviderConfig) -> None:
         """Replace the primary provider config for future resolves and clones."""

--- a/src/agentos/provider/selector.py
+++ b/src/agentos/provider/selector.py
@@ -282,9 +282,9 @@ class ModelSelector:
         if fallbacks is not None:
             self._config.fallbacks = list(fallbacks)
             self._chain = [self._chain[0], *fallbacks]
-            if self._admitted_index is not None and self._admitted_index != 0:
-                self._admitted_index = None
         self._index = 0
+        if self._admitted_index is not None and self._admitted_index != 0:
+            self._admitted_index = None
         if self._admitted_index is not None and self._admitted_index >= len(self._chain):
             self._admitted_index = None
 

--- a/tests/test_provider_circuit_breaker.py
+++ b/tests/test_provider_circuit_breaker.py
@@ -446,6 +446,36 @@ def test_override_model_resets_stale_fallback_index_to_primary() -> None:
     assert selector.active_provider_id == "openrouter"
 
 
+def test_override_model_without_fallbacks_resets_stale_fallback_admission_on_long_chain() -> None:
+    """When a selector has advanced to a fallback and override_model updates the
+    model on a long chain without changing fallbacks (fallbacks=None), stale
+    fallback admission must be cleared so the primary model is evaluated
+    instead of silently serving the old fallback link."""
+    clock = FakeClock()
+    breaker = _breaker(clock, threshold=1, cooldown=60.0)
+    _fail(breaker, "openrouter", 1)
+
+    selector = _three_link_selector(breaker)
+    selector.resolve()
+    assert selector.active_provider_id == "deepseek"
+    assert selector._index == 1
+    assert selector._admitted_index == 1
+
+    # Cooldown expires: openrouter is now in HALF_OPEN state
+    clock.advance(60.0)
+
+    # Override primary model without altering the fallback chain (fallbacks=None)
+    selector.override_model("openai/gpt-5.4-mini")
+    assert selector._index == 0
+    assert selector._admitted_index is None
+
+    # Resolving evaluates the primary provider (openrouter) instead of silently
+    # returning the old fallback link (deepseek)
+    selector.resolve()
+    assert selector.active_provider_id == "openrouter"
+    assert selector._admitted_index == 0
+
+
 def test_a_different_turn_does_not_share_the_held_probe() -> None:
     clock = FakeClock()
     breaker = _breaker(clock, threshold=1, cooldown=60.0)

--- a/tests/test_provider_circuit_breaker.py
+++ b/tests/test_provider_circuit_breaker.py
@@ -214,9 +214,7 @@ def test_disabled_breaker_always_admits() -> None:
 
 
 def test_settings_clamp_nonsense_values() -> None:
-    settings = BreakerSettings(
-        failure_threshold=0, cooldown_seconds=-5.0, max_cooldown_seconds=0.0
-    )
+    settings = BreakerSettings(failure_threshold=0, cooldown_seconds=-5.0, max_cooldown_seconds=0.0)
     assert settings.failure_threshold == 1
     assert settings.cooldown_seconds == 1.0
     assert settings.max_cooldown_seconds == 1.0
@@ -351,9 +349,7 @@ def test_breaker_state_survives_clone() -> None:
 
 
 def test_selector_defaults_to_its_own_breaker() -> None:
-    selector = ModelSelector(
-        SelectorConfig(primary=ProviderConfig("openrouter", "m", api_key="k"))
-    )
+    selector = ModelSelector(SelectorConfig(primary=ProviderConfig("openrouter", "m", api_key="k")))
     assert selector.circuit_breaker is not None
     assert selector.clone().circuit_breaker is selector.circuit_breaker
 
@@ -395,6 +391,57 @@ def test_repeated_resolve_keeps_the_probe_this_selector_was_granted() -> None:
     assert selector.active_provider_id == "openrouter"  # probe granted
 
     selector.override_model("openai/other")
+    selector.resolve()
+    assert selector.active_provider_id == "openrouter"
+
+
+def test_override_model_resets_index_and_prevents_index_error_with_shorter_chain() -> None:
+    """When a selector has advanced to a fallback and override_model updates the
+    chain with fewer fallbacks, the selector must not crash with IndexError and
+    must evaluate from the primary."""
+    clock = FakeClock()
+    breaker = _breaker(clock, threshold=1)
+    _fail(breaker, "openrouter", 1)  # openrouter is in OPEN state
+
+    selector = _three_link_selector(breaker)
+    selector.resolve()
+    # First resolve skipped openrouter (index 0) and picked deepseek (index 1)
+    assert selector.active_provider_id == "deepseek"
+    assert selector._index == 1
+
+    # Override model with an empty fallback list (shortened chain of length 1)
+    selector.override_model("openai/gpt-5-mini", fallbacks=[])
+    assert len(selector._chain) == 1
+    assert selector._index == 0
+
+    # Must not raise IndexError: list index out of range
+    selector.resolve()
+    assert selector.active_provider_id == "openrouter"
+
+
+def test_override_model_resets_stale_fallback_index_to_primary() -> None:
+    """When the primary recovers or a new model is configured, override_model
+    must reset index to 0 so the primary provider is evaluated."""
+    clock = FakeClock()
+    breaker = _breaker(clock, threshold=1, cooldown=60.0)
+    _fail(breaker, "openrouter", 1)
+
+    selector = _three_link_selector(breaker)
+    selector.resolve()
+    assert selector.active_provider_id == "deepseek"
+    assert selector._index == 1
+
+    # Cooldown expires: openrouter is now in HALF_OPEN state
+    clock.advance(60.0)
+
+    # Override model on primary with a new fallback list
+    selector.override_model(
+        "openai/gpt-5.4-mini",
+        fallbacks=[ProviderConfig("anthropic", "claude-sonnet-4-6", api_key="k")],
+    )
+    assert selector._index == 0
+
+    # Resolving now probes openrouter instead of remaining stuck on index 1
     selector.resolve()
     assert selector.active_provider_id == "openrouter"
 


### PR DESCRIPTION
Fixes #1616

## Summary

When `ModelSelector.override_model(model, fallbacks=...)` updates the primary model or replaces the fallback chain (e.g. during Auto-Pilot router tier adjustments in `PromptAssemblerStage`), it was not resetting `self._index` to 0 and was retaining stale fallback admission.

If the selector had already advanced to a fallback link (e.g. `_index == 1` due to an open circuit breaker on the primary or a prior failover):
1. Shortening the fallback chain (e.g. `fallbacks=[]`) resulted in `self._index >= len(self._chain)`, causing subsequent calls to `resolve()`, `active_provider_id`, or `current_config` to crash with `IndexError: list index out of range`.
2. With a long fallback chain (or when `fallbacks` argument is omitted), `self._index` and/or `self._admitted_index` remained stuck on the fallback link, silently continuing to serve the old fallback and ignoring the newly configured primary model.

## Changes

- In `ModelSelector.override_model()`:
  - Reset `self._index = 0` unconditionally whenever `override_model()` is called so subsequent resolves evaluate the primary provider.
  - Unconditionally clear `self._admitted_index = None` whenever `self._admitted_index != 0` (dropping any held admission belonging to an old fallback link, whether `fallbacks` was passed or omitted).
  - Preserve `self._admitted_index == 0` for intra-turn half-open probe continuity.
  - Add defensive bounds check clearing `self._admitted_index = None` if `self._admitted_index >= len(self._chain)`.
- In `tests/test_provider_circuit_breaker.py`:
  - Add `test_override_model_resets_index_and_prevents_index_error_with_shorter_chain` verifying no `IndexError` occurs when shortening the chain while on a fallback.
  - Add `test_override_model_resets_stale_fallback_index_to_primary` verifying the active pointer returns to 0 and evaluates the primary provider when `fallbacks` is updated.
  - Add `test_override_model_without_fallbacks_resets_stale_fallback_admission_on_long_chain` verifying stale fallback admission is cleared and the new primary model is evaluated on a long chain even when `fallbacks` argument is omitted.
