### PR TITLE
fix(tools): stop counting /dev/null as a shell write target

### DIFF
--- a/src/agentos/tools/builtin/shell.py
+++ b/src/agentos/tools/builtin/shell.py
@@ -82,6 +82,7 @@ _SANDBOX_NETWORK_FAILURE_MARKERS: tuple[str, ...] = (
     "failed to resolve",
     "curl: (6)",
 )
+_NULL_SINK_PATH = "/dev/null"
 _SHELL_NULL_REDIRECT_RE = re.compile(
     r"(?:(?<=^)|(?<=[\s;|&]))\d*[<>]{1,2}\s*/dev/null(?=$|[\s;|&])"
 )
@@ -354,10 +355,16 @@ _TEE_PATTERN = re.compile(
 
 
 def _shell_write_targets(command: str) -> list[str]:
-    scanned = _FD_DUP_PATTERN.sub(" ", command)
+    # Discarding output is not a write, so the null sink must not read as a
+    # write target -- otherwise ``> /dev/null`` alone blocks the command under
+    # workspace lockdown. Stripping the redirections first mirrors what
+    # ``_sensitive_shell_block`` already does; the trailing filter is what
+    # covers ``tee /dev/null``, where the sink arrives as an argument rather
+    # than as a redirection and so survives the stripper.
+    scanned = _FD_DUP_PATTERN.sub(" ", _without_shell_null_redirections(command))
     targets: list[str] = [match.group(2) for match in _REDIRECTION_PATTERN.finditer(scanned)]
     targets.extend(match.group(2) for match in _TEE_PATTERN.finditer(scanned))
-    return targets
+    return [target for target in targets if target != _NULL_SINK_PATH]
 
 
 def _workspace_lockdown_shell_block(

--- a/tests/test_tools/test_shell_approval_policy.py
+++ b/tests/test_tools/test_shell_approval_policy.py
@@ -524,6 +524,111 @@ def test_shell_write_targets_ignores_words_ending_in_tee(command: str) -> None:
     assert shell._shell_write_targets(command) == []
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        "pip install requests > /dev/null",
+        "pip install requests 2>/dev/null",
+        "pip install requests &>/dev/null",
+        "pip install requests > /dev/null 2>&1",
+        "pip install requests >/dev/null 2>&1",
+        "echo hi | tee /dev/null",
+        "echo hi | tee -a /dev/null",
+        "make build >/dev/null; make test >/dev/null",
+    ],
+)
+def test_shell_write_targets_ignores_the_null_sink(command: str) -> None:
+    """Discarding output is not a write. ``/dev/null`` is not under any lockdown
+    root, so counting it as a write target refused a large share of ordinary
+    commands under workspace lockdown."""
+    assert shell._shell_write_targets(command) == []
+
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        ("cmd > out.txt 2>/dev/null", ["out.txt"]),
+        ("cmd 2>/dev/null > /etc/passwd", ["/etc/passwd"]),
+        ("cmd 2>/dev/null | tee /etc/passwd", ["/etc/passwd"]),
+        ("cmd >/dev/null | tee -a out.log", ["out.log"]),
+    ],
+)
+def test_shell_write_targets_keeps_real_targets_beside_a_null_sink(
+    command: str,
+    expected: list[str],
+) -> None:
+    """The null sink is dropped without over-stripping: a real target in the
+    same command still has to be reported."""
+    assert shell._shell_write_targets(command) == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "command",
+    [
+        "pip install requests > /dev/null",
+        "pip install requests 2>/dev/null",
+        "pip install requests &>/dev/null",
+        "pip install requests > /dev/null 2>&1",
+        "echo hi | tee /dev/null",
+    ],
+)
+async def test_workspace_lockdown_allows_null_sink_redirections(
+    tmp_path: Path,
+    command: str,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.interaction_mode = InteractionMode.UNATTENDED
+    ctx.elevated = "bypass"
+    ctx.workspace_dir = str(workspace)
+    ctx.workspace_lockdown = True  # type: ignore[attr-defined]
+
+    result = await shell._check_exec_approval(
+        "exec_command",
+        command,
+        str(workspace),
+        "command requires approval",
+        None,
+        False,
+    )
+
+    assert result is None or result.get("reason") != "workspace_lockdown"
+
+
+@pytest.mark.asyncio
+async def test_workspace_lockdown_still_blocks_a_real_target_beside_a_null_sink(
+    tmp_path: Path,
+) -> None:
+    """Guards the other direction: dropping the null sink must not smuggle a
+    genuine out-of-workspace write past the lockdown."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside.txt"
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.interaction_mode = InteractionMode.UNATTENDED
+    ctx.elevated = "bypass"
+    ctx.workspace_dir = str(workspace)
+    ctx.workspace_lockdown = True  # type: ignore[attr-defined]
+
+    result = await shell._check_exec_approval(
+        "exec_command",
+        f"echo ok > {outside} 2>/dev/null",
+        str(workspace),
+        "command requires approval",
+        None,
+        False,
+    )
+
+    assert result is not None
+    assert result["status"] == "blocked"
+    assert result["reason"] == "workspace_lockdown"
+    assert result["target"] == str(outside)
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "template",


### PR DESCRIPTION
Fixes #1545

## The bug

`_sensitive_shell_block` strips null redirections before it scans
(`shell.py:264`), but `_shell_write_targets` runs `_REDIRECTION_PATTERN` against the raw command:

```python
def _shell_write_targets(command: str) -> list[str]:
    scanned = _FD_DUP_PATTERN.sub(" ", command)
    targets: list[str] = [match.group(2) for match in _REDIRECTION_PATTERN.finditer(scanned)]
    targets.extend(match.group(2) for match in _TEE_PATTERN.finditer(scanned))
    return targets
```

It is the only feed into `_workspace_lockdown_shell_block`, and `/dev/null` is not under any lockdown
root, so under lockdown the whole command is refused with `reason="workspace_lockdown"` and a message
naming `/dev/null` as an out-of-workspace write target. `> /dev/null 2>&1` is one of the most common
shell idioms there is.

## The fix

Two halves, because the null sink reaches the scanner two different ways. Measured on
`upstream/main` @ 0d9c59a1, `_shell_write_targets` returns:

| command | before | routing through `_without_shell_null_redirections` only | this PR |
| --- | --- | --- | --- |
| `pip install requests > /dev/null` | `['/dev/null']` | `[]` | `[]` |
| `pip install requests 2>/dev/null` | `['/dev/null']` | `[]` | `[]` |
| `pip install requests &>/dev/null` | `['/dev/null']` | `[]` | `[]` |
| `pip install requests > /dev/null 2>&1` | `['/dev/null']` | `[]` | `[]` |
| `echo hi \| tee /dev/null` | `['/dev/null']` | **`['/dev/null']`** | `[]` |
| `echo hi > /etc/passwd` | `['/etc/passwd']` | `['/etc/passwd']` | `['/etc/passwd']` |
| `echo hi \| tee /etc/passwd` | `['/etc/passwd']` | `['/etc/passwd']` | `['/etc/passwd']` |

Routing through `_without_shell_null_redirections` — the parity with the sensitive-path scanner you
asked for — fixes the four redirection forms but not `tee /dev/null`: there the sink is an *argument*,
not a redirection, so `_SHELL_NULL_REDIRECT_RE` (which requires a `[<>]` operator) cannot see it. So
the fix does both:

```python
def _shell_write_targets(command: str) -> list[str]:
    # Discarding output is not a write, so the null sink must not read as a
    # write target -- otherwise ``> /dev/null`` alone blocks the command under
    # workspace lockdown. Stripping the redirections first mirrors what
    # ``_sensitive_shell_block`` already does; the trailing filter is what
    # covers ``tee /dev/null``, where the sink arrives as an argument rather
    # than as a redirection and so survives the stripper.
    scanned = _FD_DUP_PATTERN.sub(" ", _without_shell_null_redirections(command))
    targets: list[str] = [match.group(2) for match in _REDIRECTION_PATTERN.finditer(scanned)]
    targets.extend(match.group(2) for match in _TEE_PATTERN.finditer(scanned))
    return [target for target in targets if target != _NULL_SINK_PATH]
```

`_NULL_SINK_PATH = "/dev/null"` is defined next to `_SHELL_NULL_REDIRECT_RE` so the two notions of
"null sink" sit together.

## Tests

All in `tests/test_tools/test_shell_approval_policy.py`, beside the existing `_shell_write_targets`
coverage. 18 new cases, offline and deterministic:

- `test_shell_write_targets_ignores_the_null_sink` (8 params) — the benign matrix you specified:
  `> /dev/null`, `2>/dev/null`, `&>/dev/null`, `> /dev/null 2>&1`, `>/dev/null 2>&1`,
  `| tee /dev/null`, `| tee -a /dev/null`, plus two null redirections in one `;`-joined command.
- `test_shell_write_targets_keeps_real_targets_beside_a_null_sink` (4 params) — the anti-over-strip
  direction: `cmd > out.txt 2>/dev/null` → `['out.txt']`, `cmd 2>/dev/null > /etc/passwd` →
  `['/etc/passwd']`, `cmd 2>/dev/null | tee /etc/passwd` → `['/etc/passwd']`,
  `cmd >/dev/null | tee -a out.log` → `['out.log']`.
- `test_workspace_lockdown_allows_null_sink_redirections` (5 params) — the same benign forms driven
  end-to-end through `_check_exec_approval` under `workspace_lockdown`, asserting no
  `workspace_lockdown` block. This is the user-visible half of the bug.
- `test_workspace_lockdown_still_blocks_a_real_target_beside_a_null_sink` — `echo ok > <outside>
  2>/dev/null` is still blocked, and `result["target"]` is the real outside path, so dropping the sink
  cannot smuggle a genuine out-of-workspace write past the lockdown.

Without the fix, 17 of the 18 fail. The 18th (`..._still_blocks_a_real_target_beside_a_null_sink`)
passes either way by design — it is the guard proving this PR does not over-strip.

## Verification

Self-test (upstream `shell.py` swapped back in, tests unchanged):

```
$ uv run pytest -q tests/test_tools/test_shell_approval_policy.py
17 failed, 70 passed in 2.18s
```

With the fix:

```
$ uv run pytest -q tests/test_tools/test_shell_approval_policy.py
87 passed in 2.07s

$ uv run pytest -q
6 failed, 10261 passed, 34 skipped, 4 warnings, 3 errors in 248.44s
```

The 6 failures / 3 errors are pre-existing on `upstream/main` and unrelated to this change (pilot
router ONNX encoder assets, a machine-timezone hygiene check, and wheelhouse packaging tests needing
built ML assets absent from this environment) — same set, same count, before and after this diff.

```
$ uv run ruff check .
All checks passed!

$ uv run mypy --show-error-codes src
Success: no issues found in 625 source files
```

## One adjacent case, deliberately left alone

Windows' null sink (`NUL`) gets no equivalent treatment here. `_SHELL_NULL_REDIRECT_RE` does not know
about it either, so handling it would be a new behaviour rather than a consistency fix, and it wants
its own issue — happy to follow up if you want it covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tbgoh4XkHPqGdEVwfjsuhx
