### PR TITLE
fix(gateway): normalize sessions.create displayName like rename/patch already do

### DIFF
--- a/src/agentos/gateway/rpc_sessions.py
+++ b/src/agentos/gateway/rpc_sessions.py
@@ -853,7 +853,10 @@ async def _handle_sessions_create(params: dict | None, ctx: RpcContext) -> dict:
     if not isinstance(params, dict):
         params = {}
     agent_id = normalize_agent_id(params.get("agentId", "main"))
-    display_name = params.get("displayName")
+    # Funnel through the same normalizer sessions.rename/sessions.patch use,
+    # so a session created with a multi-line or oversized title can't store a
+    # shape those other write paths would never allow.
+    display_name = normalize_session_name(params.get("displayName"))
     message = params.get("message")
     model = _model_value(params.get("model")) or _agent_registry_model(ctx, agent_id)
     kind = params.get("kind") or params.get("sessionKind")

--- a/tests/test_gateway/test_rpc_sessions.py
+++ b/tests/test_gateway/test_rpc_sessions.py
@@ -639,6 +639,72 @@ class TestSessionsCreate:
 
         assert res.ok is True
 
+    @pytest.mark.asyncio
+    async def test_create_collapses_multiline_display_name_like_rename_does(self, dispatcher):
+        session_manager = FakeSessionManager()
+        ctx = make_ctx(session_manager=session_manager)
+
+        res = await dispatcher.dispatch(
+            "r1",
+            "sessions.create",
+            {"agentId": "myagent", "displayName": "Line one\nLine two\ttabbed"},
+            ctx,
+        )
+
+        assert res.ok is True
+        stored = session_manager._storage._sessions[res.payload["key"]]
+        assert stored.display_name == "Line one Line two tabbed"
+
+    @pytest.mark.asyncio
+    async def test_create_truncates_display_name_to_max_session_name_length(self, dispatcher):
+        session_manager = FakeSessionManager()
+        ctx = make_ctx(session_manager=session_manager)
+
+        res = await dispatcher.dispatch(
+            "r1",
+            "sessions.create",
+            {"agentId": "myagent", "displayName": "x" * 500},
+            ctx,
+        )
+
+        assert res.ok is True
+        stored = session_manager._storage._sessions[res.payload["key"]]
+        assert stored.display_name == "x" * 120
+
+    @pytest.mark.asyncio
+    async def test_create_drops_control_bytes_from_display_name(self, dispatcher):
+        session_manager = FakeSessionManager()
+        ctx = make_ctx(session_manager=session_manager)
+        evil = "Innocent\x1b[2J\x1b[HHACKED"
+
+        res = await dispatcher.dispatch(
+            "r1",
+            "sessions.create",
+            {"agentId": "myagent", "displayName": evil},
+            ctx,
+        )
+
+        assert res.ok is True
+        stored = session_manager._storage._sessions[res.payload["key"]]
+        assert "\x1b" not in stored.display_name
+        assert stored.display_name == "Innocent[2J[HHACKED"
+
+    @pytest.mark.asyncio
+    async def test_create_blank_display_name_normalizes_to_none(self, dispatcher):
+        session_manager = FakeSessionManager()
+        ctx = make_ctx(session_manager=session_manager)
+
+        res = await dispatcher.dispatch(
+            "r1",
+            "sessions.create",
+            {"agentId": "myagent", "displayName": "   \n\t  "},
+            ctx,
+        )
+
+        assert res.ok is True
+        stored = session_manager._storage._sessions[res.payload["key"]]
+        assert stored.display_name is None
+
 
 class TestSessionsList:
     @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #1618

## The bug

