### PR TITLE
fix(channels): settle status reactions on the failure path

### DIFF
--- a/src/agentos/channels/_reactions.py
+++ b/src/agentos/channels/_reactions.py
@@ -26,8 +26,22 @@ class _BaseStatusReactor:
         self._adapter = adapter; self._log = logger; self._disabled = False; self._active: dict[str, list[Any]] = defaultdict(list)
     async def received(self, message: IncomingMessage) -> None: await self._add_state(message, "received")
     async def running(self, message: IncomingMessage) -> None: await self._add_state(message, "running")
-    async def failed(self, message: IncomingMessage) -> None: await self._add_state(message, "failed")
-    async def completed(self, message: IncomingMessage) -> None:
+    async def failed(self, message: IncomingMessage) -> None:
+        # Terminal, like ``completed``: clear the progress marks so the message
+        # is not left carrying a contradictory pair, but keep the failure mark
+        # as the outcome. The failure token is deliberately not tracked -- there
+        # is no later call to reclaim it, so tracking it leaks the ``_active``
+        # entry for the adapter's lifetime.
+        await self._clear_active(message)
+        if self._disabled:
+            return
+        try:
+            await self._add(message, "failed")
+        except Exception as exc:
+            self._warn_failure("add:failed", exc)
+            self._disable(f"add_failed:{type(exc).__name__}")
+    async def completed(self, message: IncomingMessage) -> None: await self._clear_active(message)
+    async def _clear_active(self, message: IncomingMessage) -> None:
         key = self._message_key(message)
         for token in self._active.pop(key, []):
             try:

