### PR TITLE
fix(scheduler): run the reserved job row on manual run, not the pre-reservation snapshot

### DIFF
--- a/src/agentos/scheduler/engine.py
+++ b/src/agentos/scheduler/engine.py
@@ -203,8 +203,7 @@ class SchedulerEngine:
                 reason=ReservationRejectionReason.NOT_FOUND.value,
                 error="Cron job not found",
             )
-        handler = self._timer._handlers.get(job.handler_key)
-        if handler is None:
+        if self._timer._handlers.get(job.handler_key) is None:
             return ManualRunResult(
                 status=ManualRunStatus.NO_HANDLER,
                 reason="no_handler",
@@ -219,6 +218,28 @@ class SchedulerEngine:
         )
         if isinstance(reservation, JobReservationRejected):
             return _manual_result_from_rejection(reservation)
+        # Run the row the reservation itself read, not the snapshot taken
+        # before it: an update landing between the two reads otherwise
+        # executes the payload, prompt or timeout the operator just replaced.
+        # ``timer._run_single`` already opens with ``reservation.job``.
+        job = reservation.job
+        handler = self._timer._handlers.get(job.handler_key)
+        if handler is None:
+            # The update could also have changed handler_key, so the handler
+            # has to be resolved again from the reserved row -- and the
+            # reservation released the way the timer path does.
+            error = f"No handler registered for key '{job.handler_key}'"
+            await self._store.finalize_reserved_missing_handler(
+                job.id,
+                reservation.token,
+                error=error,
+            )
+            return ManualRunResult(
+                status=ManualRunStatus.NO_HANDLER,
+                reason="no_handler",
+                error=error,
+                current_status=getattr(job.status, "value", str(job.status)),
+            )
         exe = await execute_with_timeout(job, handler)
         await self._store.save_execution(exe)
         await apply_reserved_result(job.id, reservation.token, exe, self._store)

