### PR TITLE
fix(memory): redact secrets behind snake_case qualifiers

### DIFF
--- a/src/agentos/memory/redaction.py
+++ b/src/agentos/memory/redaction.py
@@ -6,8 +6,22 @@ import re
 
 from agentos.redact import redact_sensitive_text
 
+# A leading ``qualifier_``/``qualifier-`` chain is part of the name: ``_`` is a
+# word character, so ``\b`` alone never fires before "token" in ``reset_token``
+# and the value went into durable memory unmasked. The keyword must still sit
+# immediately before the separator, which is what keeps ordinary field names
+# such as ``token_count`` or ``my_token_count`` out — the keyword there is
+# followed by ``_count``, not by ``:``/``=`` — and camelCase humps are still not
+# split, so ``sellToken`` stays an asset name rather than a credential.
+#
+# The chain is bounded rather than ``*``: every ``-`` is a word boundary, so
+# an unbounded chain retries a growing prefix at each of the n segment starts
+# in a run like ``"8f3a-" * 20000`` — quadratic, and measured at 22s for one
+# 100KB line on a path that runs per transcript message. Four qualifiers is
+# well past anything real (``password_reset_token`` uses two).
 _KEYWORD_PATTERN = re.compile(
-    r"(?i)\b(api[_-]?key|secret|token|password)(\s*[:=]\s*)(\"[^\"]*\"|'[^']*'|\S+)"
+    r"(?i)\b((?:[a-z0-9]+[_-]){0,4}(?:api[_-]?key|secret|token|password))"
+    r"(\s*[:=]\s*)(\"[^\"]*\"|'[^']*'|\S+)"
 )
 
 

--- a/tests/test_security/test_memory_redaction.py
+++ b/tests/test_security/test_memory_redaction.py
@@ -94,3 +94,69 @@ from agentos.memory.redaction import redact_memory_text
 )
 def test_redact_memory_text(input_text: str, expected_text: str) -> None:
     assert redact_memory_text(input_text) == expected_text
+
+
+@pytest.mark.parametrize(
+    "input_text",
+    [
+        "reset_token: 8f3a91c2b6d04e7f9a1b5c3d7e2f4a6b",
+        "csrf_token=8f3a91c2b6d04e7f9a1b5c3d7e2f4a6b",
+        "device_token: 8f3a91c2b6d04e7f9a1b5c3d7e2f4a6b",
+        "verification_token = 8f3a91c2b6d04e7f9a1b5c3d7e2f4a6b",
+        "password_reset_token: 8f3a91c2b6d04e7f9a1b5c3d7e2f4a6b",
+        "app_secret: 8f3a91c2b6d04e7f9a1b5c3d7e2f4a6b",
+        "db_password = hunter2hunter2",
+        "stripe_api_key: 8f3a91c2b6d04e7f9a1b5c3d7e2f4a6b",
+    ],
+)
+def test_snake_case_qualified_secret_names_are_redacted(input_text: str) -> None:
+    # "_" is a word character, so \b never fires before "token" when a
+    # snake_case qualifier is glued to it — the value used to pass through
+    # unmasked on the way into durable memory.
+    name, _, _value = input_text.partition("=" if "=" in input_text else ":")
+    redacted = redact_memory_text(input_text)
+    assert "8f3a91c2b6d04e7f9a1b5c3d7e2f4a6b" not in redacted
+    assert "hunter2hunter2" not in redacted
+    assert redacted.startswith(name.rstrip())
+
+
+@pytest.mark.parametrize(
+    "input_text",
+    [
+        "sellToken: 123",
+        "token_count = 5",
+        "my_token_count = 10",
+        "reset_token_count = 5",
+        "secret_santa_name: bob",
+        "the password reset flow is broken",
+    ],
+)
+def test_snake_case_widening_does_not_redact_ordinary_field_names(input_text: str) -> None:
+    assert redact_memory_text(input_text) == input_text
+
+
+def test_hyphen_runs_do_not_backtrack_quadratically() -> None:
+    """redact_memory_text runs per transcript message; it must stay linear.
+
+    Every "-" is a word boundary, so an unbounded qualifier chain retried a
+    growing prefix at each of the n segment starts. One 100KB line took 22s.
+    """
+    import time
+
+    text = "8f3a-" * 20000
+
+    start = time.perf_counter()
+    redact_memory_text(text)
+    elapsed = time.perf_counter() - start
+
+    assert elapsed < 1.0, f"redaction took {elapsed:.2f}s on a 100KB hyphen run"
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["reset_token", "app_reset_token", "mobile_app_reset_token", "my_mobile_app_reset_token"],
+)
+def test_qualifier_chains_up_to_the_bound_still_redact(name: str) -> None:
+    secret = "8f3a91c2b6d04e7f9a1b5c3d7e2f4a6b"
+
+    assert secret not in redact_memory_text(f"{name}: {secret}")


