### PR TITLE
fix(scheduler): stop reading status codes inside longer numbers

### DIFF
--- a/src/agentos/scheduler/jobs.py
+++ b/src/agentos/scheduler/jobs.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
 from zoneinfo import ZoneInfo
@@ -60,8 +61,6 @@ _TRANSIENT_ERROR_PATTERNS = (
     "rate limit",
     "too many requests",
     "resource exhausted",
-    "429",
-    "529",
     "overload",
     "timeout",
     "timed out",
@@ -72,9 +71,6 @@ _TRANSIENT_ERROR_PATTERNS = (
     "service unavailable",
     "bad gateway",
     "gateway timeout",
-    "502",
-    "503",
-    "504",
     "cloudflare",
 )
 _PERMANENT_ERROR_PATTERNS = (
@@ -82,11 +78,29 @@ _PERMANENT_ERROR_PATTERNS = (
     "invalid api key",
     "invalid_api_key",
     "forbidden",
-    "401",
-    "403",
     "validation",
     "invalid request",
     "no handler registered",
+)
+# Bare status codes are matched as whole numbers rather than by plain
+# containment: "403" is a substring of the "4033" in "timed out after 4033ms",
+# and a permanent classification disables the job on its first failure with no
+# retry, so a duration that happens to contain an auth code must not read as
+# one. \b is not enough — "." is a non-word character, so it still reads
+# "12.403 seconds" as a 403 — hence an explicit digit-and-dot guard in front
+# and a digit guard behind. A trailing "." is deliberately still allowed, so a
+# code that ends a sentence ("got 403.") keeps matching, while a dot followed
+# by a letter is rejected so a script named report-403.sh does not disable its
+# own job (scripts.py interpolates path.name into the error text). Because the
+# guard is about digits rather than word characters it also still matches a
+# code glued to a name, like "http_403", which plain \b would have dropped.
+_TRANSIENT_ERROR_CODES = ("429", "529", "502", "503", "504")
+_PERMANENT_ERROR_CODES = ("401", "403")
+_TRANSIENT_ERROR_CODE_RE = re.compile(
+    rf"(?<![\d.])(?:{'|'.join(_TRANSIENT_ERROR_CODES)})(?!\d)(?!\.[A-Za-z])"
+)
+_PERMANENT_ERROR_CODE_RE = re.compile(
+    rf"(?<![\d.])(?:{'|'.join(_PERMANENT_ERROR_CODES)})(?!\d)(?!\.[A-Za-z])"
 )
 
 
@@ -100,12 +114,17 @@ def classify_error(error_text: str | None) -> str:
     if not error_text:
         return "transient"
     lowered = error_text.lower()
-    for pattern in _PERMANENT_ERROR_PATTERNS:
-        if pattern in lowered:
-            return "permanent"
-    for pattern in _TRANSIENT_ERROR_PATTERNS:
-        if pattern in lowered:
-            return "transient"
+    if any(pattern in lowered for pattern in _PERMANENT_ERROR_PATTERNS):
+        return "permanent"
+    if _PERMANENT_ERROR_CODE_RE.search(lowered):
+        return "permanent"
+    # Both transient checks are redundant with the default below and are kept,
+    # as the pattern loop already was before this change, so the taxonomy stays
+    # explicit and symmetric with the permanent side.
+    if any(pattern in lowered for pattern in _TRANSIENT_ERROR_PATTERNS):
+        return "transient"
+    if _TRANSIENT_ERROR_CODE_RE.search(lowered):
+        return "transient"
     return "transient"
 
 # Exponential backoff schedule for retryable jobs.

--- a/tests/test_scheduler/test_exact_and_retry_classification.py
+++ b/tests/test_scheduler/test_exact_and_retry_classification.py
@@ -200,6 +200,37 @@ def test_classify_error_defaults_to_transient() -> None:
     assert classify_error("something obscure") == "transient"
 
 
+def test_classify_error_ignores_status_codes_inside_longer_numbers() -> None:
+    # "403" is a substring of the "4033" in a millisecond duration, and the
+    # permanent loop runs first, so plain containment let an ordinary timeout
+    # permanently disable the job on its first failure.
+    assert classify_error("Request timed out after 4033ms") == "transient"
+    assert classify_error("Upstream latency 4011ms on retry attempt") == "transient"
+    assert classify_error("job failed after 5030 attempts") == "transient"
+
+
+def test_classify_error_ignores_status_codes_inside_decimals() -> None:
+    # "." is not a word character, so \b alone still read these as codes.
+    assert classify_error("Handler timed out after 12.403 seconds") == "transient"
+    assert classify_error("p95 0.403 s") == "transient"
+    assert classify_error("latency 1.429 s") == "transient"
+
+
+def test_classify_error_ignores_status_codes_inside_file_names() -> None:
+    # scripts.py interpolates path.name into the error text.
+    assert classify_error("Script timed out after 30s: report-403.sh") == "transient"
+
+
+def test_classify_error_still_matches_delimited_status_codes() -> None:
+    assert classify_error("HTTP 403: forbidden") == "permanent"
+    assert classify_error("status=401") == "permanent"
+    assert classify_error("(429)") == "transient"
+    # A trailing sentence period is not a file extension.
+    assert classify_error("got 403.") == "permanent"
+    # A code glued to a name by a word character, which \b would have dropped.
+    assert classify_error("upstream returned http_403") == "permanent"
+
+
 def _recurring_failure(error: str) -> CronJob:
     return CronJob(
         id="job-1",


### PR DESCRIPTION
Fixes #1519

## The bug

`_PERMANENT_ERROR_PATTERNS` matched bare status codes by plain substring containment, so `"403"` matched the `"4033"` in `Request timed out after 4033ms`. The permanent loop runs before the transient one, so the match won even though the same text carries the explicit `"timed out"` transient signature.

Traced through `_apply_result_state`, `"permanent"` immediately sets `status = DISABLED` and `enabled = False`, with no retry and no backoff — a single network blip whose message happened to contain a 3-digit millisecond duration permanently disabled an otherwise healthy recurring job.

## The fix

Bare codes are split out of the substring tuples and matched as whole numbers.

`\b` turned out to be the wrong boundary for a *number*. `.` is not a word character, so a `\b`-anchored pattern still reads `Handler timed out after 12.403 seconds` and `p95 0.403 s` as 403s — the same first-failure disable, just in float form. The guard is therefore about digits rather than word characters:

```
(?<![\d.])(?:401|403)(?!\d)(?!\.[A-Za-z])
```

- no digit or dot in front — rejects `4033ms`, `12.403`, `0.403`
- no digit behind — rejects `4033`
- a dot followed by a letter is rejected, so a script named `report-403.sh` does not disable its own job (`scheduler/scripts.py` interpolates `path.name` straight into the error text)
- a trailing `.` is still allowed, so a code ending a sentence (`got 403.`) keeps matching

Being digit-based rather than word-based also *keeps* a case plain `\b` would have lost: `http_403` still classifies as permanent, where a word boundary would have downgraded a genuine auth failure to transient and burned all five `MAX_CONSECUTIVE_ERRORS` retries through the backoff schedule.

Permanent-before-transient precedence is unchanged.

## Tests

New regression tests in `tests/test_scheduler/test_exact_and_retry_classification.py` cover the reported strings, the decimal form, the filename form, and the delimited codes that must keep matching. Existing classification tests are untouched and pass.

`uv run pytest -q` → 10263 passed, 27 skipped. `ruff check` and `mypy src/agentos` clean.

## Merge safety

This PR touches only `src/agentos/scheduler/jobs.py` and its test file, and does not touch `CHANGELOG.md`. It has been verified to merge cleanly against `main` both before and after #1510, #1513, #1514 and #1517, in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P89M4WTuw9EwCKgoU4Z55r