### PR TITLE
fix(gateway): drain every runtime task on reset, not just up to the first timeout

### DIFF
--- a/src/agentos/gateway/rpc_sessions.py
+++ b/src/agentos/gateway/rpc_sessions.py
@@ -259,14 +259,27 @@ async def _drain_task_runtime_for_session(
 
     try:
         rows = await task_runtime.list(session_key=session_key)
+        # One slow task must not strand the others: the timeout is per task,
+        # matching the settle loop above. A shared outer ``except`` aborted the
+        # whole loop on the first timeout, so reset/delete went on to touch
+        # session storage while later tasks were still running against it.
+        undrained = 0
         for row in rows:
-            if _task_status_value(getattr(row, "status", None)) in _ACTIVE_TASK_STATUSES:
+            if _task_status_value(getattr(row, "status", None)) not in _ACTIVE_TASK_STATUSES:
+                continue
+            try:
                 await asyncio.wait_for(
                     task_runtime.wait(row.task_id),
                     timeout=_RESET_RUNTIME_CANCEL_DRAIN_SECONDS,
                 )
-    except TimeoutError:
-        log.warning(f"sessions.{op}.task_runtime_drain_timeout", session_key=session_key)
+            except TimeoutError:
+                undrained += 1
+        if undrained:
+            log.warning(
+                f"sessions.{op}.task_runtime_drain_timeout",
+                session_key=session_key,
+                undrained_tasks=undrained,
+            )
     except Exception:
         log.warning(f"sessions.{op}.task_runtime_drain_failed", session_key=session_key)
 

--- a/tests/test_gateway/test_reset_drain_per_task_timeout.py
+++ b/tests/test_gateway/test_reset_drain_per_task_timeout.py
@@ -1,0 +1,120 @@
+"""Draining runtime tasks on session reset/delete.
+
+Regression coverage for #1538: the final drain loop wrapped the whole ``for`` in
+one ``try/except TimeoutError``, so the first task that exceeded the drain
+timeout aborted the loop and every remaining active task was never waited on --
+reset/delete then went on to touch session storage while those tasks were still
+running against it, and the single warning gave no hint of how many were skipped.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from agentos.gateway import rpc_sessions
+
+_SESSION_KEY = "agent:main:drain"
+
+
+class _FakeTaskRuntime:
+    """Runtime whose ``wait`` never returns for the task ids in *hanging*."""
+
+    def __init__(self, task_ids: list[str], hanging: set[str]) -> None:
+        self._task_ids = task_ids
+        self._hanging = hanging
+        self.waited: list[str] = []
+        self.cancelled = 0
+
+    async def list(self, session_key: str) -> list[Any]:
+        return [SimpleNamespace(task_id=tid, status="running") for tid in self._task_ids]
+
+    async def wait(self, task_id: str) -> None:
+        self.waited.append(task_id)
+        if task_id in self._hanging:
+            await asyncio.Event().wait()
+
+    async def cancel(self, session_key: str) -> int:
+        self.cancelled += 1
+        return len(self._task_ids)
+
+
+@pytest.fixture(autouse=True)
+def _fast_timeouts(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(rpc_sessions, "_RESET_RUNTIME_SETTLE_SECONDS", 0.01)
+    monkeypatch.setattr(rpc_sessions, "_RESET_RUNTIME_CANCEL_DRAIN_SECONDS", 0.02)
+
+
+@pytest.fixture
+def warnings(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, dict[str, Any]]]:
+    recorded: list[tuple[str, dict[str, Any]]] = []
+
+    def record(event: str, **kwargs: Any) -> None:
+        recorded.append((event, kwargs))
+
+    monkeypatch.setattr(rpc_sessions.log, "warning", record)
+    return recorded
+
+
+async def _drain(runtime: _FakeTaskRuntime) -> None:
+    await rpc_sessions._drain_task_runtime_for_session(
+        runtime,
+        _SESSION_KEY,
+        source="sessions_reset",
+        reason="session_reset",
+        op="reset",
+    )
+
+
+@pytest.mark.asyncio
+async def test_drain_waits_for_every_active_task_even_when_an_earlier_one_times_out(
+    warnings: list[tuple[str, dict[str, Any]]],
+) -> None:
+    runtime = _FakeTaskRuntime(["t1", "t2", "t3"], hanging={"t1"})
+
+    await _drain(runtime)
+
+    # The drain loop runs after the settle loop, so each task id is visited
+    # twice; what matters is that t2 and t3 were still waited on after t1
+    # timed out rather than being stranded.
+    assert runtime.waited.count("t2") == 2
+    assert runtime.waited.count("t3") == 2
+
+
+@pytest.mark.asyncio
+async def test_drain_timeout_warning_reports_how_many_tasks_did_not_drain(
+    warnings: list[tuple[str, dict[str, Any]]],
+) -> None:
+    runtime = _FakeTaskRuntime(["t1", "t2", "t3"], hanging={"t1", "t3"})
+
+    await _drain(runtime)
+
+    timeouts = [kw for event, kw in warnings if event.endswith("task_runtime_drain_timeout")]
+    assert len(timeouts) == 1
+    assert timeouts[0]["undrained_tasks"] == 2
+    assert timeouts[0]["session_key"] == _SESSION_KEY
+
+
+@pytest.mark.asyncio
+async def test_drain_logs_no_timeout_warning_when_every_task_drains(
+    warnings: list[tuple[str, dict[str, Any]]],
+) -> None:
+    runtime = _FakeTaskRuntime(["t1", "t2"], hanging=set())
+
+    await _drain(runtime)
+
+    assert [event for event, _ in warnings if event.endswith("task_runtime_drain_timeout")] == []
+
+
+@pytest.mark.asyncio
+async def test_drain_still_cancels_before_waiting(
+    warnings: list[tuple[str, dict[str, Any]]],
+) -> None:
+    runtime = _FakeTaskRuntime(["t1"], hanging=set())
+
+    await _drain(runtime)
+
+    assert runtime.cancelled == 1


### PR DESCRIPTION
Fixes #1538

## The bug

`_drain_task_runtime_for_session`'s final drain loop wraps the whole `for` in one
`try/except TimeoutError` (`rpc_sessions.py:259-271`):

```python
try:
    rows = await task_runtime.list(session_key=session_key)
    for row in rows:
        if _task_status_value(getattr(row, "status", None)) in _ACTIVE_TASK_STATUSES:
            await asyncio.wait_for(
                task_runtime.wait(row.task_id),
                timeout=_RESET_RUNTIME_CANCEL_DRAIN_SECONDS,
            )
except TimeoutError:
    log.warning(f"sessions.{op}.task_runtime_drain_timeout", session_key=session_key)
```

The first task that exceeds the drain timeout unwinds out of the loop, so every remaining active task
is never waited on. The settle loop 20 lines above already does the right thing — its
`try/except TimeoutError` sits *inside* the `for` (`rpc_sessions.py:236-246`).

Two consequences, and the second is the one that hides the first: reset/delete proceeds to touch
session storage while other tasks may still be running against it, and the single
`task_runtime_drain_timeout` warning says nothing about how many tasks were skipped.

## The fix

Both halves of your review note.

```python
# One slow task must not strand the others: the timeout is per task,
# matching the settle loop above. A shared outer ``except`` aborted the
# whole loop on the first timeout, so reset/delete went on to touch
# session storage while later tasks were still running against it.
undrained = 0
for row in rows:
    if _task_status_value(getattr(row, "status", None)) not in _ACTIVE_TASK_STATUSES:
        continue
    try:
        await asyncio.wait_for(
            task_runtime.wait(row.task_id),
            timeout=_RESET_RUNTIME_CANCEL_DRAIN_SECONDS,
        )
    except TimeoutError:
        undrained += 1
if undrained:
    log.warning(
        f"sessions.{op}.task_runtime_drain_timeout",
        session_key=session_key,
        undrained_tasks=undrained,
    )
```

The `continue`-style status guard matches the settle loop's shape. `task_runtime_drain_failed` is
untouched.

Two details worth naming rather than leaving for review to find:

- **Worst-case drain time is now bounded by active-task count** (`n × _RESET_RUNTIME_CANCEL_DRAIN_SECONDS`)
  instead of one shared window. That is the same trade the settle loop already makes, and it is the
  point of the change — the old shape was fast precisely because it gave up.
- **A `TimeoutError` raised by `task_runtime.list()` itself** now falls to `except Exception` and logs
  `task_runtime_drain_failed` rather than `task_runtime_drain_timeout`. The drain-timeout event now
  means only "a task did not drain", which is what its `undrained_tasks` count describes.

## Tests

`tests/test_gateway/test_reset_drain_per_task_timeout.py` — 4 cases driving
`_drain_task_runtime_for_session` against a fake runtime whose `wait` never returns for chosen task
ids (offline, deterministic; the two module timeouts are monkeypatched down to 10/20 ms):

- `test_drain_waits_for_every_active_task_even_when_an_earlier_one_times_out` — with `t1` hanging,
  `t2` and `t3` are still waited on. This is the stranding bug.
- `test_drain_timeout_warning_reports_how_many_tasks_did_not_drain` — with `t1` and `t3` hanging,
  exactly one warning is emitted carrying `undrained_tasks == 2`.
- `test_drain_logs_no_timeout_warning_when_every_task_drains` — no drain-timeout warning when nothing
  times out, so the count cannot be logged as zero.
- `test_drain_still_cancels_before_waiting` — cancellation still runs ahead of the drain.

Without the fix the first two fail (the second with `KeyError: 'undrained_tasks'`); the last two pass
either way by design, guarding behaviour this change must not alter.

## Verification

Self-test (upstream `rpc_sessions.py` swapped back in, tests unchanged):

```
$ uv run pytest -q tests/test_gateway/test_reset_drain_per_task_timeout.py
2 failed, 2 passed in 1.28s
FAILED ...::test_drain_waits_for_every_active_task_even_when_an_earlier_one_times_out
FAILED ...::test_drain_timeout_warning_reports_how_many_tasks_did_not_drain
```

With the fix:

```
$ uv run pytest -q tests/test_gateway/test_reset_drain_per_task_timeout.py
4 passed in 1.29s

$ uv run pytest -q
6 failed, 10247 passed, 34 skipped, 4 warnings, 3 errors in 247.24s
```

The 6 failures / 3 errors are pre-existing on `upstream/main` and unrelated to this change (pilot
router ONNX encoder assets, a machine-timezone hygiene check, and wheelhouse packaging tests needing
built ML assets absent from this environment) — same set, same count, before and after this diff.

```
$ uv run ruff check .
All checks passed!

$ uv run mypy --show-error-codes src
Success: no issues found in 625 source files
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tbgoh4XkHPqGdEVwfjsuhx
