### PR TITLE
feat(web-ui): report the image tiers in the composer route picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- The chat composer's route picker now shows the tiers an image turn is routed
+  to. They sit below the pinnable list as plain text, not as options: the router
+  picks the vision route before holds are consulted, so pinning one would
+  install a hold that never takes effect. Until now they were filtered out
+  everywhere — `router.hold.get` reports pinnable text tiers only — so the only
+  way to learn which model an image would be handed to was to send one and read
+  the route label afterwards. `router.hold.get` gained a separate `imageTiers`
+  list for this, built by the new `build_router_image_routes()`; it reports
+  every `supports_image` tier rather than only the `image_only` one, because the
+  router's image branch picks at random among all of them.
+  ([#1632](https://github.com/use-agent-os/agent-os/issues/1632))
+
 ### Fixed
 
 - The chat composer's route picker now names the model a turn actually ran on

--- a/frontend/src/i18n/en/chat.ts
+++ b/frontend/src/i18n/en/chat.ts
@@ -183,6 +183,9 @@ export const chat = defineNamespace('chat', {
   routeSearchPlaceholder: 'Search tiers and models',
   routeNoMatch: 'No route matches',
   routeDisabledTitle: 'Turn on the Pilot Router to pick a tier',
+  routeImageHint: 'Images route here automatically',
+  routeImageHintTitle:
+    'Image turns are routed to a vision tier before any pin is applied, so these cannot be pinned',
   routeImageOverride: 'image route',
   routeImageOverrideTitle:
     'This turn used the image tier: image turns are routed before the pin is applied',

--- a/frontend/src/views/chat/RoutePicker.test.tsx
+++ b/frontend/src/views/chat/RoutePicker.test.tsx
@@ -12,6 +12,7 @@ function route(overrides: Partial<RoutePinApi> = {}): RoutePinApi {
       { tier: 'c2', model: 'glm-5.2' },
       { tier: 'c3', model: 'claude-opus-5' },
     ],
+    imageTiers: [{ tier: 'image_model', model: 'gpt-4o' }],
     models: [
       // gpt-5.6-luna is also tier c1's model — the overlap the dedup handles.
       { id: 'gpt-5.6-luna', name: 'gpt-5.6-luna' },
@@ -197,6 +198,72 @@ describe('RoutePicker', () => {
     fireEvent.click(screen.getAllByRole('option')[0]!)
     expect(clear).toHaveBeenCalledTimes(1)
     expect(pin).not.toHaveBeenCalled()
+  })
+
+  it('reports the image tier so the vision model is knowable before sending one', () => {
+    render(<RoutePicker route={route()} />)
+    fireEvent.click(trigger())
+    expect(screen.getByText('Images route here automatically')).toBeInTheDocument()
+    expect(screen.getByText('image_model')).toBeInTheDocument()
+    expect(screen.getByText('gpt-4o')).toBeInTheDocument()
+  })
+
+  it('keeps the image tier out of the options, since a pin on it never applies', () => {
+    render(<RoutePicker route={route()} />)
+    fireEvent.click(trigger())
+    // Auto + 4 tiers + terra + grok, exactly as before: the image row is not
+    // one of them.
+    expect(screen.getAllByRole('option')).toHaveLength(7)
+    expect(screen.queryByRole('option', { name: /image_model/ })).not.toBeInTheDocument()
+  })
+
+  it('does not repeat a vision tier that is already pinnable in the list', () => {
+    // c3 takes images AND text, so it is a real, pinnable option; listing it
+    // again below would read as a second, different route.
+    render(
+      <RoutePicker
+        route={route({
+          imageTiers: [
+            { tier: 'c3', model: 'claude-opus-5' },
+            { tier: 'image_model', model: 'gpt-4o' },
+          ],
+        })}
+      />,
+    )
+    fireEvent.click(trigger())
+    expect(screen.getAllByText('c3')).toHaveLength(1)
+    expect(screen.getByText('image_model')).toBeInTheDocument()
+  })
+
+  it('filters the image rows with the same search as the options', () => {
+    render(<RoutePicker route={route()} />)
+    fireEvent.click(trigger())
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'grok' } })
+    expect(screen.queryByText('image_model')).not.toBeInTheDocument()
+    expect(screen.queryByText('Images route here automatically')).not.toBeInTheDocument()
+  })
+
+  it('finds the image tier by its model id, which no option row carries', () => {
+    render(<RoutePicker route={route()} />)
+    fireEvent.click(trigger())
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'gpt-4o' } })
+    expect(screen.queryByRole('option')).not.toBeInTheDocument()
+    expect(screen.getByText('image_model')).toBeInTheDocument()
+    // The image row IS the match, so the empty-list note would contradict it.
+    expect(screen.queryByText('No route matches')).not.toBeInTheDocument()
+  })
+
+  it('still reports no match when neither an option nor an image row survives', () => {
+    render(<RoutePicker route={route()} />)
+    fireEvent.click(trigger())
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'nothing-here' } })
+    expect(screen.getByText('No route matches')).toBeInTheDocument()
+  })
+
+  it('omits the section entirely when no tier takes images', () => {
+    render(<RoutePicker route={route({ imageTiers: [] })} />)
+    fireEvent.click(trigger())
+    expect(screen.queryByText('Images route here automatically')).not.toBeInTheDocument()
   })
 
   it('flags the turns an image route took instead of the pin', () => {

--- a/frontend/src/views/chat/RoutePicker.tsx
+++ b/frontend/src/views/chat/RoutePicker.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { CheckIcon, RouteIcon } from 'lucide-react'
-import type { RoutePinApi } from './useRoutePin'
+import type { RoutePinApi, RoutePinTier } from './useRoutePin'
 import { t } from '@/i18n'
 import '@/i18n/en/chat'
 
@@ -14,6 +14,12 @@ import '@/i18n/en/chat'
  * bare model id does not; a directly-named model borrows them from the default
  * tier. That distinction matters to the router, not to the person choosing, so
  * it stays out of the list and lives in the tier rows' own labels.
+ *
+ * The vision tiers sit BELOW that list, outside the listbox, as plain text. An
+ * image turn is routed before holds are consulted, so those tiers are not
+ * choices — offering them as options would promise a pin that the router
+ * ignores. They are shown at all because otherwise the only way to learn what
+ * an image is handed to is to send one and read the label afterwards.
  *
  * The button reports what is actually in force:
  *
@@ -148,6 +154,20 @@ export function RoutePicker({ route }: RoutePickerProps) {
     )
   }, [route.tiers, route.models, query])
 
