### PR TITLE
fix(channels): read stdin via a thread on Windows, not connect_read_pipe

### DIFF
--- a/src/agentos/channels/terminal.py
+++ b/src/agentos/channels/terminal.py
@@ -32,11 +32,30 @@ class TerminalChannel:
                 self._reader = reader
             return self._reader
 
-    async def receive(self) -> IncomingMessage:
-        """Read one line from stdin and return as IncomingMessage."""
+    async def _readline(self) -> str:
+        """One line of stdin, decoded and stripped of its trailing newline.
+
+        ``loop.connect_read_pipe`` registers ``sys.stdin`` with the event
+        loop's I/O multiplexer. On Windows, the default ``ProactorEventLoop``
+        does that via IOCP, which requires an overlapped-capable handle — an
+        interactive console handle is not one, so the registration raises
+        ``OSError: [WinError 6] The handle is invalid`` and permanently
+        breaks the reader. ``send``/``edit`` in this same class already avoid
+        touching the loop's I/O machinery for stdio by running the blocking
+        call in a thread; reading stdin the same way sidesteps IOCP
+        registration entirely.
+        """
+        if sys.platform == "win32":
+            loop = asyncio.get_running_loop()
+            line: str = await loop.run_in_executor(None, sys.stdin.readline)
+            return line.rstrip("\n")
         reader = await self._get_reader()
         line_bytes = await reader.readline()
-        content = line_bytes.decode(errors="replace").rstrip("\n")
+        return line_bytes.decode(errors="replace").rstrip("\n")
+
+    async def receive(self) -> IncomingMessage:
+        """Read one line from stdin and return as IncomingMessage."""
+        content = await self._readline()
         log.debug("terminal.receive", content=content[:80])
         return IncomingMessage(
             sender_id=self.sender_id,

--- a/tests/test_channels/test_terminal_channel.py
+++ b/tests/test_channels/test_terminal_channel.py
@@ -1,0 +1,98 @@
+"""TerminalChannel.receive() on Windows vs POSIX.
+
+Issue #1575: TerminalChannel._get_reader called loop.connect_read_pipe on
+sys.stdin, which the default Windows ProactorEventLoop tries to register
+with IOCP. An interactive console handle is not overlapped-capable, so that
+registration raised OSError: [WinError 6] The handle is invalid and
+permanently broke the reader. Windows now reads stdin via
+loop.run_in_executor(None, sys.stdin.readline) instead, the same pattern
+send()/edit() in this class already use for stdout.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from agentos.channels.terminal import TerminalChannel
+
+
+class _FakeStreamReader:
+    """Stand-in for the asyncio.StreamReader the POSIX path would build."""
+
+    def __init__(self, lines: list[bytes]) -> None:
+        self._lines = list(lines)
+
+    async def readline(self) -> bytes:
+        if not self._lines:
+            return b""
+        return self._lines.pop(0)
+
+
+@pytest.mark.asyncio
+async def test_receive_uses_executor_readline_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The Windows path must never touch connect_read_pipe / _get_reader —
+    that is exactly the call that raises WinError 6."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    lines = iter(["hello world\n", "second line\n"])
+
+    class _FakeStdin:
+        def readline(self) -> str:
+            return next(lines)
+
+    monkeypatch.setattr(sys, "stdin", _FakeStdin())
+    channel = TerminalChannel()
+
+    async def _get_reader_should_not_be_called() -> _FakeStreamReader:
+        raise AssertionError("_get_reader (connect_read_pipe) must not run on Windows")
+
+    monkeypatch.setattr(channel, "_get_reader", _get_reader_should_not_be_called)
+
+    first = await channel.receive()
+    second = await channel.receive()
+
+    assert first.content == "hello world"
+    assert second.content == "second line"
+    assert first.sender_id == "user"
+    assert first.channel_id == "terminal"
+
+
+@pytest.mark.asyncio
+async def test_receive_reports_eof_as_empty_content_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    class _EofStdin:
+        def readline(self) -> str:
+            return ""
+
+    monkeypatch.setattr(sys, "stdin", _EofStdin())
+    channel = TerminalChannel()
+
+    message = await channel.receive()
+
+    assert message.content == ""
+
+
+@pytest.mark.asyncio
+async def test_receive_still_uses_the_stream_reader_off_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-Windows platforms keep the original connect_read_pipe-backed
+    reader — this fix is additive, not a platform-wide behavior change."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    channel = TerminalChannel()
+    fake_reader = _FakeStreamReader([b"posix line\n"])
+
+    async def _fake_get_reader() -> _FakeStreamReader:
+        return fake_reader
+
+    monkeypatch.setattr(channel, "_get_reader", _fake_get_reader)
+
+    message = await channel.receive()
+
+    assert message.content == "posix line"


### PR DESCRIPTION
Summary
TerminalChannel._get_reader called loop.connect_read_pipe on sys.stdin to build an asyncio.StreamReader
On Windows, the default ProactorEventLoop registers that handle with IOCP, which requires an overlapped-capable handle — an interactive console handle is not one, so the registration raised OSError: [WinError 6] The handle is invalid and permanently broke the reader on every receive() call
send()/edit() in this same class already avoid touching the loop's I/O machinery for stdio, running the blocking write in a thread via run_in_executor — receive() now does the same for reads on Windows: loop.run_in_executor(None, sys.stdin.readline), sidestepping IOCP registration entirely
Non-Windows platforms are unchanged — still the connect_read_pipe-backed StreamReader
Scope note: TerminalChannel currently has no consumers and isn't wired into discover_all(), so nothing exercises this path today — but it's public API (agentos.channels.TerminalChannel) an embedder or plugin may construct directly, and a class that can't run on a supported platform shouldn't ship broken
Fixes #1575 

Test plan
 Verified live on a real Windows process with piped stdin: two lines read correctly, EOF returns empty content — no crash, matching the POSIX reader's behavior
 Added tests/test_channels/test_terminal_channel.py (no prior coverage existed): the Windows path never touches _get_reader/connect_read_pipe (the exact call that crashes), EOF is reported as empty content, and non-Windows platforms are confirmed unaffected (still routed through the StreamReader path)
 uv run pytest tests/test_channels -q — 498 passed
 uv run ruff check / uv run mypy clean on changed files (fixed one no-any-return finding — run_in_executor's return type isn't inferred through its generic signature)