`session/naming.py`'s `normalize_session_name()` docstring is explicit: "Every write path funnels
through `normalize_session_name`" so a stored session name stays single-line, trimmed, and bounded to
`MAX_SESSION_NAME_LENGTH` (120 chars). `sessions.rename` (`rpc_sessions.py:1609`) and `sessions.patch`
(`rpc_sessions.py:1541`, whose own comment says this exists "so a patch and a rename can never store
different shapes") both call it. `sessions.create` doesn't:

```python
agent_id = normalize_agent_id(params.get("agentId", "main"))
display_name = params.get("displayName")
```

`display_name` goes straight into `SessionManager.create(..., display_name=display_name, ...)` →
`SessionNode(display_name=...)`, which has no length/content validation of its own. Whatever the
caller sends is stored verbatim.

I verified the downstream impact directly: `markup_escape()` (`ui.py:234`) is Rich's `escape()`, which
only escapes Rich's own `[...]` markup syntax — it does not touch raw ANSI/control bytes:

```pycon
>>> markup_escape("Innocent\x1b[2J\x1b[H\x1b[31mHACKED")
'Innocent\x1b[2J\x1b[H\x1b[31mHACKED'   # ESC bytes pass through untouched
```

That string is exactly what a `/new <pasted-title>` in gateway-mode TUI (`slash_gateway.py:189`, the
title is only `.strip()`-ed) sends as `displayName` to `sessions.create`, and it's exactly what gets
printed back via `markup_escape()` at `slash_gateway.py:244,251` — so raw terminal escape sequences
(clear-screen, cursor moves, color changes, OSC title-setting) in a session title execute on whatever
terminal later renders that session's title/toolbar/list row. `sessions.create` is also a documented
public RPC method (`docs/http-api.md`), so this isn't gated behind any special access path.

## The fix

Funnel `displayName` through the same `normalize_session_name()` call `sessions.rename` and
`sessions.patch` already use, before it reaches `SessionManager.create`:

```python
display_name = normalize_session_name(params.get("displayName"))
```

Nothing else in `_handle_sessions_create` changed.

## Tests

`tests/test_gateway/test_rpc_sessions.py`, added to the existing `TestSessionsCreate` class (4 cases,
offline, deterministic, matching the file's existing `FakeSessionManager`-based style):

- `test_create_collapses_multiline_display_name_like_rename_does` — `"Line one\nLine two\ttabbed"`
  collapses to `"Line one Line two tabbed"`, the same shape `sessions.rename` produces.
- `test_create_truncates_display_name_to_max_session_name_length` — a 500-char name truncates to 120.
- `test_create_drops_control_bytes_from_display_name` — the exact ANSI-escape repro from the issue;
  asserts the stored name contains no `\x1b` byte.
- `test_create_blank_display_name_normalizes_to_none` — whitespace-only input normalizes to `None`,
  same as the other write paths.

All 4 fail without the fix (each asserts the exact normalized shape the bug skips) and pass with it.
The other 12 pre-existing `TestSessionsCreate` tests pass either way, guarding behavior this change
doesn't touch (agent resolution, message seeding, model selection, stub/no-manager paths).

## Verification

Self-test (upstream `rpc_sessions.py` swapped in temporarily):

```
$ uv run pytest -q tests/test_gateway/test_rpc_sessions.py -k TestSessionsCreate
4 failed, 12 passed in 1.67s
FAILED tests/test_gateway/test_rpc_sessions.py::TestSessionsCreate::test_create_collapses_multiline_display_name_like_rename_does
FAILED tests/test_gateway/test_rpc_sessions.py::TestSessionsCreate::test_create_truncates_display_name_to_max_session_name_length
FAILED tests/test_gateway/test_rpc_sessions.py::TestSessionsCreate::test_create_drops_control_bytes_from_display_name
FAILED tests/test_gateway/test_rpc_sessions.py::TestSessionsCreate::test_create_blank_display_name_normalizes_to_none
```

With the fix:

```
$ uv run pytest -q tests/test_gateway/test_rpc_sessions.py -k TestSessionsCreate
16 passed in 1.66s

$ uv run pytest -q
6 failed, 10247 passed, 34 skipped, 4 warnings, 3 errors in 248.55s
```

The 6 failures / 3 errors are pre-existing on `upstream/main`, unrelated to this change (pilot router
ONNX encoder assets, a machine-timezone hygiene check, and wheelhouse packaging tests needing built ML
assets not present in this environment) — same set before and after this diff.

```
$ uv run ruff check .
All checks passed!

$ uv run mypy --show-error-codes src
Success: no issues found in 625 source files
```

## One adjacent case, deliberately left alone

`normalize_session_name` raises `ValueError` if given a non-`str`, non-`None` value — that's the
existing behavior `sessions.rename` already has at the exact same call site, so this PR doesn't change
how a malformed (non-string) `displayName` is handled, only how a string one is sanitized.
