### PR TITLE
fix(slack): drop the account-wide thread anchor that leaked replies across conversations

### DIFF
--- a/src/agentos/channels/slack.py
+++ b/src/agentos/channels/slack.py
@@ -135,7 +135,6 @@ class SlackChannel:
     )
     _client: httpx.AsyncClient | None = field(default=None, init=False, repr=False)
     _connected: bool = field(default=False, init=False, repr=False)
-    _last_thread_ts: str | None = field(default=None, init=False, repr=False)
     _last_message_at: datetime | None = field(default=None, init=False, repr=False)
     _dedupe: EventDedupeCache = field(
         default_factory=lambda: EventDedupeCache(max_size=10_000),
@@ -340,10 +339,6 @@ class SlackChannel:
         if thread_ts is not None and ts is not None:
             metadata["is_thread_root"] = thread_ts == ts
 
-        # Track last thread_ts for reply_in_thread auto-threading
-        if thread_ts is not None:
-            self._last_thread_ts = thread_ts
-
         return IncomingMessage(
             sender_id=event.get("user", self.sender_id),
             channel_id=event.get("channel", self.slack_channel_id),
@@ -399,8 +394,12 @@ class SlackChannel:
             channel = str(meta["channel"])
         if "thread_ts" in meta:
             thread_ts = meta["thread_ts"]
-        elif thread_ts is None and self.reply_in_thread and self._last_thread_ts:
-            thread_ts = self._last_thread_ts
+        # No account-wide fallback anchor here on purpose: one shared
+        # ``thread_ts`` serves every channel, thread and user, so an outgoing
+        # message without its own anchor would land in whichever conversation
+        # last spoke. A reply that needs a thread carries one already, via
+        # ``build_reply_message``/``streaming_reply_kwargs``; anything else
+        # belongs in the channel, un-threaded.
         if not channel:
             log.error("slack.send_failed", channel="", error="no_target_channel")
             raise RuntimeError("Slack send has no target channel")

--- a/tests/test_channels/test_slack_thread_anchor_isolation.py
+++ b/tests/test_channels/test_slack_thread_anchor_isolation.py
@@ -1,0 +1,131 @@
+"""Slack replies must never inherit another conversation's thread.
+
+Regression coverage for #1543: ``SlackChannel`` kept a single
+``_last_thread_ts`` for the whole account, overwritten by every inbound event
+carrying a ``thread_ts``, and ``send`` fell back to it whenever an outgoing
+message had no anchor of its own. The thread a message landed in was therefore
+decided by whichever conversation spoke most recently -- so a scheduled
+delivery, heartbeat or other proactive send could be posted into an unrelated
+conversation's thread.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from agentos.channels.slack import SlackChannel
+from agentos.channels.types import IncomingMessage, OutgoingMessage
+
+_REQUEST = httpx.Request("POST", "https://slack.test/api")
+
+
+def _ok_response() -> httpx.Response:
+    return httpx.Response(200, json={"ok": True, "ts": "1.0"}, request=_REQUEST)
+
+
+def _channel(**kwargs: Any) -> SlackChannel:
+    channel = SlackChannel(token="xoxb-test", slack_channel_id="C123", **kwargs)
+    channel.bot_user_id = "UBOT"
+    return channel
+
+
+def _attach(channel: SlackChannel) -> AsyncMock:
+    client = AsyncMock()
+    client.post = AsyncMock(return_value=_ok_response())
+    channel._client = client
+    return client.post
+
+
+def _inbound_threaded_event(channel: str, thread_ts: str) -> dict[str, Any]:
+    return {
+        "user": "U1",
+        "channel": channel,
+        "text": "hello",
+        "ts": thread_ts,
+        "thread_ts": thread_ts,
+    }
+
+
+@pytest.mark.asyncio
+async def test_send_does_not_inherit_a_thread_from_another_conversation() -> None:
+    channel = _channel(reply_in_thread=True)
+    post = _attach(channel)
+    # Conversation A speaks in a thread...
+    channel.parse_event(_inbound_threaded_event("C_AAA", "1700000000.000100"))
+
+    # ...then an unrelated proactive message goes out to conversation B.
+    await channel.send(OutgoingMessage(content="scheduled report", reply_to="C_BBB"))
+
+    payload = post.await_args.kwargs["json"]
+    assert payload["channel"] == "C_BBB"
+    assert "thread_ts" not in payload
+
+
+@pytest.mark.asyncio
+async def test_send_without_an_anchor_posts_unthreaded_in_the_same_conversation() -> None:
+    channel = _channel(reply_in_thread=True)
+    post = _attach(channel)
+    channel.parse_event(_inbound_threaded_event("C_AAA", "1700000000.000100"))
+
+    # Even back into the same channel, an anchorless send belongs in the
+    # channel: the adapter cannot know which of its threads was meant.
+    await channel.send(OutgoingMessage(content="heartbeat", reply_to="C_AAA"))
+
+    payload = post.await_args.kwargs["json"]
+    assert payload["channel"] == "C_AAA"
+    assert "thread_ts" not in payload
+
+
+@pytest.mark.asyncio
+async def test_send_still_honours_an_explicit_thread_anchor() -> None:
+    channel = _channel(reply_in_thread=True)
+    post = _attach(channel)
+
+    await channel.send(
+        OutgoingMessage(
+            content="in-thread reply",
+            reply_to="C_AAA",
+            metadata={"channel": "C_AAA", "thread_ts": "1700000000.000100"},
+        )
+    )
+
+    payload = post.await_args.kwargs["json"]
+    assert payload["thread_ts"] == "1700000000.000100"
+
+
+@pytest.mark.asyncio
+async def test_reply_built_for_an_inbound_message_still_threads_to_it() -> None:
+    channel = _channel(reply_in_thread=True)
+    post = _attach(channel)
+    # A different conversation speaks last, so a shared anchor would win here.
+    channel.parse_event(_inbound_threaded_event("C_BBB", "1700000000.000999"))
+    inbound = IncomingMessage(
+        sender_id="U1",
+        channel_id="C_AAA",
+        content="question",
+        metadata={"ts": "1700000000.000200", "thread_ts": "1700000000.000100"},
+    )
+
+    await channel.send(channel.build_reply_message("answer", inbound))
+
+    payload = post.await_args.kwargs["json"]
+    assert payload["channel"] == "C_AAA"
+    assert payload["thread_ts"] == "1700000000.000100"
+
+
+@pytest.mark.asyncio
+async def test_reply_to_a_bare_thread_ts_is_still_supported() -> None:
+    channel = _channel(reply_in_thread=True)
+    post = _attach(channel)
+
+    await channel.send(
+        OutgoingMessage(content="threaded", reply_to="1700000000.000100"),
+    )
+
+    payload = post.await_args.kwargs["json"]
+    assert payload["channel"] == "C123"
+    assert payload["thread_ts"] == "1700000000.000100"


### PR DESCRIPTION
Fixes #1543

## The bug

`_last_thread_ts` was one field on the `SlackChannel` instance serving every channel, thread and user
on the account. `parse_event` overwrote it on every inbound event carrying a `thread_ts`, and `send`
fell back to it whenever the outgoing message had no anchor of its own:

```python
if "thread_ts" in meta:
    thread_ts = meta["thread_ts"]
elif thread_ts is None and self.reply_in_thread and self._last_thread_ts:
    thread_ts = self._last_thread_ts
```

So the thread a message landed in was decided by whichever conversation spoke most recently. Any
outgoing message not built through `build_reply_message` — a scheduled delivery, a heartbeat, a
proactive notification — could be posted into an unrelated conversation's thread.

## The fix

Dropped the shared-state fallback rather than scoping it, as you asked — no per-conversation dict, so
nothing here needs to coordinate with #1131:

```python
if "thread_ts" in meta:
    thread_ts = meta["thread_ts"]
# No account-wide fallback anchor here on purpose: one shared
# ``thread_ts`` serves every channel, thread and user, so an outgoing
# message without its own anchor would land in whichever conversation
# last spoke. A reply that needs a thread carries one already, via
# ``build_reply_message``/``streaming_reply_kwargs``; anything else
# belongs in the channel, un-threaded.
```

With the fallback gone, `_last_thread_ts` had no remaining reader, so the field and the `parse_event`
write that maintained it are removed too — the whole diff is 6 insertions / 7 deletions in `slack.py`.
It is a private, `init=False` dataclass field with no reference anywhere else in `src` or `tests`
(`grep -rn "_last_thread_ts"` returns only the three sites removed here), so nothing outside the
adapter can be keyed on it.

The correct per-message behaviour already existed and is untouched: `build_reply_message` /
`streaming_reply_kwargs` derive the anchor from the specific inbound message via `_reply_thread_ts`.

## Tests

`tests/test_channels/test_slack_thread_anchor_isolation.py` — 5 cases, offline (the httpx client is an
`AsyncMock`, matching `test_slack_retry.py`'s style), asserting on the actual `chat.postMessage`
payload:

- `test_send_does_not_inherit_a_thread_from_another_conversation` — conversation A speaks in a thread,
  then a proactive send to conversation B carries no `thread_ts`. This is the disclosure bug.
- `test_send_without_an_anchor_posts_unthreaded_in_the_same_conversation` — even back into the same
  channel, an anchorless send goes to the channel: the adapter cannot know which thread was meant.
- `test_send_still_honours_an_explicit_thread_anchor` — an explicit `metadata["thread_ts"]` still
  threads.
- `test_reply_built_for_an_inbound_message_still_threads_to_it` — a different conversation speaks last
  (a shared anchor would have won here), and the reply still threads to the message being answered.
- `test_reply_to_a_bare_thread_ts_is_still_supported` — `reply_to` carrying a raw `ts` still threads.

Without the fix the first two fail; the other three pass either way by design — they guard the
threading paths this PR must not disturb.

## Verification

Self-test (upstream `slack.py` swapped back in, tests unchanged):

```
$ uv run pytest -q tests/test_channels/test_slack_thread_anchor_isolation.py
2 failed, 3 passed in 1.28s
FAILED ...::test_send_does_not_inherit_a_thread_from_another_conversation
FAILED ...::test_send_without_an_anchor_posts_unthreaded_in_the_same_conversation
```

With the fix:

```
$ uv run pytest -q tests/test_channels/test_slack_thread_anchor_isolation.py
5 passed in 1.18s

$ uv run pytest -q
6 failed, 10248 passed, 34 skipped, 4 warnings, 3 errors in 247.47s
```

The 6 failures / 3 errors are pre-existing on `upstream/main` and unrelated to this change (pilot
router ONNX encoder assets, a machine-timezone hygiene check, and wheelhouse packaging tests needing
built ML assets absent from this environment) — same set, same count, before and after this diff.

```
$ uv run ruff check .
All checks passed!

$ uv run mypy --show-error-codes src
Success: no issues found in 625 source files
```

## One behaviour change worth naming

With `reply_in_thread=True`, an anchorless send that previously *happened* to land in the last-seen
thread now posts to the channel un-threaded. That is the intended correction — the old placement was
only ever coincidentally right — but it is a visible difference for any deployment that leaned on it,
so it is called out here rather than left for someone to discover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tbgoh4XkHPqGdEVwfjsuhx