--- a/tests/test_channels/test_status_reaction_lifecycle.py
+++ b/tests/test_channels/test_status_reaction_lifecycle.py
@@ -1,0 +1,122 @@
+"""Status-reaction lifecycle on the failure path.
+
+Regression coverage for #1560: ``failed()`` appended its token through
+``_add_state`` and nothing ever reclaimed it, because ``completed()`` was the
+only method that popped ``_active``. On the ``TaskQueueFullError`` path --
+``received(msg)`` then ``failed(msg)``, then return -- the message was left
+carrying a contradictory ✅/❌ pair forever, and the ``_active`` entry leaked
+once per rejected message for the adapter's lifetime.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agentos.channels._reactions import _BaseStatusReactor
+from agentos.channels.types import IncomingMessage
+
+
+class _RecordingReactor(_BaseStatusReactor):
+    def __init__(self) -> None:
+        super().__init__("test", _SilentLog())
+        self.added: list[str] = []
+        self.removed: list[str] = []
+
+    async def _add(self, message: IncomingMessage, state: str) -> Any:
+        self.added.append(state)
+        return state
+
+    async def _remove(self, token: Any) -> None:
+        self.removed.append(str(token))
+
+
+class _SilentLog:
+    def warning(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+
+def _message(ts: str = "1700000000.000100") -> IncomingMessage:
+    return IncomingMessage(
+        sender_id="U1",
+        channel_id="C1",
+        content="hi",
+        metadata={"ts": ts},
+    )
+
+
+@pytest.mark.asyncio
+async def test_failed_clears_the_progress_marks_and_keeps_the_failure_mark() -> None:
+    reactor = _RecordingReactor()
+    message = _message()
+
+    await reactor.received(message)
+    await reactor.running(message)
+    await reactor.failed(message)
+
+    assert reactor.added == ["received", "running", "failed"]
+    # The ✅/👀 pair is cleared; ❌ stays as the outcome marker.
+    assert reactor.removed == ["received", "running"]
+
+
+@pytest.mark.asyncio
+async def test_failed_does_not_leave_a_tracked_entry_behind() -> None:
+    reactor = _RecordingReactor()
+    message = _message()
+
+    await reactor.received(message)
+    await reactor.failed(message)
+
+    assert not reactor._active
+
+
+@pytest.mark.asyncio
+async def test_repeated_rejections_do_not_accumulate_entries() -> None:
+    reactor = _RecordingReactor()
+
+    for index in range(5):
+        message = _message(ts=f"1700000000.00{index:04d}")
+        await reactor.received(message)
+        await reactor.failed(message)
+
+    assert not reactor._active
+
+
+@pytest.mark.asyncio
+async def test_completed_after_failed_does_not_remove_the_failure_mark() -> None:
+    reactor = _RecordingReactor()
+    message = _message()
+
+    await reactor.received(message)
+    await reactor.failed(message)
+    await reactor.completed(message)
+
+    assert reactor.removed == ["received"]
+
+
+@pytest.mark.asyncio
+async def test_completed_still_clears_every_tracked_mark() -> None:
+    reactor = _RecordingReactor()
+    message = _message()
+
+    await reactor.received(message)
+    await reactor.running(message)
+    await reactor.completed(message)
+
+    assert reactor.removed == ["received", "running"]
+    assert not reactor._active
+
+
+@pytest.mark.asyncio
+async def test_failed_is_skipped_once_reactions_are_disabled() -> None:
+    reactor = _RecordingReactor()
+    message = _message()
+    await reactor.received(message)
+    reactor._disable("test")
+
+    await reactor.failed(message)
+
+    # The tracked mark is still reclaimed, but no new reaction is attempted.
+    assert reactor.removed == ["received"]
+    assert reactor.added == ["received"]


### PR DESCRIPTION
Fixes #1560

## The bug

`_BaseStatusReactor.completed` was the only method that popped `_active` and removed emoji;
`received`, `running` and `failed` all appended through `_add_state`. On the `TaskQueueFullError`
path `channel_dispatch.py` calls `received(msg)` (line 537), then `failed(msg)` (line 608), then
returns — no `completed(msg)`, and the same shape again at lines 932/937.

So a rejected message keeps **both** ✅ and ❌ forever, and the `_active` entry is never reclaimed —
one leaked list per rejected message, repeatable for as long as the queue keeps filling.

## The fix

`failed()` becomes terminal in the way you described: clear the tracked progress marks, keep ❌ as the
outcome, and leave nothing behind in `_active`. It deliberately does **not** call `completed()`, which
would take the ❌ with it, and it does not track its own token — there is no later call that would
reclaim it, so tracking it is what leaked in the first place.

```python
async def failed(self, message: IncomingMessage) -> None:
    # Terminal, like ``completed``: clear the progress marks so the message
    # is not left carrying a contradictory pair, but keep the failure mark
    # as the outcome. The failure token is deliberately not tracked -- there
    # is no later call to reclaim it, so tracking it leaks the ``_active``
    # entry for the adapter's lifetime.
    await self._clear_active(message)
    if self._disabled:
        return
    try:
        await self._add(message, "failed")
    except Exception as exc:
        self._warn_failure("add:failed", exc)
        self._disable(f"add_failed:{type(exc).__name__}")

async def completed(self, message: IncomingMessage) -> None: await self._clear_active(message)
```

`completed()`'s removal loop moved to `_clear_active()` unchanged, so `completed()` behaves exactly as
before.

**Why no call-site changes:** all three `failed()` sites (`channel_dispatch.py:608`, `932`, `937`) are
terminal — each returns immediately after, with no `completed()` on the same path — so making
`failed()` itself settle keeps every existing caller correct and cannot be forgotten by a future one.
Nothing else in `src` or `tests` calls `failed()`. If you would rather have an explicit
`failed_final()`/`settled()` on the protocol and leave `failed()` non-terminal, say so and I will
reshape it — I picked the smaller change because the current usage is uniformly terminal.

## Tests

`tests/test_channels/test_status_reaction_lifecycle.py` — 6 cases against a recording subclass of
`_BaseStatusReactor` (offline, deterministic, no Slack client involved):

- `test_failed_clears_the_progress_marks_and_keeps_the_failure_mark` — ✅/👀 removed, ❌ added and not
  removed. The user-visible half.
- `test_failed_does_not_leave_a_tracked_entry_behind` — `_active` is empty after the failure path.
- `test_repeated_rejections_do_not_accumulate_entries` — five rejected messages leave nothing tracked;
  this is the leak under sustained load.
- `test_completed_after_failed_does_not_remove_the_failure_mark` — a later `completed()` is a no-op
  for ❌, so the outcome marker survives.
- `test_completed_still_clears_every_tracked_mark` — the untouched success path.
- `test_failed_is_skipped_once_reactions_are_disabled` — after `_disable()`, the tracked mark is still
  reclaimed but no new reaction is attempted.

Without the fix, 5 of the 6 fail.

## Verification

Self-test (upstream `_reactions.py` swapped back in, tests unchanged):

```
$ uv run pytest -q tests/test_channels/test_status_reaction_lifecycle.py
5 failed, 1 passed in 1.19s
```

With the fix:

```
$ uv run pytest -q tests/test_channels/test_status_reaction_lifecycle.py
6 passed in 1.17s

$ uv run pytest -q
6 failed, 10256 passed, 34 skipped, 4 warnings, 3 errors in 247.67s
```

The 6 failures / 3 errors are pre-existing on `upstream/main` and unrelated to this change (pilot
router ONNX encoder assets, a machine-timezone hygiene check, and wheelhouse packaging tests needing
built ML assets absent from this environment) — same set, same count, before and after this diff.

```
$ uv run ruff check .
All checks passed!

$ uv run mypy --show-error-codes src
Success: no issues found in 625 source files
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tbgoh4XkHPqGdEVwfjsuhx