--- a/tests/test_scheduler/test_run_now_uses_reserved_job.py
+++ b/tests/test_scheduler/test_run_now_uses_reserved_job.py
@@ -1,0 +1,180 @@
+"""Manual "run now" must execute the reserved row, not a pre-reservation snapshot.
+
+Regression coverage for #1555: ``run_job_now`` read the job, reserved it, then
+ran ``execute_with_timeout(job, handler)`` against the row it read *before* the
+reservation. ``reservation.job`` -- the freshly-read row the reservation itself
+returned, and what ``timer._run_single`` already uses -- was ignored, so an
+``update()`` landing between the two reads ran the payload, prompt, timeout or
+handler the operator had just replaced.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from agentos.scheduler.engine import SchedulerEngine
+from agentos.scheduler.persistence import JobStore
+from agentos.scheduler.types import (
+    CronJob,
+    JobStatus,
+    ManualRunStatus,
+    ScheduleKind,
+    SessionTarget,
+)
+
+_JOB_ID = "job-run-now"
+
+
+def _cron_job(handler_key: str = "agent_run", payload: dict | None = None) -> CronJob:
+    return CronJob(
+        id=_JOB_ID,
+        name=_JOB_ID,
+        cron_expr="* * * * *",
+        handler_key=handler_key,
+        payload=payload or {"kind": "agent_turn", "task": "original", "agent_id": "main"},
+        session_target=SessionTarget.ISOLATED,
+        schedule_kind=ScheduleKind.CRON,
+        next_run_at=datetime.now(UTC) + timedelta(minutes=5),
+        status=JobStatus.PENDING,
+    )
+
+
+def _update_during_reservation(store: JobStore, **changes: Any) -> None:
+    """Land an ``update()`` in the window run_job_now leaves open.
+
+    ``run_job_now`` reads the job, then reserves it. Mutating inside the
+    reservation call reproduces exactly that window: the outer snapshot is
+    stale, while ``reservation.job`` carries the new row.
+    """
+    original = store.reserve_manual_job
+
+    async def reserve_after_update(job_id: str, *args: Any, **kwargs: Any):
+        current = await store.get(job_id)
+        assert current is not None
+        for field, value in changes.items():
+            setattr(current, field, value)
+        await store.save(current)
+        return await original(job_id, *args, **kwargs)
+
+    store.reserve_manual_job = reserve_after_update  # type: ignore[method-assign]
+
+
+@pytest.mark.asyncio
+async def test_run_now_executes_the_payload_from_the_reserved_row() -> None:
+    async with JobStore(":memory:") as store:
+        await store.save(_cron_job())
+        engine = SchedulerEngine(store)
+        seen: list[dict] = []
+
+        async def handler(job: CronJob) -> str:
+            seen.append(dict(job.payload))
+            return "ok"
+
+        engine._timer._handlers["agent_run"] = handler
+        _update_during_reservation(
+            store,
+            payload={"kind": "agent_turn", "task": "updated", "agent_id": "main"},
+        )
+
+        result = await engine.run_job_now(_JOB_ID)
+
+        assert result.status is ManualRunStatus.ACCEPTED
+        assert seen == [{"kind": "agent_turn", "task": "updated", "agent_id": "main"}]
+
+
+@pytest.mark.asyncio
+async def test_run_now_dispatches_to_the_handler_key_from_the_reserved_row() -> None:
+    # ``handler_key`` is derived from the payload kind, so switching a job from
+    # an agent turn to a reminder moves it from ``agent_run`` to
+    # ``static_message`` -- an ordinary edit that repoints the handler.
+    async with JobStore(":memory:") as store:
+        await store.save(_cron_job())
+        engine = SchedulerEngine(store)
+        called: list[str] = []
+
+        async def agent_handler(job: CronJob) -> str:
+            called.append("agent_run")
+            return "ok"
+
+        async def reminder_handler(job: CronJob) -> str:
+            called.append("static_message")
+            return "ok"
+
+        engine._timer._handlers["agent_run"] = agent_handler
+        engine._timer._handlers["static_message"] = reminder_handler
+        _update_during_reservation(
+            store,
+            handler_key="static_message",
+            payload={"kind": "reminder", "text": "updated reminder", "agent_id": "main"},
+        )
+
+        result = await engine.run_job_now(_JOB_ID)
+
+        assert result.status is ManualRunStatus.ACCEPTED
+        assert called == ["static_message"]
+
+
+@pytest.mark.asyncio
+async def test_run_now_releases_the_reservation_when_the_updated_handler_is_missing() -> None:
+    async with JobStore(":memory:") as store:
+        await store.save(_cron_job())
+        engine = SchedulerEngine(store)
+
+        async def handler(job: CronJob) -> str:
+            return "ok"
+
+        # Only the agent-turn handler is registered, so an edit to a reminder
+        # leaves the reserved row pointing at a handler that does not exist.
+        engine._timer._handlers["agent_run"] = handler
+        _update_during_reservation(
+            store,
+            handler_key="static_message",
+            payload={"kind": "reminder", "text": "updated reminder", "agent_id": "main"},
+        )
+
+        result = await engine.run_job_now(_JOB_ID)
+
+        assert result.status is ManualRunStatus.NO_HANDLER
+        assert result.error is not None
+        assert "static_message" in result.error
+        # The reservation must not be left held on a job that will never run.
+        stored = await store.get(_JOB_ID)
+        assert stored is not None
+        assert not stored.reservation_token
+
+
+@pytest.mark.asyncio
+async def test_run_now_still_runs_normally_without_a_concurrent_update() -> None:
+    async with JobStore(":memory:") as store:
+        await store.save(_cron_job())
+        engine = SchedulerEngine(store)
+        seen: list[dict] = []
+
+        async def handler(job: CronJob) -> str:
+            seen.append(dict(job.payload))
+            return "ok"
+
+        engine._timer._handlers["agent_run"] = handler
+
+        result = await engine.run_job_now(_JOB_ID)
+
+        assert result.status is ManualRunStatus.ACCEPTED
+        assert seen == [{"kind": "agent_turn", "task": "original", "agent_id": "main"}]
+
+
+@pytest.mark.asyncio
+async def test_run_now_reports_no_handler_without_reserving_when_none_is_registered() -> None:
+    async with JobStore(":memory:") as store:
+        await store.save(_cron_job())
+        engine = SchedulerEngine(store)
+
+        result = await engine.run_job_now(_JOB_ID)
+
+        assert result.status is ManualRunStatus.NO_HANDLER
+        stored = await store.get(_JOB_ID)
+        assert stored is not None
+        assert not stored.reservation_token
+        assert stored.status is JobStatus.PENDING


### PR DESCRIPTION
Fixes #1555

## The bug

`run_job_now` (`scheduler/engine.py:197-225`) reads the job, reserves it, then executes the row it read
**before** the reservation:

```python
job = await self._ops.get(job_id)          # snapshot
handler = self._timer._handlers.get(job.handler_key)
...
reservation = await self._store.reserve_manual_job(...)   # reads the row again
...
exe = await execute_with_timeout(job, handler)            # runs the snapshot
```

`reservation.job` — the freshly-read row the reservation itself returned — is never used, so an
`update()` landing between the two reads means the operator who just saved a change and clicked "run
now" gets the *old* payload, prompt or timeout executed. `timer._run_single` one file over already
opens with `job = reservation.job` (`scheduler/timer.py:223`); the manual path is the odd one out.

## The fix

```python
reservation = await self._store.reserve_manual_job(...)
if isinstance(reservation, JobReservationRejected):
    return _manual_result_from_rejection(reservation)
# Run the row the reservation itself read, not the snapshot taken
# before it: an update landing between the two reads otherwise
# executes the payload, prompt or timeout the operator just replaced.
# ``timer._run_single`` already opens with ``reservation.job``.
job = reservation.job
handler = self._timer._handlers.get(job.handler_key)
```

**And the handler lookup you flagged.** `handler_key` is derived from the payload kind
(`payloads.normalize_contract`), so an edit from an agent turn to a reminder moves the job from
`agent_run` to `static_message` — the stale snapshot would dispatch to the old handler. The handler is
now resolved from the reserved row too, and when the new key has no registered handler the reservation
is finalized the same way `timer._run_single` does it, via
`finalize_reserved_missing_handler` — otherwise the job would be left holding a reservation it can
never use:

```python
if handler is None:
    error = f"No handler registered for key '{job.handler_key}'"
    await self._store.finalize_reserved_missing_handler(job.id, reservation.token, error=error)
    return ManualRunResult(status=ManualRunStatus.NO_HANDLER, reason="no_handler", error=error, ...)
```

The pre-reservation `NO_HANDLER` fast-fail is kept, so a job whose handler was never registered still
returns without taking a reservation at all — unchanged behaviour for that case.

## Tests

`tests/test_scheduler/test_run_now_uses_reserved_job.py` — 5 cases against a real
`JobStore(":memory:")` and a real `SchedulerEngine` (offline, deterministic). The concurrent update is
landed inside `reserve_manual_job`, which is exactly the window the bug leaves open: the outer snapshot
is stale while `reservation.job` carries the new row.

- `test_run_now_executes_the_payload_from_the_reserved_row` — the payload edited mid-window is the one
  the handler receives.
- `test_run_now_dispatches_to_the_handler_key_from_the_reserved_row` — an agent-turn job edited to a
  reminder runs `static_message`, not `agent_run`. This is the second half of your review note.
- `test_run_now_releases_the_reservation_when_the_updated_handler_is_missing` — the edit repoints the
  job at an unregistered handler: result is `NO_HANDLER` **and** the stored row no longer holds a
  reservation token.
- `test_run_now_still_runs_normally_without_a_concurrent_update` and
  `test_run_now_reports_no_handler_without_reserving_when_none_is_registered` — guards for the
  ordinary paths, including that the fast-fail still avoids reserving.

Without the fix the first three fail; the last two pass either way by design.

## Verification

Self-test (upstream `engine.py` swapped back in, tests unchanged):

```
$ uv run pytest -q tests/test_scheduler/test_run_now_uses_reserved_job.py
3 failed, 2 passed in 1.30s
FAILED ...::test_run_now_executes_the_payload_from_the_reserved_row
FAILED ...::test_run_now_dispatches_to_the_handler_key_from_the_reserved_row
FAILED ...::test_run_now_releases_the_reservation_when_the_updated_handler_is_missing
```

With the fix:

```
$ uv run pytest -q tests/test_scheduler/test_run_now_uses_reserved_job.py
5 passed in 1.26s

$ uv run pytest -q
6 failed, 10248 passed, 34 skipped, 4 warnings, 3 errors in 249.95s
```

The 6 failures / 3 errors are pre-existing on `upstream/main` and unrelated to this change (pilot
router ONNX encoder assets, a machine-timezone hygiene check, and wheelhouse packaging tests needing
built ML assets absent from this environment) — same set, same count, before and after this diff.

```
$ uv run ruff check .
All checks passed!

$ uv run mypy --show-error-codes src
Success: no issues found in 625 source files
```

## One adjacent case, deliberately left alone

The reservation write itself is still a read-modify-write against the same row (#1537), so this PR
narrows the manual-run window but does not close the separate reservation-clobber race that issue
describes. Kept out of scope deliberately — it wants the field-scoped-save change you outlined there,
not a second patch in this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tbgoh4XkHPqGdEVwfjsuhx
