### PR TITLE
fix(tools): fix background process multibyte UTF-8 output corruption

### DIFF
--- a/src/agentos/tools/builtin/shell.py
+++ b/src/agentos/tools/builtin/shell.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import codecs
 import contextlib
 import contextvars
 import json
@@ -567,8 +568,12 @@ async def _read_bg_output(session: _BgSession) -> None:
     stdout = session.process.stdout
     if stdout is None:
         return
+    decoder = codecs.getincrementaldecoder("utf-8")("replace")
     while chunk := await stdout.read(4096):
-        _append_bg_output(session, chunk.decode("utf-8", errors="replace"))
+        if decoded := decoder.decode(chunk):
+            _append_bg_output(session, decoded)
+    if final := decoder.decode(b"", final=True):
+        _append_bg_output(session, final)
 
 
 def _append_bg_output(session: _BgSession, output: str) -> None:


### PR DESCRIPTION
Fixes #1547.

This PR fixes an issue where background processes emitting multi-byte UTF-8 characters (like CJK or emojis) were being corrupted when their byte sequences happened to straddle the 4096-byte `stdout.read` chunk boundaries. 

The implementation now uses `codecs.getincrementaldecoder("utf-8")("replace")` per session instead of decoding individual byte chunks directly. This properly buffers incomplete byte sequences until the next chunk arrives, ensuring all multi-byte characters are faithfully reconstructed. The decoder is correctly flushed with `final=True` at EOF to guarantee no trailing characters are lost.
