### PR TITLE
fix(tools): resolve a relative workdir in the shell denial ledger

### DIFF
--- a/src/agentos/tools/builtin/shell.py
+++ b/src/agentos/tools/builtin/shell.py
@@ -759,7 +759,7 @@ async def exec_command(
             status = approval_response.get("status")
             if status == "approval_denied":
                 await _record_shell_denial(
-                    "exec_command", command, workdir, DenialReason.HUMAN_REJECTED
+                    "exec_command", command, cwd, DenialReason.HUMAN_REJECTED
                 )
             return json.dumps(approval_response)
 
@@ -926,7 +926,7 @@ async def background_process(
             status = approval_response.get("status")
             if status == "approval_denied":
                 await _record_shell_denial(
-                    "background_process", command, workdir, DenialReason.HUMAN_REJECTED
+                    "background_process", command, cwd, DenialReason.HUMAN_REJECTED
                 )
             return json.dumps(approval_response)
 
@@ -1288,15 +1288,27 @@ def _sandbox_request_for(
         return None
     action_kind = "shell.background" if tool_name == "background_process" else "shell.exec"
     ctx = current_tool_context.get()
+    ctx_workspace: Path | None = None
+    if ctx is not None and ctx.workspace_dir:
+        wp = Path(ctx.workspace_dir).expanduser()
+        if wp.is_absolute():
+            ctx_workspace = wp
     workspace = None
     if workdir:
-        p = Path(workdir)
+        p = Path(workdir).expanduser()
         if p.is_absolute():
             workspace = p
-    if workspace is None and ctx is not None and ctx.workspace_dir:
-        wp = Path(ctx.workspace_dir)
-        if wp.is_absolute():
-            workspace = wp
+        elif ctx_workspace is not None:
+            # A relative workdir is relative to the workspace, and cwd is part
+            # of the ledger fingerprint: dropping it hashed a denial under
+            # ``subproject/`` as a denial at the workspace root, so two
+            # different targets shared one denial count. A traversing workdir
+            # is deliberately left as it resolves — this request is only ever
+            # fingerprinted, never handed to a backend, so keeping distinct
+            # targets distinct is the whole point and grants nothing.
+            workspace = (ctx_workspace / p).resolve()
+    if workspace is None:
+        workspace = ctx_workspace
     if workspace is None:
         workspace = runtime.workspace if runtime.workspace.is_absolute() else Path.cwd()
 

--- a/tests/test_tools/test_shell_denial_ledger_workdir.py
+++ b/tests/test_tools/test_shell_denial_ledger_workdir.py
@@ -1,0 +1,108 @@
+"""`_sandbox_request_for` must resolve a relative ``workdir`` (issue #1510).
+
+The denial ledger fingerprints a `SandboxRequest`, and `cwd` is part of that
+fingerprint. Dropping a relative `workdir` made every denial under a
+subdirectory hash as a denial at the workspace root.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agentos.sandbox.config import SandboxSettings
+from agentos.sandbox.integration import configure_runtime, reset_runtime
+from agentos.tools.builtin import shell
+from agentos.tools.types import CallerKind, ToolContext, current_tool_context
+
+
+@pytest.fixture(autouse=True)
+def _runtime(tmp_path: Path):
+    reset_runtime()
+    configure_runtime(
+        SandboxSettings(sandbox=True, backend="noop", security_grading=False),
+        workspace=tmp_path,
+    )
+    token = current_tool_context.set(
+        ToolContext(
+            caller_kind=CallerKind.CLI,
+            session_key="agent:main:test",
+            workspace_dir=str(tmp_path),
+        )
+    )
+    yield
+    current_tool_context.reset(token)
+    reset_runtime()
+
+
+def _cwd_for(workdir: str | None) -> Path:
+    built = shell._sandbox_request_for("exec_command", "rm -rf build", workdir)
+    assert built is not None
+    request, _policy, _session_id = built
+    return request.cwd
+
+
+def test_relative_workdir_resolves_against_the_workspace(tmp_path: Path) -> None:
+    (tmp_path / "subproject").mkdir()
+
+    assert _cwd_for("subproject") == (tmp_path / "subproject").resolve()
+
+
+def test_dot_relative_workdir_resolves_against_the_workspace(tmp_path: Path) -> None:
+    (tmp_path / "tests").mkdir()
+
+    assert _cwd_for("./tests") == (tmp_path / "tests").resolve()
+
+
+def test_absolute_workdir_is_still_honoured(tmp_path: Path) -> None:
+    other = tmp_path / "elsewhere"
+    other.mkdir()
+
+    assert _cwd_for(str(other)) == other.resolve()
+
+
+def test_missing_workdir_falls_back_to_the_workspace(tmp_path: Path) -> None:
+    assert _cwd_for(None) == tmp_path.resolve()
+
+
+def test_denials_in_different_subdirectories_fingerprint_differently(tmp_path: Path) -> None:
+    from agentos.sandbox.integration import action_fingerprint
+
+    (tmp_path / "a").mkdir()
+    (tmp_path / "b").mkdir()
+
+    built_a = shell._sandbox_request_for("exec_command", "rm -rf build", "a")
+    built_b = shell._sandbox_request_for("exec_command", "rm -rf build", "b")
+    assert built_a is not None and built_b is not None
+
+    assert action_fingerprint(built_a[0]) != action_fingerprint(built_b[0])
+
+
+@pytest.mark.asyncio
+async def test_exec_command_records_the_denial_against_the_subdirectory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end: a denial under subproject/ must not hash as one at the root."""
+    from agentos.sandbox.integration import action_fingerprint, get_runtime
+
+    (tmp_path / "subproject").mkdir()
+
+    async def _denied(**_kwargs: object) -> dict[str, object]:
+        return {"status": "approval_denied"}
+
+    monkeypatch.setattr(shell, "_check_exec_approval", _denied)
+
+    await shell.exec_command("rm -rf build", workdir="subproject")
+
+    runtime = get_runtime()
+    assert runtime is not None
+    recorded, _reason = await runtime.ledger.last_denial("agent:main:test")
+
+    built = shell._sandbox_request_for("exec_command", "rm -rf build", "subproject")
+    assert built is not None
+    assert recorded == action_fingerprint(built[0])
+
+    root = shell._sandbox_request_for("exec_command", "rm -rf build", None)
+    assert root is not None
+    assert recorded != action_fingerprint(root[0])


### PR DESCRIPTION
Fixes #1510

## The bug

`_sandbox_request_for` kept a `workdir` only when it was already absolute, so `Path("subproject").is_absolute()` being `False` silently dropped it and the request fell back to the workspace root.

`cwd` is part of the request's action fingerprint, so every denial under a subdirectory hashed as a denial at the root: `rm -rf build` refused in `subproject/` and the same command refused at the top level shared one denial count in the ledger, and one §8.3 stale-output purge.

## The fix

- `_sandbox_request_for` now resolves a relative `workdir` against `ctx.workspace_dir`, the same base `_effective_workdir` already uses.
- `exec_command` and `background_process` computed `cwd = _effective_workdir(workdir)` and then handed the raw, unresolved `workdir` to `_record_shell_denial`. Both now pass the resolved `cwd` that every check above them already receives.

## On the issue's third point — `gate_action` — deliberately not done

The issue also asks that the resolved `cwd` be passed to `gate_action`. I implemented that, then backed it out, because `gate_action` feeds its `cwd` to `_resolve_workspace`, which is the sandbox **policy workspace root**, not just a fingerprint input. Measured against this branch with the change in place:

| `workdir` | policy mount before | policy mount with resolved `cwd` |
|---|---|---|
| `"frontend"` | `<ws>` (rw) | `<ws>/frontend` (rw) |
| `"../.."` | `<ws>` (rw) | `<parent of ws>` (rw) |

So it both **narrows** the mount in the ordinary case — a build in `frontend/` loses rw on the repo root, sibling paths and `.git` — and, worse, **re-roots it above the workspace entirely** for a traversing `workdir`. That is a sandbox weakening, not a bookkeeping fix.

Making `request.cwd` follow the `workdir` without moving the mount needs the policy workspace and the request cwd separated in `gate_action`, which is a larger change than this one and wants its own issue. Note the same latent problem exists in `_resolve_workspace` itself, which drops a relative `cwd` exactly as `_sandbox_request_for` did.

A traversing `workdir` *is* left as it resolves inside `_sandbox_request_for`, and that is safe: this request is only ever fingerprinted, never handed to a backend, so keeping distinct targets distinct is the whole point and grants nothing.

## Known adjacent gap

`_sandbox_request_for` calls `build_request` without `env`, while `gate_action` passes the merged env, and `action_fingerprint` hashes `env["PATH"]` — so a ledger fingerprint and a gate fingerprint for the same action never agree. That is pre-existing and orthogonal to the `cwd` bug, but it does mean a recorded shell denial is not yet reachable from the §8.3/§8.4 guards. Worth its own issue.

## Tests

New `tests/test_tools/test_shell_denial_ledger_workdir.py`: relative, `./`-relative, absolute and missing `workdir`; distinct fingerprints for distinct subdirectories; and an end-to-end case driving `exec_command` with a denied approval, asserting the recorded fingerprint is the subdirectory's and not the workspace root's. All four failing cases verified red against pristine `main`.

`uv run pytest -q` → 10265 passed, 27 skipped. `ruff check` and `mypy src/agentos` clean.

## Merge safety

This PR touches only `src/agentos/tools/builtin/shell.py` and a new test file, and does not touch `CHANGELOG.md`. #1513 touches the same source file; the two sets of hunks are disjoint and have been verified to merge cleanly in either order, with the combined tree passing the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P89M4WTuw9EwCKgoU4Z55r