+  // Vision tiers already offered above are dropped: a text tier that also takes
+  // images is pinnable and has a real row, so repeating it here would read as a
+  // second, different route. Filtered by the same needle as the options, so a
+  // search does not leave a stale row stranded under an empty list.
+  const imageRows = useMemo<RoutePinTier[]>(() => {
+    const pinnable = new Set(route.tiers.map((row) => row.tier))
+    const shown = route.imageTiers.filter((row) => !pinnable.has(row.tier))
+    const needle = query.trim().toLowerCase()
+    if (!needle) return shown
+    return shown.filter(
+      (row) => row.tier.toLowerCase().includes(needle) || row.model.toLowerCase().includes(needle),
+    )
+  }, [route.tiers, route.imageTiers, query])
+
   const selectedKey =
     route.pinnedModel !== null
       ? `m:${route.pinnedModel}`
@@ -229,7 +249,9 @@ export function RoutePicker({ route }: RoutePickerProps) {
           />
           <ul id="chat-route-menu" className="chat-route-list" role="listbox">
             {rows.length === 0 ? (
-              <li className="chat-route-empty">{t('chat.routeNoMatch')}</li>
+              imageRows.length === 0 ? (
+                <li className="chat-route-empty">{t('chat.routeNoMatch')}</li>
+              ) : null
             ) : (
               rows.map((row) => (
                 <li role="none" key={row.key}>
@@ -250,6 +272,17 @@ export function RoutePicker({ route }: RoutePickerProps) {
               ))
             )}
           </ul>
+          {imageRows.length > 0 ? (
+            <div className="chat-route-image" title={t('chat.routeImageHintTitle')}>
+              <p className="chat-route-image__hint">{t('chat.routeImageHint')}</p>
+              {imageRows.map((row) => (
+                <p className="chat-route-image__row" key={row.tier}>
+                  <span className="chat-route-image__tier">{row.tier}</span>
+                  <span className="chat-route-image__model">{row.model}</span>
+                </p>
+              ))}
+            </div>
+          ) : null}
         </div>
       ) : null}
     </div>

