### PR TITLE
fix(scheduler): keep ops edits from reverting a concurrent job reservation

### DIFF
--- a/src/agentos/scheduler/ops.py
+++ b/src/agentos/scheduler/ops.py
@@ -333,7 +333,7 @@ class SchedulerOps:
             job.next_run_at = _next_run(job, now)
 
         _resolve_script_placeholder(job)
-        await self._store.save(job)
+        await self._store.save(job, write_reservation=False)
         return job
 
     async def update(self, job_id: str, **patch) -> CronJob | None:
@@ -470,7 +470,7 @@ class SchedulerOps:
 
         job.updated_at = now
         _resolve_script_placeholder(job)
-        await self._store.save(job)
+        await self._store.save(job, write_reservation=False)
         return job
 
     async def remove(self, job_id: str) -> bool:
@@ -488,7 +488,7 @@ class SchedulerOps:
             return None
         job.status = JobStatus.PAUSED
         job.updated_at = datetime.now(UTC)
-        await self._store.save(job)
+        await self._store.save(job, write_reservation=False)
         return job
 
     async def resume(self, job_id: str) -> CronJob | None:
@@ -514,7 +514,7 @@ class SchedulerOps:
         else:
             job.next_run_at = _next_run(job, now)
 
-        await self._store.save(job)
+        await self._store.save(job, write_reservation=False)
         return job
 
     async def get(self, job_id: str) -> CronJob | None:

--- a/src/agentos/scheduler/persistence.py
+++ b/src/agentos/scheduler/persistence.py
@@ -392,6 +392,71 @@ class _AsyncReentrantLock:
         self.release()
 
 
+#: Columns the reservation protocol owns. ``reserve_due_job`` claims a row with
+#: a lock-free atomic UPDATE, so a caller that read the row before that claim
+#: must not carry its pre-reservation snapshot of these back over it. Mirrors
+#: exactly what :func:`agentos.scheduler.types.clear_reservation` resets.
+_RESERVATION_COLUMNS: tuple[str, ...] = (
+    "reservation_token",
+    "reserved_at",
+    "reserved_by",
+    "reservation_source",
+    "scheduled_run_at",
+)
+
+#: Every other column an upsert may overwrite on conflict.
+_UPSERT_UPDATE_COLUMNS: tuple[str, ...] = (
+    "name",
+    "cron_expr",
+    "handler_key",
+    "payload",
+    "status",
+    "updated_at",
+    "last_run_at",
+    "next_run_at",
+    "run_count",
+    "error_count",
+    "last_error",
+    "max_retries",
+    "jitter_seconds",
+    "schedule_kind",
+    "schedule_raw",
+    "session_target",
+    "session_key",
+    "timeout_seconds",
+    "wake_mode",
+    "delete_after_run",
+    "enabled",
+    "backoff_until",
+    "consecutive_errors",
+    "delivery_json",
+    "origin_session_key",
+    "tool_policy_json",
+    "tz",
+    "anchor_at",
+    "creator_session_key",
+    "creator_sender_id",
+)
+
+
+def _build_upsert_update_clause(*, write_reservation: bool) -> str:
+    columns = _UPSERT_UPDATE_COLUMNS
+    if write_reservation:
+        columns = columns + _RESERVATION_COLUMNS
+    assignments = ",\n                ".join(f"{column}=excluded.{column}" for column in columns)
+    return f"            ON CONFLICT(id) DO UPDATE SET\n                {assignments}\n            "
+
+
+_UPSERT_CLAUSE_WITH_RESERVATION = _build_upsert_update_clause(write_reservation=True)
+_UPSERT_CLAUSE_KEEPING_RESERVATION = _build_upsert_update_clause(write_reservation=False)
+
+
+def _upsert_update_clause(write_reservation: bool) -> str:
+    if write_reservation:
+        return _UPSERT_CLAUSE_WITH_RESERVATION
+    return _UPSERT_CLAUSE_KEEPING_RESERVATION
+
+
 class JobStore:
     """Async SQLite store for CronJob records."""
 
@@ -534,7 +599,7 @@ class JobStore:
     def _iso(self, dt: datetime | None) -> str | None:
         return _storage_iso(dt)
 
-    async def _execute_save(self, job: CronJob) -> None:
+    async def _execute_save(self, job: CronJob, *, write_reservation: bool = True) -> None:
         handler_key, payload, session_target, session_key = normalize_contract(
             handler_key=job.handler_key,
             payload=job.payload,
@@ -560,43 +625,8 @@ class JobStore:
                  scheduled_run_at, tool_policy_json, tz, anchor_at,
                  creator_session_key, creator_sender_id)
             VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
