### PR TITLE
fix(skills): lock lockfile read-modify-write, write it atomically

### DIFF
--- a/src/agentos/skills/hub/installer.py
+++ b/src/agentos/skills/hub/installer.py
@@ -217,36 +217,37 @@ class SkillInstaller:
 
         # 5. Update lockfile
         sha = compute_sha256(install_dir)
-        lockfile = Lockfile.load(self._lockfile_path)
-        lockfile.add(
-            name,
-            LockEntry(
-                source=source_id,
-                identifier=identifier,
-                # The field has existed since the lockfile did and was never
-                # written, so every install reported an empty version — now
-                # that `acquisition.version` is on the wire, that is visible.
-                version=bundle_meta.version if bundle_meta else "",
-                installed_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-                path=str(install_dir),
-                sha256=sha,
-                license=bundle_meta.license if bundle_meta else "",
-                upstream_url=bundle_meta.homepage if bundle_meta else "",
-                publisher_id=_publisher_slug(bundle_meta, source_id),
-                # The row's author credit when it has one, else the brand it
-                # named. Both are untrusted free text and neither is resolved as
-                # identity — only ``publisher_id`` is (see
-                # ``agentos.skills.publishers``) — so recording the more
-                # specific of the two costs nothing and keeps the human who
-                # wrote a brand-distributed skill visible after install.
-                publisher_name=(bundle_meta.author or bundle_meta.provider) if bundle_meta else "",
-                source_trust=bundle_meta.trust_level if bundle_meta else "",
-                scan_verdict=scan_result.verdict,
-                scan_strategy=scan_result.strategy,
-                scan_findings=[asdict(finding) for finding in scan_result.findings],
-            ),
+        entry = LockEntry(
+            source=source_id,
+            identifier=identifier,
+            # The field has existed since the lockfile did and was never
+            # written, so every install reported an empty version — now
+            # that `acquisition.version` is on the wire, that is visible.
+            version=bundle_meta.version if bundle_meta else "",
+            installed_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            path=str(install_dir),
+            sha256=sha,
+            license=bundle_meta.license if bundle_meta else "",
+            upstream_url=bundle_meta.homepage if bundle_meta else "",
+            publisher_id=_publisher_slug(bundle_meta, source_id),
+            # The row's author credit when it has one, else the brand it
+            # named. Both are untrusted free text and neither is resolved as
+            # identity — only ``publisher_id`` is (see
+            # ``agentos.skills.publishers``) — so recording the more
+            # specific of the two costs nothing and keeps the human who
+            # wrote a brand-distributed skill visible after install.
+            publisher_name=(bundle_meta.author or bundle_meta.provider) if bundle_meta else "",
+            source_trust=bundle_meta.trust_level if bundle_meta else "",
+            scan_verdict=scan_result.verdict,
+            scan_strategy=scan_result.strategy,
+            scan_findings=[asdict(finding) for finding in scan_result.findings],
         )
-        lockfile.save(self._lockfile_path)
+
+        def _record(lf: Lockfile) -> bool:
+            lf.add(name, entry)
+            return True
+
+        await Lockfile.update(self._lockfile_path, _record)
 
         log.info("skill.installed", name=name, source=source_id, verdict=scan_result.verdict)
         return InstallResult(
@@ -263,7 +264,6 @@ class SkillInstaller:
         if not _SAFE_NAME_RE.match(name):
             return InstallResult(success=False, name=name, message=f"Invalid skill name: {name}")
 
-        lockfile = Lockfile.load(self._lockfile_path)
         # Remove from disk (only within managed dir)
         install_dir = (self._managed_dir / name).resolve()
         managed_root = self._managed_dir.resolve()
@@ -271,9 +271,7 @@ class SkillInstaller:
             shutil.rmtree(install_dir)
 
         # Remove from lockfile
-        removed = lockfile.remove(name)
-        if removed:
-            lockfile.save(self._lockfile_path)
+        removed = await Lockfile.update(self._lockfile_path, lambda lf: lf.remove(name))
 
         if not install_dir.exists() and not removed:
             return InstallResult(success=False, name=name, message=f"Skill '{name}' not found")

--- a/src/agentos/skills/hub/lockfile.py
+++ b/src/agentos/skills/hub/lockfile.py
@@ -2,12 +2,31 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
+from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
+from agentos.memory.atomic_write import atomic_write_text
 from agentos.paths import default_agentos_home
+
+#: One asyncio.Lock per resolved lockfile path, so concurrent installs that
+#: each do load -> mutate -> save race on the same in-memory lock instead of
+#: each racing the filesystem independently. Keyed by path (not a single
+#: global lock) so tests and multiple AGENTOS_HOME roots pointing at
+#: different lockfiles don't serialize against each other.
+_locks: dict[str, asyncio.Lock] = {}
+
+
+def _lock_for(path: Path) -> asyncio.Lock:
+    key = str(path.resolve())
+    lock = _locks.get(key)
+    if lock is None:
+        lock = asyncio.Lock()
+        _locks[key] = lock
+    return lock
 
 
 def default_lockfile_path() -> Path:
@@ -92,7 +111,37 @@ class Lockfile:
             "version": self.version,
             "installed": {name: asdict(entry) for name, entry in self.installed.items()},
         }
-        path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        # A plain write_text truncates before writing the new content; a crash
+        # or full disk mid-write leaves a partial file that load() then reads
+        # as JSONDecodeError and silently treats as an empty lockfile. Writing
+        # to a temp file and renaming into place means a reader only ever
+        # sees the old content or the new content, never a truncated file.
+        atomic_write_text(path, json.dumps(data, indent=2))
+
+    @staticmethod
+    async def update(path: Path, mutate: Callable[[Lockfile], bool]) -> bool:
+        """Load, apply *mutate*, and save as one critical section.
+
+        ``load() -> mutate -> save()`` done separately races: two concurrent
+        callers each load before the other's save lands, and the later save
+        overwrites the file wholesale, silently dropping the earlier caller's
+        change. Locking only around ``save()`` does not close this — the
+        ``load()`` has to be inside the same critical section, or a caller can
+        still load stale data before another caller's save takes the lock.
+
+        *mutate* returns whether it changed the lockfile; that same value is
+        returned here so a caller like ``remove()`` (which is a no-op for a
+        name that was never installed) can tell whether anything happened
+        without also having to thread a mutable result out of the callback.
+        A ``False`` return leaves the file untouched rather than rewriting it
+        with no news.
+        """
+        async with _lock_for(path):
+            lf = Lockfile.load(path)
+            changed = mutate(lf)
+            if changed:
+                lf.save(path)
+            return changed
 
     def add(self, name: str, entry: LockEntry) -> None:
         self.installed[name] = entry

--- a/tests/test_skills_hub_lockfile.py
+++ b/tests/test_skills_hub_lockfile.py
@@ -1,0 +1,134 @@
+"""Lockfile.save/load atomicity and Lockfile.update's read-modify-write lock.
+
+Issue #1557: ``Lockfile.load``/``.save`` were a whole-file JSON read and a
+whole-file ``write_text`` with no locking of any kind. ``SkillInstaller``
+called ``load() -> mutate() -> save()`` per install/uninstall; two overlapping
+calls could load before either had saved, so the later ``save()`` overwrote
+the file wholesale and silently dropped the earlier caller's entry.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from agentos.skills.hub.lockfile import LockEntry, Lockfile, _lock_for
+
+
+@pytest.mark.asyncio
+async def test_lock_for_serializes_access_to_the_same_path(tmp_path: Path) -> None:
+    """The lock keyed to one path must never let two holders' critical
+    sections overlap, regardless of scheduling order."""
+    path = tmp_path / "lock.json"
+    events: list[str] = []
+
+    async def worker(tag: str, hold: float) -> None:
+        async with _lock_for(path):
+            events.append(f"{tag}:enter")
+            await asyncio.sleep(hold)
+            events.append(f"{tag}:exit")
+
+    await asyncio.gather(worker("a", 0.02), worker("b", 0.0))
+
+    # Whichever ran first, its enter/exit pair must be contiguous — the other
+    # worker's "enter" never lands between them.
+    assert events[0].endswith("enter")
+    assert events[1].endswith("exit")
+    assert events[0].split(":")[0] == events[1].split(":")[0]
+
+
+@pytest.mark.asyncio
+async def test_lock_for_does_not_serialize_different_paths(tmp_path: Path) -> None:
+    """Two different lockfile paths (e.g. two AGENTOS_HOME roots in tests)
+    must not contend with each other's lock."""
+    path_a = tmp_path / "a.json"
+    path_b = tmp_path / "b.json"
+    order: list[str] = []
+    released_a = asyncio.Event()
+
+    async def hold_a() -> None:
+        async with _lock_for(path_a):
+            order.append("a:enter")
+            await released_a.wait()
+            order.append("a:exit")
+
+    async def touch_b() -> None:
+        async with _lock_for(path_b):
+            order.append("b:enter")
+            order.append("b:exit")
+        released_a.set()
+
+    await asyncio.gather(hold_a(), touch_b())
+
+    # b completed fully while a was still holding its own lock.
+    assert order.index("b:enter") < order.index("a:exit")
+
+
+@pytest.mark.asyncio
+async def test_update_persists_the_mutation(tmp_path: Path) -> None:
+    path = tmp_path / "lock.json"
+
+    def _mutate(lf: Lockfile) -> bool:
+        lf.add("demo", LockEntry(source="s", identifier="demo"))
+        return True
+
+    changed = await Lockfile.update(path, _mutate)
+
+    assert changed is True
+    assert Lockfile.load(path).get("demo") is not None
+
+
+@pytest.mark.asyncio
+async def test_update_skips_the_write_when_mutate_reports_no_change(tmp_path: Path) -> None:
+    """remove() of a name that was never installed must not rewrite the file
+    with "no news" — it returns False and update() leaves the file alone."""
+    path = tmp_path / "lock.json"
+
+    changed = await Lockfile.update(path, lambda lf: lf.remove("never-installed"))
+
+    assert changed is False
+    assert not path.exists()
+
+
+@pytest.mark.asyncio
+async def test_two_concurrent_updates_to_different_skills_both_survive(
+    tmp_path: Path,
+) -> None:
+    """Issue #1557's exact reproduction: two concurrent installs of different
+    skills, each doing load -> mutate -> save, must not clobber each other."""
+    path = tmp_path / "lock.json"
+
+    async def install(name: str) -> None:
+        def _mutate(lf: Lockfile) -> bool:
+            lf.add(name, LockEntry(source="s", identifier=name))
+            return True
+
+        await Lockfile.update(path, _mutate)
+
+    await asyncio.gather(*(install(f"skill-{i}") for i in range(10)))
+
+    installed = Lockfile.load(path).installed
+    assert set(installed.keys()) == {f"skill-{i}" for i in range(10)}
+
+
+def test_save_writes_valid_json_round_trip(tmp_path: Path) -> None:
+    path = tmp_path / "lock.json"
+    lf = Lockfile()
+    lf.add("demo", LockEntry(source="s", identifier="demo"))
+
+    lf.save(path)
+
+    assert lf.get("demo") is not None
+    on_disk = json.loads(path.read_text(encoding="utf-8"))
+    assert on_disk["installed"]["demo"]["identifier"] == "demo"
+
+
+def test_save_leaves_no_leftover_temp_file(tmp_path: Path) -> None:
+    path = tmp_path / "lock.json"
+    Lockfile().save(path)
+
+    leftovers = list(path.parent.glob(f".{path.name}.*.tmp"))
+    assert leftovers == []


### PR DESCRIPTION
Summary
Lockfile.load/.save were a whole-file JSON read and a whole-file write_text, with no locking of any kind
SkillInstaller.install/.uninstall each did load() → mutate() → save() independently; two overlapping calls both loaded before either saved, so the later save() overwrote the file wholesale and silently dropped the earlier caller's lockfile entry
The skill stayed installed on disk while disappearing from skills-lock.json, breaking update/uninstall bookkeeping for it, with nothing surfacing an error at the time
Added Lockfile.update(path, mutate): loads, applies mutate, and saves under a path-keyed asyncio.Lock, all as one critical section — a lock around save() alone would still let a caller load stale data before another caller's save takes the lock
mutate returns whether it changed the lockfile, so a no-op remove() (name never installed) leaves the file untouched rather than rewriting it with no news
install() and uninstall() now go through this instead of separate load/mutate/save calls
save() also switched from a plain write_text to the existing atomic_write_text helper (temp file + os.replace, already used for memory state): a crash or full disk mid-write used to leave a truncated file that load() then silently read as an empty lockfile via its except (JSONDecodeError, TypeError, OSError) fallback — a reader now only ever sees the old content or the new content, never a partial one
Fixes #1557 

Test plan
 Added tests/test_skills_hub_lockfile.py: the lock serializes access to the same path without ever interleaving enter/exit, and does not serialize different paths against each other
 Lockfile.update() persists on change and skips the write when mutate reports no change
 The issue's exact reproduction — 10 concurrent installs of different skills — all survive and appear in the lockfile
 Atomic-write round-trip and no-leftover-temp-file checks
 uv run pytest tests/test_skills_hub_lockfile.py tests/test_skills_hub_installer_update.py tests/test_skills_hub_installer_security.py tests/test_skills_inventory.py tests/test_skills_shadow_guard.py tests/test_gateway/test_rpc_skills_uninstall_key.py tests/test_gateway/test_rpc_skills_search_payload.py -q — 77 passed
 uv run pytest tests -k "skill or Skill" -q — 780 passed, 4 skipped (one unrelated pre-existing failure: a Windows symlink-permission environment limitation, not touched by this change)
 uv run ruff check / uv run mypy clean on changed files