### PR TITLE
fix(cron): clamp cron.runs' limit before it reaches the raw SQL LIMIT

### DIFF
--- a/src/agentos/gateway/rpc_cron.py
+++ b/src/agentos/gateway/rpc_cron.py
@@ -496,6 +496,21 @@ def _ensure_delivery_supported(
 #: provider must not hold up the form.
 _TARGET_PROBE_TIMEOUT_SECONDS = 10.0
 
+#: Ceiling for ``cron.runs``' ``limit`` param, which reaches a raw SQL
+#: ``LIMIT ?`` (persistence.py's ``list_executions``) unclamped otherwise.
+#: SQLite treats a negative ``LIMIT`` as "no limit", so an unvalidated
+#: negative value returns a job's entire run history in one response instead
+#: of the bounded preview the run-history drawer expects.
+_MAX_CRON_RUNS_LIMIT = 1000
+
+
+def _coerce_cron_runs_limit(raw: Any, *, default: int = 20) -> int:
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return default
+    return min(max(1, value), _MAX_CRON_RUNS_LIMIT)
+
 
 def _delivery_target_pairs(delivery_raw: Any) -> list[tuple[str, str]]:
     """The (channel, recipient) pairs a delivery block asks us to send to.
@@ -1103,7 +1118,7 @@ async def _handle_cron_runs(params: dict | None, ctx: RpcContext) -> list[dict]:
     job_id = params.get("id") or params.get("job_id")
     if not job_id:
         raise ValueError("params.id is required")
-    limit = params.get("limit", 20)
+    limit = _coerce_cron_runs_limit(params.get("limit", 20))
     scheduler = getattr(ctx, "cron_scheduler", None)
     if scheduler is None:
         return []

--- a/tests/test_gateway/test_rpc_cron_runs_limit.py
+++ b/tests/test_gateway/test_rpc_cron_runs_limit.py
@@ -1,0 +1,81 @@
+"""``cron.runs``' ``limit`` param must never reach the store unclamped.
+
+``persistence.list_executions`` passes ``limit`` straight into a raw SQL
+``LIMIT ?``. SQLite reads a negative ``LIMIT`` as "no limit at all" (the same
+footgun ``mcp_server/bridge.py``'s ``_clamp_limit`` already guards against for
+session listings), so an unvalidated negative or absurdly large value would
+return a job's entire run history in one response instead of the bounded
+preview the run-history drawer expects.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agentos.gateway.rpc import RpcContext
+from agentos.gateway.rpc_cron import _MAX_CRON_RUNS_LIMIT, _handle_cron_runs
+from agentos.scheduler.types import JobExecution
+
+
+class _RecordingScheduler:
+    """Records the ``limit`` it actually receives instead of executing a query."""
+
+    def __init__(self) -> None:
+        self.received_limit: int | None = None
+
+    async def get_runs(self, job_id: str, limit: int = 20) -> list[JobExecution]:
+        self.received_limit = limit
+        return []
+
+
+def _ctx(scheduler: Any) -> RpcContext:
+    ctx = RpcContext(conn_id="test", session_manager=None)
+    ctx.cron_scheduler = scheduler  # type: ignore[attr-defined]
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_negative_limit_is_clamped_to_one_not_passed_through() -> None:
+    scheduler = _RecordingScheduler()
+
+    await _handle_cron_runs({"id": "job-1", "limit": -1}, _ctx(scheduler))
+
+    assert scheduler.received_limit == 1
+
+
+@pytest.mark.asyncio
+async def test_oversized_limit_is_capped() -> None:
+    scheduler = _RecordingScheduler()
+
+    await _handle_cron_runs({"id": "job-1", "limit": 10_000_000}, _ctx(scheduler))
+
+    assert scheduler.received_limit == _MAX_CRON_RUNS_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_non_numeric_limit_falls_back_to_the_default() -> None:
+    scheduler = _RecordingScheduler()
+
+    await _handle_cron_runs({"id": "job-1", "limit": "not-a-number"}, _ctx(scheduler))
+
+    assert scheduler.received_limit == 20
+
+
+@pytest.mark.asyncio
+async def test_ordinary_limit_passes_through_unchanged() -> None:
+    scheduler = _RecordingScheduler()
+
+    await _handle_cron_runs({"id": "job-1", "limit": 5}, _ctx(scheduler))
+
+    assert scheduler.received_limit == 5
+
+
+@pytest.mark.asyncio
+async def test_omitted_limit_uses_the_default_of_twenty() -> None:
+    scheduler = _RecordingScheduler()
+
+    await _handle_cron_runs({"id": "job-1"}, _ctx(scheduler))
+
+    assert scheduler.received_limit == 20


### PR DESCRIPTION
## Linked issue

Fixes #1651

- [x] This pull request fully resolves the linked issue.

## Summary

`_handle_cron_runs` read `params.get("limit", 20)` and passed it straight through `scheduler.get_runs` → `persistence.list_executions`, which puts it directly into `"... ORDER BY started_at DESC LIMIT ?"` with no validation anywhere in the chain.

SQLite treats a negative `LIMIT` as "no limit at all" — the same footgun `mcp_server/bridge.py`'s `_clamp_limit` already guards against for session listings, with an explicit comment about it — so a negative limit (reachable from the CLI via `agentos cron runs <job> --limit -1`, or from any JSON-RPC client) returns a job's entire run history in one response instead of the bounded preview the run-history drawer expects. An absurdly large positive limit has the same unbounded effect.

Fixed by clamping to `[1, _MAX_CRON_RUNS_LIMIT]` at the RPC boundary, matching the existing `_clamp_limit` convention, with a default fallback for a non-numeric value.

## Tests

Added `tests/test_gateway/test_rpc_cron_runs_limit.py`: negative limit clamps to 1, oversized clamps to the ceiling, non-numeric falls back to the default, ordinary values pass through unchanged. Confirmed directly (not just via the constant's import failure) that the old code passed `-1` straight through to the scheduler unclamped.

    ruff check src/agentos/gateway/rpc_cron.py tests/test_gateway/test_rpc_cron_runs_limit.py   # All checks passed!
    mypy src/agentos/gateway/rpc_cron.py --show-error-codes   # Success: no issues found
    pytest tests/test_gateway tests/test_scheduler tests/test_tools/test_cron_tool_runs.py tests/test_tools/test_cron_tool_update_clone.py tests/test_tools/test_cron_tool_strict.py tests/test_cli/test_cron_cmd.py -q
    # 2066 passed, 2 pre-existing/unrelated failures (same on unmodified main)