--- a/frontend/src/views/chat/chat.css
+++ b/frontend/src/views/chat/chat.css
@@ -2960,6 +2960,46 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+/* Vision tiers, below the listbox and outside it: an image turn is routed
+   before holds are consulted, so these are reported, never offered. Rows are
+   indented past the check column so their tier names still line up with the
+   options above. */
+.chat-route-image {
+  flex: none;
+  margin-top: 4px;
+  padding-top: 5px;
+  padding-bottom: 3px;
+  border-top: 1px solid var(--hairline);
+}
+.chat-route-image__hint {
+  margin: 0;
+  padding: 3px 9px 5px;
+  color: var(--dim);
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  line-height: 1.3;
+}
+.chat-route-image__row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  padding: 3px 9px 3px 31px;
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  line-height: 1.3;
+}
+.chat-route-image__tier {
+  flex: none;
+}
+.chat-route-image__model {
+  overflow: hidden;
+  min-width: 0;
+  color: var(--dim);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
 /* Gear trigger + popover holding the toolbar in the composer input bar
    (chat.js:1248-1281 chat-toolbar-wrap). */

--- a/frontend/src/views/chat/useRoutePin.test.ts
+++ b/frontend/src/views/chat/useRoutePin.test.ts
@@ -17,6 +17,7 @@ const HOLD_GET_OK = {
     { tier: 'c0', model: 'deepseek-v4-flash' },
     { tier: 'c3', model: 'claude-opus-5' },
   ],
+  imageTiers: [{ tier: 'image_model', model: 'gpt-4o' }],
 }
 
 const MODELS_OK = [
@@ -390,5 +391,60 @@ describe('useRoutePin', () => {
 
     // image_only tiers are not pinnable text routes and must not be offered.
     expect(result.current.tiers).toEqual([{ tier: 'c1', model: 'gpt-5.6-luna' }])
+  })
+
+  it('reads the image tiers the gateway reports', async () => {
+    const { rpc } = fakeRpc()
+    const { result } = renderHook(() => useRoutePin(rpc, 'agent:main:main'))
+    await waitFor(() => expect(result.current.enabled).toBe(true))
+
+    expect(result.current.imageTiers).toEqual([{ tier: 'image_model', model: 'gpt-4o' }])
+    // Kept apart from the pinnable list: a hold on a vision tier never applies.
+    expect(result.current.tiers.some((row) => row.tier === 'image_model')).toBe(false)
+  })
+
+  it('reports no image tiers when an older gateway omits the field', async () => {
+    const { rpc } = fakeRpc({
+      'router.hold.get': {
+        enabled: true,
+        provider: 'opencap',
+        hold: null,
+        tiers: [{ tier: 'c0', model: 'deepseek-v4-flash' }],
+      },
+    })
+    const { result } = renderHook(() => useRoutePin(rpc, 'agent:main:main'))
+    await waitFor(() => expect(result.current.enabled).toBe(true))
+
+    expect(result.current.imageTiers).toEqual([])
+  })
+
+  it('falls back to every vision-capable config tier, not only the image-only one', () => {
+    const { rpc } = fakeRpc()
+    const { result } = renderHook(() =>
+      useRoutePin(rpc, 'agent:main:main', {
+        c1: { model: 'gpt-5.6-luna', supportsImage: false, imageOnly: false },
+        c3: { model: 'claude-opus-5', supportsImage: true, imageOnly: false },
+        image_model: { model: 'minimax-m3', supportsImage: true, imageOnly: true },
+      }),
+    )
+
+    // The router's image branch picks among every supports_image tier, so the
+    // fallback splits on that flag rather than on image_only.
+    expect(result.current.imageTiers).toEqual([
+      { tier: 'c3', model: 'claude-opus-5' },
+      { tier: 'image_model', model: 'minimax-m3' },
+    ])
+  })
+
+  it('does not carry one session’s image tiers over to the next', async () => {
+    const { rpc } = fakeRpc()
+    const { result, rerender } = renderHook(({ key }) => useRoutePin(rpc, key), {
+      initialProps: { key: 'agent:main:one' },
+    })
+    await waitFor(() => expect(result.current.imageTiers).toHaveLength(1))
+
+    rerender({ key: 'agent:main:two' })
+
+    expect(result.current.imageTiers).toEqual([])
   })
 })

