### PR TITLE
fix(tools): recognize more null-schema shapes when collapsing nullable unions

### DIFF
--- a/src/agentos/tools/schema_sanitize.py
+++ b/src/agentos/tools/schema_sanitize.py
@@ -46,7 +46,24 @@ _SCHEMA_LIST_KEYS = ("allOf", "anyOf", "oneOf", "prefixItems")
 
 
 def _is_null_schema(node: Any) -> bool:
-    return isinstance(node, Mapping) and node.get("type") == "null"
+    if not isinstance(node, Mapping):
+        return False
+    if "type" in node:
+        node_type = node["type"]
+        if node_type is None or node_type == "null":
+            return True
+        if (
+            isinstance(node_type, (list, tuple))
+            and node_type
+            and all(t in ("null", None) for t in node_type)
+        ):
+            return True
+    if "const" in node and node["const"] is None:
+        return True
+    enum_val = node.get("enum")
+    if isinstance(enum_val, (list, tuple)) and len(enum_val) == 1 and enum_val[0] is None:
+        return True
+    return False
 
 
 def _collect_defs(schema: Mapping[str, Any]) -> dict[str, Any]:
@@ -132,7 +149,7 @@ def _sanitize_node(
             continue
 
         if key == "type" and isinstance(value, list):
-            concrete = [entry for entry in value if entry != "null"]
+            concrete = [entry for entry in value if entry not in ("null", None)]
             out["type"] = concrete[0] if concrete else "string"
             fixes.append("collapsed_type_array")
             continue

--- a/tests/test_tools/test_schema_sanitize.py
+++ b/tests/test_tools/test_schema_sanitize.py
@@ -41,6 +41,82 @@ def test_nullable_union_collapses_to_the_concrete_branch() -> None:
     assert "collapsed_nullable_union" in fixes
 
 
+def test_nullable_union_collapses_when_null_branch_uses_a_type_list() -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "filter": {"anyOf": [{"type": "string"}, {"type": ["null"]}]},
+        },
+    }
+
+    cleaned, fixes = sanitize_input_schema(schema)
+
+    assert cleaned["properties"]["filter"] == {"type": "string"}
+    assert "collapsed_nullable_union" in fixes
+
+
+def test_nullable_union_collapses_when_null_branch_has_type_none() -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "filter": {"anyOf": [{"type": "string"}, {"type": None}]},
+        },
+    }
+
+    cleaned, fixes = sanitize_input_schema(schema)
+
+    assert cleaned["properties"]["filter"] == {"type": "string"}
+    assert "collapsed_nullable_union" in fixes
+
+
+def test_nullable_union_collapses_when_null_branch_is_a_const_null() -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "filter": {"anyOf": [{"type": "string"}, {"const": None}]},
+        },
+    }
+
+    cleaned, fixes = sanitize_input_schema(schema)
+
+    assert cleaned["properties"]["filter"] == {"type": "string"}
+    assert "collapsed_nullable_union" in fixes
+
+
+def test_nullable_union_collapses_when_null_branch_is_an_enum_of_null() -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "filter": {"anyOf": [{"type": "string"}, {"enum": [None]}]},
+        },
+    }
+
+    cleaned, fixes = sanitize_input_schema(schema)
+
+    assert cleaned["properties"]["filter"] == {"type": "string"}
+    assert "collapsed_nullable_union" in fixes
+
+
+def test_nullable_oneof_union_collapses_to_concrete_branch() -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "filter": {
+                "oneOf": [{"type": "string"}, {"type": ["null"]}],
+                "description": "Filter query.",
+            },
+        },
+    }
+
+    cleaned, fixes = sanitize_input_schema(schema)
+
+    assert cleaned["properties"]["filter"] == {
+        "type": "string",
+        "description": "Filter query.",
+    }
+    assert "collapsed_nullable_union" in fixes
+
+
 def test_union_with_two_real_branches_is_left_alone() -> None:
     schema = {
         "type": "object",


### PR DESCRIPTION
Expand `_is_null_schema` to recognize alternate null schema representations and correctly collapse nullable `anyOf` and `oneOf` unions to single concrete types.

### Problem
`_is_null_schema` previously only tested for `node.get("type") == "null"`. Alternate representations of null in JSON Schemas—such as:
- `{"type": ["null"]}`
- `{"type": None}`
- `{"const": None}`
- `{"enum": [None]}`

were not recognized as null branches. As a result:
- `{'const': None}` and `{'enum': [None]}` were left uncollapsed inside `anyOf` / `oneOf` blocks.
- `{'type': ['null']}` was subsequently normalized by `collapsed_type_array` into `{'type': 'string'}`, creating duplicate identical branches (`{'anyOf': [{'type': 'string'}, {'type': 'string'}]}`).
- Providers that reject `anyOf`/`oneOf` constructs (such as Anthropic) failed when receiving these uncollapsed unions.

### Changes
- Updated `_is_null_schema` in [schema_sanitize.py](file:///c:/Users/Administrator/.antigravity-ide/agent-os/src/agentos/tools/schema_sanitize.py) to identify:
  - `type` as `"null"`, `None`, or a list containing only `"null"`/`None`.
  - `const` equal to `None`.
  - `enum` containing a single `None` entry.
- Updated `collapsed_type_array` normalization to filter out `None` alongside `"null"`.
- Added regression tests in [test_schema_sanitize.py](file:///c:/Users/Administrator/.antigravity-ide/agent-os/tests/test_tools/test_schema_sanitize.py) verifying union collapsing for:
  - `type: ["null"]`
  - `type: None`
  - `const: None`
  - `enum: [None]`
  - `oneOf` unions with null branches and preserved sibling annotations.

Fixes #1573
