### PR TITLE
fix(tools): notify memory source writes for USER.md and memory.md in apply_patch

### DIFF
--- a/src/agentos/tools/builtin/patch.py
+++ b/src/agentos/tools/builtin/patch.py
@@ -169,17 +169,39 @@ def _validate_path(path: str, root: Path | None = None) -> Path:
     return resolved
 
 
+def _memory_source_root() -> Path | None:
+    ctx = current_tool_context.get()
+    if ctx is None or not ctx.memory_source_dir:
+        return None
+    return Path(ctx.memory_source_dir).expanduser().resolve()
+
+
+def _memory_roots(default_root: Path) -> tuple[Path, ...]:
+    roots: list[Path] = []
+    for root in (default_root, _memory_source_root()):
+        if root is None or root in roots:
+            continue
+        roots.append(root)
+    return tuple(roots)
+
+
 def _memory_source_rel_path(path: str, root: Path) -> str | None:
     resolved = _validate_path(path, root)
-    try:
-        rel = resolved.relative_to(root)
-    except ValueError:
-        return None
+    for mem_root in _memory_roots(root):
+        try:
+            rel = resolved.relative_to(mem_root)
+        except ValueError:
+            continue
 
-    if rel.parts == ("MEMORY.md",):
-        return "MEMORY.md"
-    if len(rel.parts) >= 2 and rel.parts[0] == "memory" and rel.suffix == ".md":
-        return rel.as_posix()
+        # USER.md is a curated store in its own right -- CuratedMemoryStore
+        # loads, sanitizes, and injects it alongside MEMORY.md. Editing it
+        # through a filesystem or patch tool must refresh the frozen snapshot
+        # the same way, or the change stays invisible to the model until the
+        # session ends. (It is also a bootstrap file, so it notifies both paths.)
+        if rel.parts in {("MEMORY.md",), ("memory.md",), ("USER.md",)}:
+            return rel.as_posix()
+        if len(rel.parts) >= 2 and rel.parts[0] == "memory" and rel.suffix == ".md":
+            return rel.as_posix()
     return None
 
 

--- a/tests/test_tools/test_bootstrap_write_notifications.py
+++ b/tests/test_tools/test_bootstrap_write_notifications.py
@@ -19,7 +19,7 @@ async def test_filesystem_write_notifies_bootstrap_or_memory_sources(tmp_path) -
     bootstrap_calls: list[tuple[str, str]] = []
     token = current_tool_context.set(
         ToolContext(
-                        agent_id="main",
+            agent_id="main",
             workspace_dir=str(tmp_path),
             memory_source_dir=str(tmp_path),
             on_memory_source_write=lambda agent_id, path: memory_calls.append((agent_id, path)),
@@ -50,7 +50,7 @@ async def test_patch_notifies_bootstrap_and_memory_sources(tmp_path) -> None:
     (tmp_path / "memory" / "2026-05-01.md").write_text("old\n", encoding="utf-8")
     token = current_tool_context.set(
         ToolContext(
-                        agent_id="main",
+            agent_id="main",
             workspace_dir=str(tmp_path),
             memory_source_dir=str(tmp_path),
             on_memory_source_write=lambda agent_id, path: memory_calls.append((agent_id, path)),
@@ -77,4 +77,40 @@ async def test_patch_notifies_bootstrap_and_memory_sources(tmp_path) -> None:
         current_tool_context.reset(token)
 
     assert bootstrap_calls == [("main", "USER.md")]
-    assert memory_calls == [("main", "memory/2026-05-01.md")]
+    assert ("main", "USER.md") in memory_calls
+    assert ("main", "memory/2026-05-01.md") in memory_calls
+
+
+@pytest.mark.asyncio
+async def test_patch_notifies_memory_md_and_custom_memory_dir(tmp_path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    memory_dir = tmp_path / "custom_memory"
+    memory_dir.mkdir()
+
+    (workspace_dir / "memory.md").write_text("# Old Memory\n", encoding="utf-8")
+    (memory_dir / "USER.md").write_text("Name:\n", encoding="utf-8")
+
+    memory_calls: list[tuple[str, str]] = []
+    token = current_tool_context.set(
+        ToolContext(
+            agent_id="main",
+            workspace_dir=str(workspace_dir),
+            memory_source_dir=str(memory_dir),
+            on_memory_source_write=lambda agent_id, path: memory_calls.append((agent_id, path)),
+        )
+    )
+    apply_patch = _original_async(patch_tool.apply_patch)
+    try:
+        await apply_patch(
+            """*** Begin Patch
+*** Update File: memory.md
+@@@ -1,1 +1,1 @@@
+-# Old Memory
++# New Memory
+*** End Patch"""
+        )
+    finally:
+        current_tool_context.reset(token)
+
+    assert ("main", "memory.md") in memory_calls


### PR DESCRIPTION
## Summary

When updating files using `apply_patch`, `_memory_source_rel_path` in `src/agentos/tools/builtin/patch.py` previously checked only `rel.parts == ("MEMORY.md",)` and only against the default patch root.

As a result:
1. Patching `USER.md` (curated memory store) did not notify `on_memory_source_write`, leaving the in-memory frozen snapshot stale and missing user-profile updates.
2. Patching legacy `memory.md` or files located in a configured `memory_source_dir` root did not notify `on_memory_source_write`.

This PR aligns `patch._memory_source_rel_path` with `filesystem._memory_source_rel_path` by checking all memory roots and recognizing `("MEMORY.md",)`, `("memory.md",)`, and `("USER.md",)`.

Closes #1625

## Testing

- Updated `tests/test_tools/test_bootstrap_write_notifications.py` to assert that patching `USER.md` notifies both the bootstrap and memory callbacks.
- Added `test_patch_notifies_memory_md_and_custom_memory_dir` covering `memory.md` and custom `memory_source_dir`.
- Ran full `test_tools` test suite (`1088 passed`).