--- a/frontend/src/views/chat/useRoutePin.ts
+++ b/frontend/src/views/chat/useRoutePin.ts
@@ -40,6 +40,14 @@ export interface RoutePinState {
   /** Pinnable text tiers, config order. Empty while loading or when disabled. */
   tiers: RoutePinTier[]
   /**
+   * The tiers an image turn can land on — shown, never pinned. The router picks
+   * the vision route before holds are consulted, so a pin here could not take
+   * effect; they are kept apart from `tiers` so no caller can offer them as a
+   * choice. Several can be listed: the image branch picks at random among every
+   * vision-capable tier.
+   */
+  imageTiers: RoutePinTier[]
+  /**
    * Every model of the ACTIVE provider. Routing runs through one provider, so a
    * model from any other provider in the catalog would be sent to this one
    * under a name it does not know — those are filtered out server-side rather
@@ -92,6 +100,7 @@ interface HoldGetResult {
   provider?: string
   hold?: { tier?: string; model?: string; targetType?: string } | null
   tiers?: { tier?: string; model?: string }[]
+  imageTiers?: { tier?: string; model?: string }[]
 }
 
 const EMPTY_TIERS: RoutePinTier[] = []
@@ -102,6 +111,7 @@ interface HoldSlice {
   enabled: boolean
   provider: string
   tiers: RoutePinTier[]
+  imageTiers: RoutePinTier[]
   pinned: string | null
   pinnedModel: string | null
 }
@@ -123,6 +133,7 @@ const EMPTY_HOLD = {
   enabled: false,
   provider: '',
   tiers: EMPTY_TIERS,
+  imageTiers: EMPTY_TIERS,
   pinned: null,
   pinnedModel: null,
 } as const
@@ -160,18 +171,21 @@ export function useRoutePin(
         // which of the two the user actually chose, so the picker must not read
         // the tier as a tier selection.
         const byModel = result.hold?.targetType === 'model'
+        const readTiers = (rows: { tier?: string; model?: string }[] | undefined) =>
+          (Array.isArray(rows) ? rows : [])
+            .map((row) => ({
+              tier: routerFxNormalizeTier(row?.tier || ''),
+              model: typeof row?.model === 'string' ? row.model : '',
+            }))
+            .filter((row) => row.tier)
         setHold({
           session: forSession,
           enabled: result.enabled === true,
           provider: typeof result.provider === 'string' ? result.provider : '',
           pinned: byModel ? null : routerFxNormalizeTier(result.hold?.tier || '') || null,
           pinnedModel: byModel ? String(result.hold?.model || '') || null : null,
-          tiers: (Array.isArray(result.tiers) ? result.tiers : [])
-            .map((row) => ({
-              tier: routerFxNormalizeTier(row?.tier || ''),
-              model: typeof row?.model === 'string' ? row.model : '',
-            }))
-            .filter((row) => row.tier),
+          tiers: readTiers(result.tiers),
+          imageTiers: readTiers(result.imageTiers),
         })
       })
       .catch(() => {
@@ -324,11 +338,24 @@ export function useRoutePin(
       .map(([tier, cfg]) => ({ tier, model: cfg.model || '' }))
   }, [live.tiers, tierConfigs])
 
+  // Same fallback for the image rows, split on the flag the ROUTER splits on:
+  // `supports_image`, not `image_only`. A text tier that also takes images is a
+  // candidate for an image turn, and pinnability is a separate question the
+  // list above already answers.
+  const effectiveImageTiers = useMemo(() => {
+    if (live.imageTiers.length > 0) return live.imageTiers
+    if (!tierConfigs) return EMPTY_TIERS
+    return Object.entries(tierConfigs)
+      .filter(([, cfg]) => cfg.supportsImage || cfg.imageOnly)
+      .map(([tier, cfg]) => ({ tier, model: cfg.model || '' }))
+  }, [live.imageTiers, tierConfigs])
+
   const isPinned = live.pinned !== null || live.pinnedModel !== null
 
   return {
     enabled: live.enabled,
     tiers: effectiveTiers,
+    imageTiers: effectiveImageTiers,
     models,
     pinned: live.pinned,
     pinnedModel: live.pinnedModel,

--- a/src/agentos/gateway/rpc_router.py
+++ b/src/agentos/gateway/rpc_router.py
@@ -26,6 +26,7 @@ from agentos.router_control import (
     RouterControlTarget,
     RouterControlValidationError,
     build_router_control_targets,
+    build_router_image_routes,
     resolve_router_control_model_target,
     resolve_router_control_target,
 )
@@ -178,6 +179,13 @@ async def _handle_router_hold_get(params: dict | None, ctx: RpcContext) -> dict[
     ``provider`` is the active provider id, so a client can list the models it
     is actually allowed to pin without having to know that routing runs through
     a single provider.
+
+    ``imageTiers`` is a separate, DISPLAY-only list: the tiers an image turn can
+    be routed to. It is not merged into ``tiers`` because these cannot be
+    pinned — the router picks the vision route before holds are consulted — and
+    a client that pinned one would install a hold that never takes effect. It
+    exists so the picker can show what an image will be handed to before one is
+    sent, instead of naming a tier the menu has no row for.
     """
 
     from agentos.gateway.rpc_models import active_provider_id
@@ -186,7 +194,7 @@ async def _handle_router_hold_get(params: dict | None, ctx: RpcContext) -> dict[
     try:
         cfg, store = _router_state(ctx)
     except RpcHandlerError:
-        return {"enabled": False, "hold": None, "tiers": [], "provider": ""}
+        return {"enabled": False, "hold": None, "tiers": [], "imageTiers": [], "provider": ""}
 
     hold = store.get_user_hold(key)
     return {
@@ -202,6 +210,15 @@ async def _handle_router_hold_get(params: dict | None, ctx: RpcContext) -> dict[
             }
             for target in build_router_control_targets(cfg)
             if target.target_type == "tier"
+        ],
+        "imageTiers": [
+            {
+                "tier": route.tier,
+                "model": route.model,
+                "provider": route.provider,
+                "description": route.description,
+            }
+            for route in build_router_image_routes(cfg)
         ],
     }
 

--- a/src/agentos/router_control.py
+++ b/src/agentos/router_control.py
@@ -47,6 +47,22 @@ class RouterControlTarget:
     thinking_level: str | None = None
 
 
+@dataclass(frozen=True)
+class RouterImageRoute:
+    """One tier an image turn can be routed to. NOT a pin target.
+
+    Deliberately not a ``RouterControlTarget``: these rows exist to be shown,
+    not chosen. The router picks the vision route before holds are consulted, so
+    a hold on one of these could never take effect, and giving them a
+    ``target_id`` would invite exactly that mistake.
+    """
+
+    tier: str
+    model: str
+    provider: str | None = None
+    description: str | None = None
+
+
 @dataclass
 class RouterControlHold:
     tier: str
@@ -120,6 +136,38 @@ def build_router_control_targets(router_cfg: object | None) -> list[RouterContro
         )
 
     return targets
+
+
+def build_router_image_routes(router_cfg: object | None) -> list[RouterImageRoute]:
+    """Return the tiers an image turn can land on, in config order.
+
+    The router's image branch selects among every ``supports_image`` tier — not
+    only the ``image_only`` ones — and picks at random when several qualify
+    (``engine/steps/agentos_router.py``). So the honest answer to "where does an
+    image go?" is this whole list, and a caller that showed only ``image_model``
+    would imply a determinism the router does not have.
+
+    Kept out of :func:`build_router_control_targets` on purpose. That list feeds
+    hold resolution and the ``router_control`` tool menu, where every entry must
+    be a route a turn can actually be pinned to; an image tier is not one.
+    """
+
+    routes: list[RouterImageRoute] = []
+    for tier, cfg in normalize_tier_mapping(_router_tiers(router_cfg)).items():
+        if not bool(cfg.get("supports_image", False)):
+            continue
+        model = str(cfg.get("model") or "").strip()
+        if not model:
+            continue
+        routes.append(
+            RouterImageRoute(
+                tier=tier,
+                model=model,
+                provider=str(cfg.get("provider") or "").strip() or None,
+                description=str(cfg.get("description") or "").strip() or None,
+            )
+        )
+    return routes
 
 
 def resolve_router_control_target(

--- a/tests/test_engine/test_router_control.py
+++ b/tests/test_engine/test_router_control.py
@@ -17,6 +17,7 @@ from agentos.router_control import (
     RouterControlHoldStore,
     RouterControlValidationError,
     build_router_control_targets,
+    build_router_image_routes,
     render_router_control_prompt_block,
     resolve_router_control_model_target,
     resolve_router_control_target,
@@ -44,6 +45,69 @@ def test_router_control_targets_generalize_to_every_profile() -> None:
                 assert f"tier:{tier_name}" not in target_ids
                 continue
             assert f"tier:{tier_name}" in target_ids
+
+
+def test_image_routes_list_every_vision_tier_not_just_the_image_only_one() -> None:
+    """The router picks at random among all ``supports_image`` tiers.
+
+    Reporting only ``image_model`` would imply a determinism the image branch
+    does not have.
+    """
+
+    cfg = _router_cfg(
+        {
+            "c0": {"provider": "openrouter", "model": "flash", "supports_image": False},
+            "c3": {"provider": "openrouter", "model": "opus", "supports_image": True},
+            "image_model": {
+                "provider": "openrouter",
+                "model": "gpt-4o",
+                "supports_image": True,
+                "image_only": True,
+            },
+        }
+    )
+
+    routes = build_router_image_routes(cfg)
+
+    assert [route.tier for route in routes] == ["c3", "image_model"]
+    assert [route.model for route in routes] == ["opus", "gpt-4o"]
+
+
+def test_image_routes_are_not_pin_targets() -> None:
+    """They exist to be shown, not chosen: a hold on one could never apply."""
+
+    tiers = {
+        "c1": {"provider": "openrouter", "model": "sonnet", "supports_image": False},
+        "image_model": {
+            "provider": "openrouter",
+            "model": "gpt-4o",
+            "supports_image": True,
+            "image_only": True,
+        },
+    }
+    cfg = _router_cfg(tiers)
+
+    assert [route.tier for route in build_router_image_routes(cfg)] == ["image_model"]
+    assert "tier:image_model" not in {
+        target.target_id for target in build_router_control_targets(cfg)
+    }
+    with pytest.raises(RouterControlValidationError):
+        resolve_router_control_target(cfg, "tier:image_model")
+
+
+def test_image_routes_skip_a_vision_tier_with_no_model() -> None:
+    cfg = _router_cfg(
+        {
+            "c1": {"provider": "openrouter", "model": "sonnet", "supports_image": False},
+            "image_model": {"provider": "openrouter", "model": "", "supports_image": True},
+        }
+    )
+
+    assert build_router_image_routes(cfg) == []
+
+
+def test_image_routes_are_empty_without_a_router() -> None:
+    assert build_router_image_routes(None) == []
 
 
 def test_model_targets_are_rejected_by_local_validation() -> None:

--- a/tests/test_gateway/test_rpc_router_hold.py
+++ b/tests/test_gateway/test_rpc_router_hold.py
@@ -25,6 +25,12 @@ def _router_cfg(enabled: bool = True) -> SimpleNamespace:
         tiers={
             "c0": {"model": "gemini-flash-lite", "provider": "openrouter"},
             "c3": {"model": "claude-opus-4-8", "provider": "openrouter"},
+            "image_model": {
+                "model": "gpt-4o",
+                "provider": "openrouter",
+                "supports_image": True,
+                "image_only": True,
+            },
         },
     )
 
@@ -388,6 +394,54 @@ def test_router_hold_get_reports_the_active_pin_and_pinnable_tiers() -> None:
     assert result.payload["enabled"] is True
     assert result.payload["hold"]["tier"] == "c3"
     assert {tier["tier"] for tier in result.payload["tiers"]} == {"c0", "c3"}
+
+
+def test_router_hold_get_reports_image_tiers_apart_from_the_pinnable_ones() -> None:
+    """The picker needs to show where an image goes before one is sent.
+
+    Separate from ``tiers`` because an image tier cannot be pinned: the router
+    picks the vision route before holds are consulted.
+    """
+
+    result = asyncio.run(_dispatch("router.hold.get", {"key": "agent:main:main"}, _ctx()))
+
+    assert result.error is None, result.error
+    assert result.payload is not None
+    assert {tier["tier"] for tier in result.payload["tiers"]} == {"c0", "c3"}
+    assert result.payload["imageTiers"] == [
+        {
+            "tier": "image_model",
+            "model": "gpt-4o",
+            "provider": "openrouter",
+            "description": None,
+        }
+    ]
+
+
+def test_router_hold_get_refuses_to_pin_a_reported_image_tier() -> None:
+    """Reporting the row must not make it pinnable through the same RPC."""
+
+    ctx = _ctx()
+
+    result = asyncio.run(
+        _dispatch("router.hold.set", {"key": "agent:main:main", "tier": "image_model"}, ctx)
+    )
+
+    assert result.error is not None
+    assert result.error.code == "router.unknown_tier"
+
+
+def test_router_hold_get_reports_empty_image_tiers_when_none_support_images() -> None:
+    cfg = SimpleNamespace(
+        enabled=True,
+        tiers={"c0": {"model": "gemini-flash-lite", "provider": "openrouter"}},
+    )
+
+    result = asyncio.run(_dispatch("router.hold.get", {"key": "agent:main:main"}, _ctx(cfg=cfg)))
+
+    assert result.error is None, result.error
+    assert result.payload is not None
+    assert result.payload["imageTiers"] == []
 
 
 def test_router_hold_get_reports_no_pin_when_unpinned() -> None:


### PR DESCRIPTION
Closes #1632

## Why

The route picker offers pinnable text tiers and the active provider's models.
The tiers an image turn actually lands on are in neither list:
`router.hold.get` returns `build_router_control_targets` rows, built from
`_text_tiers`, and the client-side fallback filters `imageOnly` too.

Filtering them out of the **options** is correct — the router picks the vision
route before holds are consulted, so a pin on an image tier installs a hold that
can never take effect. But filtering them out of the **UI entirely** means the
only way to learn which model an image will be handed to is to send one and read
the route label afterwards.

## What changed

**Gateway.** `router.hold.get` gained an `imageTiers` list, built by a new
`build_router_image_routes()`. Kept separate from `tiers` rather than merged
into it, so no client can offer these as a choice, and returned as a new
`RouterImageRoute` rather than a `RouterControlTarget` so they carry no
`target_id` that could be mistaken for a pin target.
`build_router_control_targets` is untouched — it feeds hold resolution and the
`router_control` tool menu, where every entry must be pinnable, and a test
asserts `router.hold.set` still rejects `tier: image_model` with
`router.unknown_tier`.

The list reports every `supports_image` tier, not only the `image_only` one.
The image branch picks with `random.choice` among all of them
(`engine/steps/agentos_router.py:1385`), so reporting just `image_model` would
imply a determinism the router does not have.

**Picker.** The rows render below the listbox and outside it, as plain text
under "Images route here automatically", with a title explaining they cannot be
pinned. A vision tier that is already a pinnable option (a text tier with
`supports_image`) is dropped from the section so one tier does not read as two
routes, and the section is filtered by the same search needle as the options —
so typing a vision model id finds the row even though no option carries it.

## Tests

- `test_router_control.py`: image routes list every vision tier in config order,
  are not pin targets (`resolve_router_control_target` still raises), skip a
  tier with no model, and are empty without a router.
- `test_rpc_router_hold.py`: `imageTiers` reported apart from `tiers`, empty
  when nothing supports images, and `router.hold.set` still refuses the tier it
  reports.
- `RoutePicker.test.tsx` / `useRoutePin.test.ts`: the row renders, stays out of
  `getAllByRole('option')` (still 7), dedups against a pinnable vision tier,
  filters with the search, does not suppress "No route matches" when nothing at
  all matches, is dropped on a session switch, and falls back to config on the
  `supports_image` flag rather than `image_only`. An older gateway that omits
  the field reports `[]`.

Reverting the source files fails 7 of the new frontend cases and collection-errors
the Python ones.

```
uv run pytest tests/test_engine/test_router_control.py tests/test_gateway/test_rpc_router_hold.py -q
  → 49 passed
uv run ruff check src tests   → clean
uv run mypy src/agentos       → only the pre-existing mem0 import-untyped error
npm --prefix frontend run check
  → tsc + eslint + prettier clean; 99 files, 2052 tests passed
```

## Note on merge order

Branched from `main`, independent of #1631, but both touch the route picker.
Merging one leaves the other with a single conflict, in
`frontend/src/views/chat/useRoutePin.ts` (adjacent additions to `RoutePinState`,
`EMPTY_HOLD` and the hook's return). Happy to rebase this one once #1631 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ck1vzFu1sbPby3iHfXVe77
