### PR TITLE
fix(tools): stop treating /dev/null as a shell write target

### DIFF
--- a/src/agentos/tools/builtin/shell.py
+++ b/src/agentos/tools/builtin/shell.py
@@ -354,10 +354,17 @@ _TEE_PATTERN = re.compile(
 
 
 def _shell_write_targets(command: str) -> list[str]:
-    scanned = _FD_DUP_PATTERN.sub(" ", command)
+    # _without_shell_null_redirections strips ``> /dev/null``-shaped
+    # operators the same way _sensitive_shell_block already does before
+    # scanning, so a command that only ever discards output is not read as
+    # writing to a real path. It cannot reach ``| tee /dev/null`` — tee has
+    # no redirection operator for that regex to match — so /dev/null is also
+    # dropped explicitly below; it is never a meaningful write target either
+    # way, and workspace lockdown has no root that could ever contain it.
+    scanned = _FD_DUP_PATTERN.sub(" ", _without_shell_null_redirections(command))
     targets: list[str] = [match.group(2) for match in _REDIRECTION_PATTERN.finditer(scanned)]
     targets.extend(match.group(2) for match in _TEE_PATTERN.finditer(scanned))
-    return targets
+    return [target for target in targets if target != "/dev/null"]
 
 
 def _workspace_lockdown_shell_block(

--- a/tests/test_tools/test_shell_approval_policy.py
+++ b/tests/test_tools/test_shell_approval_policy.py
@@ -457,6 +457,75 @@ async def test_workspace_lockdown_blocks_obvious_outside_shell_redirection(
     assert result["reason"] == "workspace_lockdown"
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "command",
+    [
+        "pip install requests > /dev/null",
+        "pip install requests 2>/dev/null",
+        "pip install requests &>/dev/null",
+        "pip install requests > /dev/null 2>&1",
+        "pip install requests | tee /dev/null",
+    ],
+)
+async def test_workspace_lockdown_allows_devnull_redirection(
+    tmp_path: Path,
+    command: str,
+) -> None:
+    """Issue #1545: discarding output to /dev/null is one of the most common
+    shell idioms there is. Under workspace_lockdown it must never be treated
+    as a write outside the workspace."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.interaction_mode = InteractionMode.UNATTENDED
+    ctx.elevated = "bypass"
+    ctx.workspace_dir = str(workspace)
+    ctx.workspace_lockdown = True  # type: ignore[attr-defined]
+
+    result = await shell._check_exec_approval(
+        "exec_command",
+        command,
+        str(workspace),
+        "command requires approval",
+        None,
+        False,
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_workspace_lockdown_still_blocks_a_real_outside_target_next_to_devnull(
+    tmp_path: Path,
+) -> None:
+    """The /dev/null exemption must not weaken lockdown for a command that
+    also names a genuine out-of-workspace path in the same line."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside.txt"
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.interaction_mode = InteractionMode.UNATTENDED
+    ctx.elevated = "bypass"
+    ctx.workspace_dir = str(workspace)
+    ctx.workspace_lockdown = True  # type: ignore[attr-defined]
+
+    result = await shell._check_exec_approval(
+        "exec_command",
+        f"pip install requests > /dev/null 2>&1; echo ok > {outside}",
+        str(workspace),
+        "command requires approval",
+        None,
+        False,
+    )
+
+    assert result is not None
+    assert result["status"] == "blocked"
+    assert result["reason"] == "workspace_lockdown"
+
+
 @pytest.mark.parametrize(
     "command",
     [
@@ -522,6 +591,31 @@ def test_shell_write_targets_detects_tee_without_whitespace_or_short_options(
 )
 def test_shell_write_targets_ignores_words_ending_in_tee(command: str) -> None:
     assert shell._shell_write_targets(command) == []
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "pip install requests > /dev/null",
+        "pip install requests 2>/dev/null",
+        "pip install requests &>/dev/null",
+        "pip install requests > /dev/null 2>&1",
+        "pip install requests | tee /dev/null",
+    ],
+)
+def test_shell_write_targets_never_treats_dev_null_as_a_write_target(command: str) -> None:
+    """Issue #1545: _sensitive_shell_block already strips ``> /dev/null``
+    before scanning, via _without_shell_null_redirections; _shell_write_targets
+    did not, so it read the same benign idiom as a write to an out-of-workspace
+    path. Every conventional spelling of discarding output, including piping
+    through tee, must yield no write targets at all."""
+    assert shell._shell_write_targets(command) == []
+
+
+def test_shell_write_targets_still_detects_a_real_target_resembling_dev_null() -> None:
+    """The /dev/null exemption must be an exact match, not a prefix — a
+    genuine write to a similarly-named path is still a real write target."""
+    assert shell._shell_write_targets("echo p > /dev/nullish") == ["/dev/nullish"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Summary
_sensitive_shell_block already strips null redirections (> /dev/null and its spellings) before scanning, via _without_shell_null_redirections
_shell_write_targets — the only feed into _workspace_lockdown_shell_block — ran its patterns against the raw command with no equivalent stripping
/dev/null resolves as a write target, is never under any lockdown root, and the entire command gets blocked with reason="workspace_lockdown" — for one of the most common shell idioms there is (> /dev/null 2>&1), and the block message points at /dev/null as an out-of-workspace write target, which reads as nonsense to whoever is debugging it
Routed _shell_write_targets through _without_shell_null_redirections the same way _sensitive_shell_block does
That covers every redirection-operator spelling (>, 2>, &>, >...2>&1) but not | tee /dev/null — tee has no redirection operator for that regex to match — so /dev/null is also dropped explicitly from the final target list, since it's never a meaningful write target either way
Fixes #1545 

Test plan
 Added the full benign matrix at the unit level: > /dev/null, 2>/dev/null, &>/dev/null, > /dev/null 2>&1, and | tee /dev/null all yield no write targets
 Added the same matrix at the block-decision level: none of the five trigger workspace_lockdown through _check_exec_approval
 Added a case proving the exemption is an exact match, not a prefix: /dev/nullish is still detected as a real write target
 Added a case proving a real out-of-workspace target sitting next to a /dev/null redirect in the same command is still blocked
 uv run pytest tests/test_tools/test_shell_approval_policy.py -q — 81 passed
 uv run pytest tests/test_tools -k shell -q — 140 passed, 5 skipped
 uv run ruff check / uv run mypy clean on changed files