### PR TITLE
fix(channels): stop email replies from falling back to reply_to as an…

### DIFF
--- a/src/agentos/channels/email.py
+++ b/src/agentos/channels/email.py
@@ -780,16 +780,25 @@ class EmailChannel:
         reply_to = (message.reply_to or "").strip()
         thread = self._threads.get(reply_to)
         metadata = message.metadata or {}
-        # The message tool writes "recipient", channel replies write "to", and
-        # scheduler/heartbeat delivery sends the bare address as reply_to, so
-        # every producer has to be able to name the mailbox.
+        # The message tool writes "recipient", channel replies write "to".
+        # ``reply_to`` here names a *thread* (an inbound Message-ID, tracked
+        # in self._threads) -- it must never be treated as a mailbox itself.
+        # A Message-ID is syntactically indistinguishable from an address
+        # (RFC 5322 gives both a local@domain shape), and its domain is
+        # chosen by whoever sent the original mail: falling back to
+        # "reply_to looks like an address" used to mean a thread that aged
+        # out of self._threads (LRU eviction, or any process restart --
+        # the cache is in-memory only) silently redirected the reply to
+        # whatever domain the original sender's Message-ID happened to
+        # carry, which they control.
         to_address = str(
             metadata.get("to") or metadata.get("recipient") or (thread.to_address if thread else "")
         ).strip()
-        if not to_address and is_email_address(reply_to):
-            to_address = normalize_address(reply_to)
         if not to_address:
-            raise ValueError("email.send has no recipient for reply_to")
+            raise ValueError(
+                "email.send has no recipient for reply_to "
+                f"{reply_to!r}: no known thread and no explicit to/recipient"
+            )
         subject = str(metadata.get("subject") or "").strip()
         if not subject:
             subject = reply_subject(thread.subject) if thread else _DEFAULT_OUTBOUND_SUBJECT