-            ON CONFLICT(id) DO UPDATE SET
-                name=excluded.name,
-                cron_expr=excluded.cron_expr,
-                handler_key=excluded.handler_key,
-                payload=excluded.payload,
-                status=excluded.status,
-                updated_at=excluded.updated_at,
-                last_run_at=excluded.last_run_at,
-                next_run_at=excluded.next_run_at,
-                run_count=excluded.run_count,
-                error_count=excluded.error_count,
-                last_error=excluded.last_error,
-                max_retries=excluded.max_retries,
-                jitter_seconds=excluded.jitter_seconds,
-                schedule_kind=excluded.schedule_kind,
-                schedule_raw=excluded.schedule_raw,
-                session_target=excluded.session_target,
-                session_key=excluded.session_key,
-                timeout_seconds=excluded.timeout_seconds,
-                wake_mode=excluded.wake_mode,
-                delete_after_run=excluded.delete_after_run,
-                enabled=excluded.enabled,
-                backoff_until=excluded.backoff_until,
-                consecutive_errors=excluded.consecutive_errors,
-                delivery_json=excluded.delivery_json,
-                origin_session_key=excluded.origin_session_key,
-                reservation_token=excluded.reservation_token,
-                reserved_at=excluded.reserved_at,
-                reserved_by=excluded.reserved_by,
-                reservation_source=excluded.reservation_source,
-                scheduled_run_at=excluded.scheduled_run_at,
-                tool_policy_json=excluded.tool_policy_json,
-                tz=excluded.tz,
-                anchor_at=excluded.anchor_at,
-                creator_session_key=excluded.creator_session_key,
-                creator_sender_id=excluded.creator_sender_id
-            """,
+            """
+            + _upsert_update_clause(write_reservation),
             (
                 job.id,
                 job.name,
@@ -638,15 +668,22 @@ class JobStore:
             ),
         )
 
-    async def save(self, job: CronJob) -> None:
+    async def save(self, job: CronJob, *, write_reservation: bool = True) -> None:
+        """Upsert *job*.
+
+        ``write_reservation=False`` leaves the reservation columns as they are
+        in the row. Callers that read-modify-write a whole job for an unrelated
+        edit must pass it, or an atomic reservation landing between their read
+        and their write is silently reverted (#1537).
+        """
         async with self._write_lock:
-            await self._execute_save(job)
+            await self._execute_save(job, write_reservation=write_reservation)
             if not self._in_transaction:
                 await self._db().commit()
 
-    async def save_no_commit(self, job: CronJob) -> None:
+    async def save_no_commit(self, job: CronJob, *, write_reservation: bool = True) -> None:
         """Insert/update a job without committing — use inside transaction()."""
-        await self._execute_save(job)
+        await self._execute_save(job, write_reservation=write_reservation)
 
     @asynccontextmanager
     async def transaction(self) -> AsyncIterator[JobStore]:

