### PR TITLE
fix(git): resolve a relative workdir against the workspace directory

### DIFF
--- a/src/agentos/tools/builtin/git.py
+++ b/src/agentos/tools/builtin/git.py
@@ -24,7 +24,15 @@ def _effective_workdir(workdir: str | None) -> str | None:
             else None
         )
         reject_foreign_host_path(workdir, platform=os.name, workspace=workspace)
-        return workdir
+        # A relative workdir must be joined onto the workspace, mirroring
+        # ``shell._effective_workdir``. Returning it raw made ``_run_git``
+        # resolve it against the process CWD instead — inspecting a different
+        # repository than the caller asked for when the gateway runs anywhere
+        # but the workspace (#1566).
+        raw = Path(workdir).expanduser()
+        if not raw.is_absolute() and ctx and ctx.workspace_dir:
+            return str((Path(ctx.workspace_dir).expanduser().resolve() / raw).resolve())
+        return str(raw.resolve())
     if ctx and ctx.workspace_dir:
         return str(Path(ctx.workspace_dir).expanduser().resolve())
     return None

--- a/tests/test_tools/test_git_workdir_policy.py
+++ b/tests/test_tools/test_git_workdir_policy.py
@@ -20,6 +20,57 @@ def test_git_effective_workdir_resolves_context_workspace(tmp_path: Path) -> Non
         current_tool_context.reset(token)
 
 
+def test_git_effective_workdir_joins_relative_path_onto_workspace(
+    tmp_path: Path,
+) -> None:
+    """A relative workdir resolves against the workspace, not the process CWD.
+
+    Regression for #1566: returning the raw string made ``_run_git`` resolve it
+    against the process CWD, so ``git_status(workdir="sub")`` inspected
+    ``$PWD/sub`` — possibly a different repository — whenever the gateway ran
+    from anywhere but the workspace.
+    """
+    workspace = tmp_path / "workspace"
+    subproject = workspace / "my-subproject"
+    subproject.mkdir(parents=True)
+
+    token = current_tool_context.set(ToolContext(workspace_dir=str(workspace)))
+    try:
+        assert git._effective_workdir("my-subproject") == str(subproject.resolve())
+    finally:
+        current_tool_context.reset(token)
+
+
+def test_git_effective_workdir_keeps_absolute_path_outside_workspace(
+    tmp_path: Path,
+) -> None:
+    """An absolute workdir is resolved as-is, not re-anchored to the workspace."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    other = tmp_path / "elsewhere"
+    other.mkdir()
+
+    token = current_tool_context.set(ToolContext(workspace_dir=str(workspace)))
+    try:
+        assert git._effective_workdir(str(other)) == str(other.resolve())
+    finally:
+        current_tool_context.reset(token)
+
+
+def test_git_effective_workdir_dotdot_stays_inside_resolved_workspace(
+    tmp_path: Path,
+) -> None:
+    """Lexical traversal is resolved, keeping the containment check honest."""
+    workspace = tmp_path / "workspace"
+    (workspace / "nested").mkdir(parents=True)
+
+    token = current_tool_context.set(ToolContext(workspace_dir=str(workspace)))
+    try:
+        assert git._effective_workdir("nested/../nested") == str((workspace / "nested").resolve())
+    finally:
+        current_tool_context.reset(token)
+
+
 def test_git_effective_workdir_rejects_foreign_posix_absolute_path_on_windows(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Closes #1566

## Problem

`git._effective_workdir` returned a relative `workdir` **unresolved**, so `_run_git` went on to resolve it against the **process CWD** in both execution modes (`git.py:65-67` and `git.py:96-103`). When the gateway or daemon runs from anywhere but the workspace, `git_status(workdir="my-subproject")` inspects `$PWD/my-subproject` — which may not exist, or may be a *different repository* whose output is returned as if it were the workspace's. The sandbox path also derives `build_policy(..., workspace, ...)` from that same wrong value.

## Fix

Mirror the reference implementation the triage points to, `shell._effective_workdir` (`shell.py:449-459`):

```python
raw = Path(workdir).expanduser()
if not raw.is_absolute() and ctx and ctx.workspace_dir:
    return str((Path(ctx.workspace_dir).expanduser().resolve() / raw).resolve())
return str(raw.resolve())
```

- a relative path is joined onto `ctx.workspace_dir` and resolved lexically;
- an absolute path is resolved as-is (unchanged behaviour);
- `reject_foreign_host_path` still runs first, with the same workspace argument.

## Verification

- New regression tests in `tests/test_tools/test_git_workdir_policy.py`: the relative join, an absolute path outside the workspace kept as-is, and `..` traversal resolved lexically.
- End-to-end check with two same-named repositories — a decoy next to the process CWD and the real one under the workspace — resolves to the workspace repo (fails on `main`).
- `uv run pytest tests/test_tools/test_git_workdir_policy.py -q` — 14 passed.
- `uv run pytest tests/test_engine/test_router_control.py tests/test_gateway/test_rpc_router_hold.py -q` — 49 passed.
- `uv run ruff check` and `uv run mypy` clean on the touched files.

Note: the same root cause is tracked separately at #1595 and #1510; this PR intentionally fixes only the `git` site.