--- a/tests/test_channels/test_email_channel.py
+++ b/tests/test_channels/test_email_channel.py
@@ -534,23 +534,67 @@ async def test_send_resolves_the_recipient_from_metadata_recipient(
     assert sent[0].get("In-Reply-To") is None
 
 
-async def test_send_resolves_the_recipient_from_reply_to_address(
+async def test_send_refuses_a_bare_reply_to_even_when_it_looks_like_an_address(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Scheduler and heartbeat delivery pass the address as ``reply_to`` alone."""
+    """Issue #1570: ``reply_to`` names a *thread* (an inbound Message-ID),
+    never a mailbox by itself. A Message-ID has the same local@domain shape
+    as a real address, and its domain is chosen by whoever sent the original
+    mail — silently treating an unknown ``reply_to`` as an address (the old
+    behavior) meant a thread that aged out of the in-memory cache (LRU
+    eviction, or any process restart) redirected the reply to whatever
+    domain the original sender's Message-ID happened to carry.
+
+    A caller that actually knows the recipient (scheduler/heartbeat
+    delivery, the message tool) must say so explicitly via
+    ``metadata["to"]``/``["recipient"]``; there is no address-shaped
+    ``reply_to`` that is safe to trust on its own.
+    """
 
     channel = EmailChannel(config=_config())
     sent: list[EmailMessage] = []
     monkeypatch.setattr(channel, "_smtp_send", sent.append)
 
-    await channel.send(OutgoingMessage(content="alert", reply_to="alerts@example.com"))
+    with pytest.raises(ValueError, match="no recipient"):
+        await channel.send(
+            OutgoingMessage(content="alert", reply_to="attacker-chosen@evil.example")
+        )
 
-    assert sent[0]["To"] == "alerts@example.com"
-    assert sent[0].get_content().strip() == "alert"
+    assert sent == []
+
+
+async def test_send_does_not_leak_a_reply_to_an_attacker_domain_after_thread_eviction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #1570's exact reproduction: an inbound mail's Message-ID can
+    name any domain the sender likes. Once its thread ages out of the
+    in-memory cache (LRU eviction, or a process restart), a later reply must
+    not be silently redirected there."""
+
+    channel = EmailChannel(config=_config())
+    inbound = channel._to_incoming(
+        _raw(sender="owner@example.com", message_id="CAGr5Gg=xyz@attacker.example")
+    )
+    assert inbound is not None
+    assert inbound.channel_id == "CAGr5Gg=xyz@attacker.example"
+
+    # Simulate the thread aging out of the cache (LRU eviction or restart).
+    channel._threads.clear()
+
+    sent: list[EmailMessage] = []
+    monkeypatch.setattr(channel, "_smtp_send", sent.append)
+
+    with pytest.raises(ValueError, match="no recipient"):
+        await channel.send(
+            OutgoingMessage(content="Hello", reply_to="CAGr5Gg=xyz@attacker.example")
+        )
+
+    assert sent == []
 
 
 async def test_send_recipient_resolution_precedence(monkeypatch: pytest.MonkeyPatch) -> None:
-    """``to`` beats ``recipient`` beats the thread cache beats ``reply_to``."""
+    """``to`` beats ``recipient`` beats the thread cache; an unknown
+    ``reply_to`` with neither has nowhere left to fall back to."""
 
     channel = EmailChannel(config=_config())
     assert channel._to_incoming(_raw()) is not None
@@ -572,14 +616,15 @@ async def test_send_recipient_resolution_precedence(monkeypatch: pytest.MonkeyPa
         )
     )
     await channel.send(OutgoingMessage(content="x", reply_to="m1@example.com"))
-    await channel.send(OutgoingMessage(content="x", reply_to="fourth@example.com"))
 
     assert [m["To"] for m in sent] == [
         "first@example.com",
         "second@example.com",
         "owner@example.com",
-        "fourth@example.com",
     ]
+
+    with pytest.raises(ValueError, match="no recipient"):
+        await channel.send(OutgoingMessage(content="x", reply_to="fourth@example.com"))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION

Summary
EmailChannel._resolve_target fell back to treating reply_to as a raw mailbox (via is_email_address) whenever the thread it named was unknown
reply_to always names a thread — the inbound Message-ID — never a mailbox by itself, but a Message-ID has the same local@domain shape as a real address, and its domain is chosen by whoever sent the original mail
self._threads is an in-memory, LRU-bounded cache that is empty after any process restart, so once a thread aged out, the fallback silently redirected the reply to whatever domain the original sender's Message-ID happened to carry — a mailbox they control
A smarter is_email_address cannot fix this: a Message-ID is genuinely indistinguishable from an address by shape
Removed the fallback entirely; _resolve_target now raises when the thread is unknown and no explicit metadata["to"]/["recipient"] is present, converting a silent misdelivery into a loud, actionable failure
Checked every real producer that relies on reply_to alone for email (scheduler/heartbeat delivery, artifact_delivery.py's send_file calls) — they all pass an existing channel_id, i.e. a thread the cache is expected to still know about, and none has a legitimate case for reply_to ever meaning a fresh, unseen mailbox. The message tool already supplies metadata["recipient"] unconditionally, so it was never relying on the fallback either
Two existing tests encoded the old (vulnerable) contract as intended behavior — one literally docstringed "scheduler and heartbeat delivery pass the address as reply_to alone" — and needed updating to the corrected one
Fixes #1570 

Test plan
 Added a direct security regression test reproducing the issue's exact steps: receive an inbound email whose Message-ID carries an attacker-controlled domain, evict the thread cache (simulating LRU eviction or a restart), attempt the reply, confirm it's refused rather than misdelivered
 Added a general "unknown reply_to that looks like an address" test
 Updated the two existing tests that had encoded the vulnerable fallback as expected behavior, to the corrected precedence chain (to > recipient > known thread, with a clear error when none apply)
 uv run pytest tests/test_channels/test_email_channel.py -q — 85 passed
 uv run pytest tests/test_channels tests/test_gateway -q — 1948 passed, 1 skipped (full suite, unrelated to this change)
 uv run ruff check / uv run mypy clean on changed files