--- a/tests/test_scheduler/test_ops_save_preserves_reservation.py
+++ b/tests/test_scheduler/test_ops_save_preserves_reservation.py
@@ -1,0 +1,163 @@
+"""An unrelated ops edit must not revert a reservation that landed mid-flight.
+
+Regression coverage for #1537: ``ops.update``/``pause``/``resume`` each do
+``get(job_id)`` -> mutate a field -> ``save(job)``, and the upsert wrote the
+reservation columns unconditionally. An atomic ``reserve_due_job`` landing in
+the gap was therefore reverted by a caller that only meant to flip ``status``,
+which silently discarded the run's result (``apply_reserved_result`` no longer
+recognises the token) and left the row free for the next tick to run the same
+job again, concurrently with the run still in flight.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from agentos.scheduler.ops import SchedulerOps
+from agentos.scheduler.persistence import JobStore
+from agentos.scheduler.types import (
+    CronJob,
+    JobExecution,
+    JobReservation,
+    JobStatus,
+    ScheduleKind,
+    SessionTarget,
+)
+
+_JOB_ID = "job-reservation-race"
+
+
+def _cron_job(next_run_at: datetime) -> CronJob:
+    return CronJob(
+        id=_JOB_ID,
+        name=_JOB_ID,
+        cron_expr="* * * * *",
+        handler_key="agent_run",
+        payload={"kind": "agent_turn", "task": "work", "agent_id": "main"},
+        session_target=SessionTarget.ISOLATED,
+        schedule_kind=ScheduleKind.CRON,
+        next_run_at=next_run_at,
+        status=JobStatus.PENDING,
+    )
+
+
+async def _reserve(store: JobStore) -> JobReservation:
+    reservation = await store.reserve_due_job(
+        _JOB_ID,
+        datetime.now(UTC),
+        source="timer",
+        owner="scheduler-timer",
+    )
+    assert isinstance(reservation, JobReservation)
+    return reservation
+
+
+class _ReserveMidEdit:
+    """Land an atomic reservation inside an ops read-modify-write.
+
+    ``ops`` reads the job, mutates a field, then saves it back. Reserving at
+    the top of that ``save`` reproduces the exact window: the row is reserved,
+    but the job object about to be written still carries the pre-reservation
+    snapshot of the reservation columns.
+    """
+
+    def __init__(self, store: JobStore) -> None:
+        self._store = store
+        self._original = store.save
+        self.reservation: JobReservation | None = None
+        store.save = self  # type: ignore[method-assign]
+
+    async def __call__(self, job: CronJob, **kwargs: object) -> None:
+        if self.reservation is None:
+            self.reservation = await _reserve(self._store)
+        await self._original(job, **kwargs)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["pause", "resume", "update"])
+async def test_ops_edit_does_not_revert_a_concurrent_reservation(operation: str) -> None:
+    async with JobStore(":memory:") as store:
+        await store.save(_cron_job(datetime.now(UTC) - timedelta(seconds=1)))
+        ops = SchedulerOps(store)
+        racer = _ReserveMidEdit(store)
+
+        if operation == "update":
+            await ops.update(_JOB_ID, name="renamed")
+        else:
+            await getattr(ops, operation)(_JOB_ID)
+
+        assert racer.reservation is not None
+        current = await store.get(_JOB_ID)
+        assert current is not None
+        assert current.reservation_token == racer.reservation.token
+        assert current.reserved_by == "scheduler-timer"
+
+
+@pytest.mark.asyncio
+async def test_result_of_the_in_flight_run_still_applies_after_a_concurrent_pause() -> None:
+    """The end-to-end consequence: the run's result must not be discarded."""
+    from agentos.scheduler.jobs import apply_reserved_result
+
+    async with JobStore(":memory:") as store:
+        await store.save(_cron_job(datetime.now(UTC) - timedelta(seconds=1)))
+        ops = SchedulerOps(store)
+        racer = _ReserveMidEdit(store)
+
+        await ops.pause(_JOB_ID)
+
+        assert racer.reservation is not None
+        execution = JobExecution(job_id=_JOB_ID, started_at=datetime.now(UTC), success=True)
+        applied = await apply_reserved_result(_JOB_ID, racer.reservation.token, execution, store)
+
+        assert applied is True
+
+
+@pytest.mark.asyncio
+async def test_ops_edit_still_writes_the_fields_it_owns() -> None:
+    async with JobStore(":memory:") as store:
+        await store.save(_cron_job(datetime.now(UTC) - timedelta(seconds=1)))
+        ops = SchedulerOps(store)
+        _ReserveMidEdit(store)
+
+        await ops.update(_JOB_ID, name="renamed")
+        await ops.pause(_JOB_ID)
+
+        current = await store.get(_JOB_ID)
+        assert current is not None
+        assert current.name == "renamed"
+        assert current.status is JobStatus.PAUSED
+
+
+@pytest.mark.asyncio
+async def test_reservation_protocol_can_still_clear_the_reservation() -> None:
+    async with JobStore(":memory:") as store:
+        await store.save(_cron_job(datetime.now(UTC) - timedelta(seconds=1)))
+        reservation = await _reserve(store)
+
+        released = await store.release_reservation(_JOB_ID, reservation.token)
+
+        assert released is True
+        current = await store.get(_JOB_ID)
+        assert current is not None
+        assert current.reservation_token == ""
+        assert current.reserved_by == ""
+
+
+@pytest.mark.asyncio
+async def test_creating_a_job_still_persists_its_columns() -> None:
+    async with JobStore(":memory:") as store:
+        ops = SchedulerOps(store)
+
+        created = await ops.add(
+            "fresh",
+            schedule_kind=ScheduleKind.CRON,
+            schedule_value="* * * * *",
+            payload={"kind": "agent_turn", "task": "work", "agent_id": "main"},
+        )
+
+        stored = await store.get(created.id)
+        assert stored is not None
+        assert stored.name == "fresh"
+        assert stored.reservation_token == ""


### PR DESCRIPTION
Fixes #1537

## The bug

`ops.update`, `ops.pause` and `ops.resume` each do `get(job_id)` → mutate a field or two →
`save(job)`, and `_execute_save`'s upsert wrote the reservation columns unconditionally:

```sql
ON CONFLICT(id) DO UPDATE SET
    ...
    reservation_token=excluded.reservation_token,
    reserved_at=excluded.reserved_at,
    reserved_by=excluded.reserved_by,
    reservation_source=excluded.reservation_source,
    scheduled_run_at=excluded.scheduled_run_at,
```

`reserve_due_job` claims a row with a deliberately lock-free atomic UPDATE. When it lands between an
ops caller's `get` and its `save`, that caller writes its pre-reservation snapshot of those columns
back over the claim — a "pause" reverting a reservation it never knew about. Both consequences are
silent: `apply_reserved_result` no longer recognises the token and drops the finished run's result,
and the row now looks free, so the next tick can reserve and run the same job again alongside the run
still in flight.

