### PR TITLE
fix(scheduler): execute manual run with fresh reservation snapshot (#1555)

### DIFF
--- a/src/agentos/scheduler/engine.py
+++ b/src/agentos/scheduler/engine.py
@@ -219,6 +219,20 @@ class SchedulerEngine:
         )
         if isinstance(reservation, JobReservationRejected):
             return _manual_result_from_rejection(reservation)
+        job = reservation.job
+        handler = self._timer._handlers.get(job.handler_key)
+        if handler is None:
+            await self._store.finalize_reserved_missing_handler(
+                job.id,
+                reservation.token,
+                error=f"No handler registered for key '{job.handler_key}'",
+            )
+            return ManualRunResult(
+                status=ManualRunStatus.NO_HANDLER,
+                reason="no_handler",
+                error=f"No handler registered for key '{job.handler_key}'",
+                current_status=getattr(job.status, "value", str(job.status)),
+            )
         exe = await execute_with_timeout(job, handler)
         await self._store.save_execution(exe)
         await apply_reserved_result(job.id, reservation.token, exe, self._store)

--- a/tests/test_scheduler/test_run_job_now_fresh_reservation.py
+++ b/tests/test_scheduler/test_run_job_now_fresh_reservation.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agentos.scheduler.engine import SchedulerEngine
+from agentos.scheduler.persistence import JobStore
+from agentos.scheduler.types import (
+    CronJob,
+    JobExecution,
+    ManualRunStatus,
+    ScheduleKind,
+    SessionTarget,
+)
+
+
+@pytest.mark.asyncio
+async def test_run_job_now_executes_fresh_reserved_job_snapshot(tmp_path: Path) -> None:
+    store = JobStore(str(tmp_path / "scheduler.db"))
+    await store.open()
+    engine = SchedulerEngine(store)
+
+    executed_jobs: list[CronJob] = []
+
+    async def capture_handler(job: CronJob) -> JobExecution:
+        executed_jobs.append(job)
+        return JobExecution(
+            id="run-1",
+            job_id=job.id,
+            status="ok",
+            output="done",
+        )
+
+    engine.register_handler("test_handler", capture_handler)
+
+    try:
+        job = await engine.add_job(
+            name="fresh-snapshot-test",
+            handler_key="test_handler",
+            payload={"version": 1},
+            session_target=SessionTarget.ISOLATED,
+            schedule_kind=ScheduleKind.CRON,
+            schedule_value="*/5 * * * *",
+        )
+
+        # Hook reserve_manual_job so that between the initial get() and reservation,
+        # the job is updated in the store with new payload and timeout.
+        orig_reserve = store.reserve_manual_job
+
+        async def updated_reserve(job_id, now, source="manual", owner="scheduler-manual"):
+            j = await store.get(job_id)
+            assert j is not None
+            j.payload = {"version": 2}
+            j.timeout_seconds = 120.0
+            await store.save(j)
+            return await orig_reserve(job_id, now, source=source, owner=owner)
+
+        store.reserve_manual_job = updated_reserve  # type: ignore[method-assign]
+
+        result = await engine.run_job_now(job.id)
+
+        assert result.status == ManualRunStatus.ACCEPTED
+        assert len(executed_jobs) == 1
+        # Verify the executed job instance has the freshly reserved state
+        assert executed_jobs[0].payload == {"version": 2}
+        assert executed_jobs[0].timeout_seconds == 120.0
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_run_job_now_finalizes_when_handler_missing_on_reserved_job(tmp_path: Path) -> None:
+    store = JobStore(str(tmp_path / "scheduler.db"))
+    await store.open()
+    engine = SchedulerEngine(store)
+
+    async def dummy_handler(job: CronJob) -> JobExecution:
+        return JobExecution(id="run-1", job_id=job.id, status="ok")
+
+    engine.register_handler("valid_handler", dummy_handler)
+
+    try:
+        job = await engine.add_job(
+            name="missing-handler-test",
+            handler_key="valid_handler",
+            schedule_kind=ScheduleKind.CRON,
+            schedule_value="*/5 * * * *",
+        )
+
+        orig_reserve = store.reserve_manual_job
+
+        async def updated_reserve(job_id, now, source="manual", owner="scheduler-manual"):
+            j = await store.get(job_id)
+            assert j is not None
+            j.handler_key = "unregistered_handler"
+            await store.save(j)
+            return await orig_reserve(job_id, now, source=source, owner=owner)
+
+        store.reserve_manual_job = updated_reserve  # type: ignore[method-assign]
+
+        result = await engine.run_job_now(job.id)
+
+        assert result.status == ManualRunStatus.NO_HANDLER
+        assert result.error == "No handler registered for key 'unregistered_handler'"
+
+        # Verify the reservation was cleanly finalized and the job is not stuck in reserved status
+        persisted = await store.get(job.id)
+        assert persisted is not None
+        assert persisted.status.value != "reserved"
+    finally:
+        await store.close()


### PR DESCRIPTION
Closes #1555

## Summary
When triggering an immediate execution of a job via `SchedulerEngine.run_job_now(job_id)`, the pre-reservation `job` snapshot was passed to `execute_with_timeout` and `apply_reserved_result` rather than the freshly reserved `reservation.job`.

If a job is updated concurrently with a manual run request (or if its attributes were modified between retrieval and reservation), `run_job_now` would execute against the stale snapshot instead of the reserved instance.

This change aligns `SchedulerEngine.run_job_now` with `SchedulerTimer._run_single` by using `reservation.job`, ensuring handler lookup and execution reflect the freshly-reserved job state and finalizing cleanly if the reserved handler is missing.

## What was changed
- Updated `SchedulerEngine.run_job_now` in `src/agentos/scheduler/engine.py` to use `reservation.job` for execution and result application.
- Added check to finalize reserved missing handler via `_store.finalize_reserved_missing_handler` if the handler is no longer available on the reserved job.
- Added comprehensive unit tests in `tests/test_scheduler/test_run_job_now_fresh_reservation.py` to verify that updated job properties (e.g. payload, timeout) are captured upon manual execution and missing handlers are finalized cleanly.

## Quality Gate Verification
- `uv run ruff check src/agentos/scheduler tests/test_scheduler` (clean)
- `uv run ruff format --check src/agentos/scheduler tests/test_scheduler` (clean)
- `uv run mypy src/agentos/scheduler/engine.py --show-error-codes` (clean)
- `uv run pytest tests/test_scheduler/ -q` (503 passed)