### PR DESCRIPTION
Fixes #1517

## The bug

`_KEYWORD_PATTERN` anchored its keyword on `\b`, but `_` is itself a word character, so the boundary never fires before `token` when a snake_case qualifier is glued to it. `reset_token`, `csrf_token`, `device_token`, `push_token` and `verification_token` all passed their values through completely unmasked — and this is the redaction path `memory_save` and `session_source.py` run before content is written to **durable memory**.

```python
>>> redact_memory_text("reset_token: 8f3a91c2b6d04e7f9a1b5c3d7e2f4a6b")
'reset_token: 8f3a91c2b6d04e7f9a1b5c3d7e2f4a6b'
```

## The fix

The keyword may now be preceded by a chain of `qualifier_` / `qualifier-` segments.

What keeps ordinary field names out is unchanged and load bearing: **the keyword must still sit immediately before the `:`/`=` separator**, so `token_count` and `my_token_count` do not match (the keyword there is followed by `_count`), and camelCase humps are still not split, so `sellToken` stays an asset name rather than a credential. Those three cases are already asserted in `test_memory_redaction.py`; a new parametrized test pins them alongside `reset_token_count` and `secret_santa_name`.

### Why the chain is bounded and not `*`

Worth calling out, because the obvious `(?:[a-z0-9]+[_-])*` is a trap here. Every `-` is a word boundary, so an unbounded chain retries a growing prefix at each of the *n* segment starts in a run like `"8f3a-" * 20000`. That is quadratic, and it measured **22s for a single 100KB line** — on a path that runs per transcript message inside `SessionSourceIndexer.sync`, which fires on session start, on the timer, on watch events and before memory searches. Bounded at four qualifiers (`password_reset_token` uses two), the same input takes **13ms**. A regression test pins the bound.

## Known adjacent gaps, deliberately not in scope

- `resetToken:` / `csrfToken:` (camelCase, no separator) are still missed. Closing that needs `redact.py`'s `_name_segments` / `_is_credential_name` segment splitter rather than this pattern, since the existing `sellToken` test forbids naively splitting humps.
- Reference-style values (`db_password = $DB_PASSWORD`, `session_token = None`) are redacted rather than preserved. That is pre-existing behaviour of `_KEYWORD_PATTERN` — `token = $MY_TOKEN` was already masked before this change — and it is the safe direction for durable memory, but it now applies to more names. Changing it means revisiting the memory redaction policy, which is a separate call.

## Tests

`uv run pytest -q` → 10278 passed, 27 skipped. `ruff check` and `mypy src/agentos` clean.

## Merge safety

This PR touches only `src/agentos/memory/redaction.py` and `tests/test_security/test_memory_redaction.py`, and does not touch `CHANGELOG.md`. It has been verified to merge cleanly against `main` both before and after #1510, #1513, #1514 and #1519, in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P89M4WTuw9EwCKgoU4Z55r