### PR TITLE
fix(scheduler): stop update/pause/resume from clobbering a concurrent…

### DIFF
--- a/src/agentos/scheduler/ops.py
+++ b/src/agentos/scheduler/ops.py
@@ -470,7 +470,7 @@ class SchedulerOps:
 
         job.updated_at = now
         _resolve_script_placeholder(job)
-        await self._store.save(job)
+        await self._store.save_preserving_reservation(job)
         return job
 
     async def remove(self, job_id: str) -> bool:
@@ -488,7 +488,7 @@ class SchedulerOps:
             return None
         job.status = JobStatus.PAUSED
         job.updated_at = datetime.now(UTC)
-        await self._store.save(job)
+        await self._store.save_preserving_reservation(job)
         return job
 
     async def resume(self, job_id: str) -> CronJob | None:
@@ -514,7 +514,7 @@ class SchedulerOps:
         else:
             job.next_run_at = _next_run(job, now)
 
-        await self._store.save(job)
+        await self._store.save_preserving_reservation(job)
         return job
 
     async def get(self, job_id: str) -> CronJob | None:

--- a/src/agentos/scheduler/persistence.py
+++ b/src/agentos/scheduler/persistence.py
@@ -648,6 +648,94 @@ class JobStore:
         """Insert/update a job without committing — use inside transaction()."""
         await self._execute_save(job)
 
+    async def _execute_save_preserving_reservation(self, job: CronJob) -> None:
+        handler_key, payload, session_target, session_key = normalize_contract(
+            handler_key=job.handler_key,
+            payload=job.payload,
+            session_target=job.session_target,
+            session_key=job.session_key,
+            origin_session_key=job.origin_session_key,
+            strict=False,
+        )
+        origin_session_key = normalize_origin_session_key(
+            session_target,
+            job.origin_session_key,
+        )
+        await self._db().execute(
+            """
+            UPDATE scheduler_jobs
+            SET name=?, cron_expr=?, handler_key=?, payload=?, status=?,
+                updated_at=?, last_run_at=?, next_run_at=?,
+                run_count=?, error_count=?, last_error=?, max_retries=?, jitter_seconds=?,
+                schedule_kind=?, schedule_raw=?, session_target=?, session_key=?,
+                timeout_seconds=?, wake_mode=?, delete_after_run=?, enabled=?, backoff_until=?,
+                consecutive_errors=?, delivery_json=?, origin_session_key=?,
+                scheduled_run_at=?, tool_policy_json=?, tz=?, anchor_at=?,
+                creator_session_key=?, creator_sender_id=?
+            WHERE id = ?
+            """,
+            (
+                job.name,
+                job.cron_expr,
+                handler_key,
+                json.dumps(payload),
+                job.status.value,
+                job.updated_at.isoformat(),
+                self._iso(job.last_run_at),
+                self._iso(job.next_run_at),
+                job.run_count,
+                job.error_count,
+                job.last_error,
+                job.max_retries,
+                job.jitter_seconds,
+                getattr(job.schedule_kind, "value", str(job.schedule_kind)),
+                job.schedule_raw,
+                getattr(session_target, "value", str(session_target)),
+                session_key,
+                job.timeout_seconds,
+                getattr(job.wake_mode, "value", str(job.wake_mode)),
+                1 if job.delete_after_run else 0,
+                1 if job.enabled else 0,
+                self._iso(job.backoff_until),
+                job.consecutive_errors,
+                _serialize_delivery(job.delivery),
+                origin_session_key,
+                self._iso(job.scheduled_run_at),
+                json.dumps(job.tool_policy or {}),
+                job.tz or "",
+                self._iso(job.anchor_at),
+                job.creator_session_key or "",
+                job.creator_sender_id or "",
+                job.id,
+            ),
+        )
+
+    async def save_preserving_reservation(self, job: CronJob) -> None:
+        """Persist every column except the reservation quartet.
+
+        ``reservation_token``, ``reserved_at``, ``reserved_by`` and
+        ``reservation_source`` are owned by the reservation protocol
+        (``reserve_due_job``, ``release_reservation``,
+        ``finalize_reserved_missing_handler``) — not by callers that only
+        mean to flip a status or edit a schedule. Those callers do
+        ``get() -> mutate a field or two -> save(job)`` with no lock spanning
+        the read+write pair; a concurrent ``reserve_due_job`` landing in that
+        gap claims the row with its own atomic ``UPDATE``, and a subsequent
+        full-column ``save()`` here would silently overwrite that claim back
+        to the pre-reservation snapshot the caller's ``get()`` captured.
+        That both drops the eventual execution result (``apply_reserved_result``
+        sees a reservation_token it doesn't recognize and returns ``False``)
+        and un-reserves the row for a second, concurrent run of the same job.
+
+        Used by :meth:`SchedulerOps.update`, ``.pause`` and ``.resume``.
+        Anything that legitimately changes the reservation columns goes
+        through :meth:`save` directly, never through this one.
+        """
+        async with self._write_lock:
+            await self._execute_save_preserving_reservation(job)
+            if not self._in_transaction:
+                await self._db().commit()
+
     @asynccontextmanager
     async def transaction(self) -> AsyncIterator[JobStore]:
         """Batch multiple save_no_commit() calls into a single commit with rollback on failure."""