## The fix

The reservation columns belong to the reservation protocol, so the `ops` path stops writing them —
no lock around the read/write pair, per your note.

`save()` / `save_no_commit()` take `write_reservation` (default `True`, so the reservation protocol's
own writes are unchanged), and the `ON CONFLICT DO UPDATE SET` assignment list is now built from a
column tuple instead of a hand-maintained literal:

```python
def _upsert_update_clause(write_reservation: bool) -> str:
    if write_reservation:
        return _UPSERT_CLAUSE_WITH_RESERVATION
    return _UPSERT_CLAUSE_KEEPING_RESERVATION
```

Both clause strings are built once at import, so nothing is assembled per save. The four `ops` save
sites pass `write_reservation=False`; every other caller is untouched, which matters because they
genuinely own those columns:

- `timer.py:78` (startup stale-RUNNING recovery) and `persistence.py` `finalize_reserved_missing_handler`
  / `release_reservation` call `clear_reservation(job)` and then save;
- `jobs.py` `apply_result` / `apply_reserved_result` clear reservations inside `_apply_result_state`.

**One interpretation stated explicitly:** you named four reservation columns; the excluded set here is
five, adding `scheduled_run_at`, because that is exactly what
`agentos.scheduler.types.clear_reservation` resets — leaving it writable would let an ops edit stamp a
stale `scheduled_run_at` onto a live reservation while the token survived. Happy to narrow it to four
if you would rather keep that column with the schedule fields.

## Tests

`tests/test_scheduler/test_ops_save_preserves_reservation.py` — 7 cases against a real
`JobStore(":memory:")` and real `SchedulerOps` (offline, deterministic). The reservation is landed
inside the ops `save` call, which is exactly the window the bug needs: the row is reserved while the
job object being written still carries the pre-reservation snapshot.

- `test_ops_edit_does_not_revert_a_concurrent_reservation[pause|resume|update]` — all three ops
  methods from the report; the stored row must still carry the reservation's token and owner.
- `test_result_of_the_in_flight_run_still_applies_after_a_concurrent_pause` — the end-to-end
  consequence: `apply_reserved_result` returns `True` instead of silently discarding the run.
- `test_ops_edit_still_writes_the_fields_it_owns` — `name` and `status` still persist, so the
  exclusion is not over-broad.
- `test_reservation_protocol_can_still_clear_the_reservation` — `release_reservation` still clears the
  columns, i.e. the default path is unchanged.
- `test_creating_a_job_still_persists_its_columns` — `ops.add` still writes a full row.

Without the fix, 4 of the 7 fail; the other 3 pass either way by design.

**Worth flagging on the tests:** my first version of these asserted against a reservation taken
*before* calling `ops.pause()`, and passed with and without the fix — `ops` re-reads the row itself,
so there was no stale snapshot and nothing to clobber. The interleaving above is what actually
reproduces the race; the earlier shape would have proven nothing.

## Verification

Self-test (upstream `persistence.py` and `ops.py` swapped back in, tests unchanged):

```
$ uv run pytest -q tests/test_scheduler/test_ops_save_preserves_reservation.py
4 failed, 3 passed in 1.30s
FAILED ...::test_ops_edit_does_not_revert_a_concurrent_reservation[pause]
FAILED ...::test_ops_edit_does_not_revert_a_concurrent_reservation[resume]
FAILED ...::test_ops_edit_does_not_revert_a_concurrent_reservation[update]
FAILED ...::test_result_of_the_in_flight_run_still_applies_after_a_concurrent_pause
```

With the fix:

```
$ uv run pytest -q tests/test_scheduler/test_ops_save_preserves_reservation.py
7 passed in 1.24s

$ uv run pytest -q
6 failed, 10250 passed, 34 skipped, 4 warnings, 3 errors in 257.32s
```

The 6 failures / 3 errors are pre-existing on `upstream/main` and unrelated to this change (pilot
router ONNX encoder assets, a machine-timezone hygiene check, and wheelhouse packaging tests needing
built ML assets absent from this environment) — same set, same count, before and after this diff.

```
$ uv run ruff check .
All checks passed!

$ uv run mypy --show-error-codes src
Success: no issues found in 625 source files
```

## One adjacent case, deliberately left alone

`timer.py:135` (startup fast-forward of `next_run_at`) is the same read-modify-write shape and still
saves with reservation writes enabled. It runs before the tick loop starts, so there is no concurrent
reservation to lose, and changing it was outside what this issue describes — mentioning it so the
choice is visible rather than accidental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tbgoh4XkHPqGdEVwfjsuhx