--- a/tests/test_scheduler/test_reservation_preserved_across_ops_save.py
+++ b/tests/test_scheduler/test_reservation_preserved_across_ops_save.py
@@ -1,0 +1,220 @@
+"""Issue #1537: update/pause/resume must not clobber a concurrent reservation.
+
+ops.update/.pause/.resume each do get(job_id) -> mutate a field or two ->
+save(job), with no lock spanning the read+write pair. If reserve_due_job's
+atomic UPDATE claims the job in that gap, a full-column save() from one of
+those callers used to overwrite reservation_token/reserved_at/reserved_by/
+reservation_source back to the pre-reservation snapshot the caller's get()
+captured -- silently reverting a reservation the caller never touched. That
+made apply_reserved_result see a reservation_token it no longer recognizes
+(discarding the execution result) and left the row looking unreserved (so
+the next tick could reserve and run the same job again, concurrently with
+the run still in flight).
+
+The fix: update/pause/resume now go through
+JobStore.save_preserving_reservation, which writes every column except the
+reservation quartet, so a concurrent reservation's columns are left exactly
+as reserve_due_job wrote them.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from agentos.scheduler.jobs import apply_reserved_result
+from agentos.scheduler.ops import SchedulerOps
+from agentos.scheduler.payloads import make_agent_turn_payload
+from agentos.scheduler.persistence import JobStore
+from agentos.scheduler.types import (
+    JobExecution,
+    JobReservation,
+    JobStatus,
+    ScheduleKind,
+    SessionTarget,
+)
+
+
+async def _open_ops(tmp_path: Path) -> tuple[JobStore, SchedulerOps]:
+    store = JobStore(str(tmp_path / "cron.db"))
+    await store.open()
+    return store, SchedulerOps(store)
+
+
+async def _add_due_job(ops: SchedulerOps, name: str = "demo") -> str:
+    job = await ops.add(
+        name=name,
+        handler_key="agent_run",
+        payload=make_agent_turn_payload("ping"),
+        session_target=SessionTarget.ISOLATED,
+        schedule_kind=ScheduleKind.EVERY,
+        schedule_value="60",
+    )
+    # Force it due right now rather than 60s out.
+    job.next_run_at = datetime.now(UTC)
+    await ops._store.save(job)
+    return job.id
+
+
+async def test_pause_racing_a_reservation_does_not_revert_it(tmp_path: Path) -> None:
+    """The exact reproduction: Task A reads the job for pause() while Task B's
+    atomic reserve_due_job lands in the gap before A's save()."""
+    store, ops = await _open_ops(tmp_path)
+    try:
+        job_id = await _add_due_job(ops)
+
+        # Task A: read the job the way ops.pause() does, before its save().
+        job = await store.get(job_id)
+        assert job is not None
+
+        # Task B: an unrelated atomic reservation lands in the gap.
+        now = datetime.now(UTC)
+        reservation = await store.reserve_due_job(job_id, now)
+        assert isinstance(reservation, JobReservation)
+
+        # Task A finishes: ops.pause() mutates status and saves.
+        job.status = JobStatus.PAUSED
+        job.updated_at = now
+        await store.save_preserving_reservation(job)
+
+        after = await store.get(job_id)
+        assert after is not None
+        assert after.status == JobStatus.PAUSED
+        assert after.reservation_token == reservation.token
+        assert after.reserved_by == reservation.reserved_by
+        assert after.reservation_source == reservation.reservation_source
+        assert after.reserved_at is not None
+    finally:
+        await store.close()
+
+
+async def test_resume_racing_a_reservation_does_not_revert_it(tmp_path: Path) -> None:
+    """reserve_due_job only claims a PENDING job, so the realistic race is a
+    (redundant) resume() on a job that is already PENDING, landing against a
+    concurrent reservation of that same job — not a resume of a job that is
+    still PAUSED in the database, which reserve_due_job would refuse anyway."""
+    store, ops = await _open_ops(tmp_path)
+    try:
+        job_id = await _add_due_job(ops)
+
+        job = await store.get(job_id)
+        assert job is not None
+        assert job.status == JobStatus.PENDING
+
+        now = datetime.now(UTC)
+        reservation = await store.reserve_due_job(job_id, now)
+        assert isinstance(reservation, JobReservation)
+
+        # ops.resume()'s own mutation, applied to the pre-reservation snapshot.
+        job.status = JobStatus.PENDING
+        job.updated_at = now
+        await store.save_preserving_reservation(job)
+
+        after = await store.get(job_id)
+        assert after is not None
+        assert after.reservation_token == reservation.token
+    finally:
+        await store.close()
+
+
+async def test_update_racing_a_reservation_does_not_revert_it(tmp_path: Path) -> None:
+    store, ops = await _open_ops(tmp_path)
+    try:
+        job_id = await _add_due_job(ops)
+
+        job = await store.get(job_id)
+        assert job is not None
+
+        now = datetime.now(UTC)
+        reservation = await store.reserve_due_job(job_id, now)
+        assert isinstance(reservation, JobReservation)
+
+        job.name = "renamed-mid-flight"
+        job.updated_at = now
+        await store.save_preserving_reservation(job)
+
+        after = await store.get(job_id)
+        assert after is not None
+        assert after.name == "renamed-mid-flight"
+        assert after.reservation_token == reservation.token
+    finally:
+        await store.close()
+
+
+async def test_execution_result_is_not_dropped_after_a_racing_pause(tmp_path: Path) -> None:
+    """End-to-end: the in-flight run's result must still apply after a
+    concurrent pause() that raced its reservation, instead of being silently
+    discarded by apply_reserved_result's token mismatch check."""
+    store, ops = await _open_ops(tmp_path)
+    try:
+        job_id = await _add_due_job(ops)
+        now = datetime.now(UTC)
+        reservation = await store.reserve_due_job(job_id, now)
+        assert isinstance(reservation, JobReservation)
+
+        # An unrelated pause() call races the in-flight run.
+        await ops.pause(job_id)
+
+        # The run started under `reservation` finishes and reports its result.
+        execution = JobExecution(
+            id="run-1",
+            job_id=job_id,
+            started_at=now,
+            finished_at=datetime.now(UTC),
+            success=True,
+        )
+        applied = await apply_reserved_result(job_id, reservation.token, execution, store)
+
+        assert applied is True
+        after = await store.get(job_id)
+        assert after is not None
+        # apply_reserved_result's own PAUSED handling clears the reservation
+        # once it can see the token it expects, rather than dropping the
+        # result because the token had already been wiped out from under it.
+        assert after.reservation_token == ""
+        assert after.status == JobStatus.PAUSED
+    finally:
+        await store.close()
+
+
+async def test_a_second_reservation_is_still_refused_after_a_racing_pause(
+    tmp_path: Path,
+) -> None:
+    """The job must stay reserved (busy) from the scheduler's perspective —
+    a racing pause() must not un-reserve it and let a second tick claim it
+    while the first run is still in flight."""
+    store, ops = await _open_ops(tmp_path)
+    try:
+        job_id = await _add_due_job(ops)
+        now = datetime.now(UTC)
+        first = await store.reserve_due_job(job_id, now)
+        assert isinstance(first, JobReservation)
+
+        await ops.pause(job_id)
+
+        second = await store.reserve_due_job(job_id, now)
+        assert not isinstance(second, JobReservation)
+    finally:
+        await store.close()
+
+
+async def test_release_reservation_still_writes_the_reservation_columns(
+    tmp_path: Path,
+) -> None:
+    """The reservation protocol's own writers (release_reservation) must be
+    unaffected -- they go through save(), not save_preserving_reservation."""
+    store, ops = await _open_ops(tmp_path)
+    try:
+        job_id = await _add_due_job(ops)
+        now = datetime.now(UTC)
+        reservation = await store.reserve_due_job(job_id, now)
+        assert isinstance(reservation, JobReservation)
+
+        released = await store.release_reservation(job_id, reservation.token)
+
+        assert released is True
+        after = await store.get(job_id)
+        assert after is not None
+        assert after.reservation_token == ""
+    finally:
+        await store.close()


### PR DESCRIPTION
Summary
ops.update, .pause and .resume each do get(job_id) → mutate a field or two → save(job), with no lock spanning the read+write pair
_execute_save is a full-column upsert that writes reservation_token=excluded.reservation_token (and reserved_at, reserved_by, reservation_source) unconditionally
If reserve_due_job's atomic UPDATE claims the job in the gap between one of those callers' get() and save(), the subsequent save() silently reverts the reservation back to the pre-reservation snapshot the caller's get() captured
Both consequences from the report follow, and both are silent: apply_reserved_result later sees a reservation_token it no longer recognizes and discards the execution result with no error, and the row now looks unreserved, so the next tick can reserve and run the same job again while the first run is still in flight
The reservation columns are owned by the reservation protocol (reserve_due_job / release_reservation / finalize_reserved_missing_handler), not by ops
Added JobStore.save_preserving_reservation, a field-scoped UPDATE that writes every column except the reservation quartet, and switched update/pause/resume to it
A lock around the read+write pair was the other option on the table, but reserve_due_job is deliberately lock-free, so a lock would only help callers that took it — this closes the gap for every caller instead
Fixes #1537 

Test plan
 Added test_reservation_preserved_across_ops_save.py: the exact pause/reservation race from the issue, plus the analogous update and resume races
 End-to-end check: a racing pause no longer causes apply_reserved_result to discard the execution result, and the existing PAUSED-status handling in jobs.py correctly clears the reservation once it can see the token
 Check that the job stays correctly "busy" so a second reservation is refused after a racing pause (no double-fire)
 Control test confirming release_reservation — the reservation protocol's own writer — is unaffected
 Verified the race-reproduction tests actually catch the bug: temporarily swapped save_preserving_reservation for plain save() in a throwaway copy and confirmed 3 of 6 tests fail against the old behavior, then reran against the fix to confirm all pass
 uv run pytest tests/test_scheduler tests/test_tools/test_cron_tool_update_clone.py tests/test_gateway -k cron -q — 261 passed
 uv run ruff check / uv run mypy clean on changed files