### PR TITLE
fix(skills): support table cells in docx replace_text (#1653)

### DIFF
--- a/src/agentos/skills/bundled/docx/scripts/edit_docx.py
+++ b/src/agentos/skills/bundled/docx/scripts/edit_docx.py
@@ -75,9 +75,34 @@ def _replace_text_in_paragraph(para: Paragraph, find: str, replacement: str) -> 
     return True
 
 
+def _iter_all_paragraphs(doc: Document) -> list[Paragraph]:
+    paragraphs: list[Paragraph] = list(doc.paragraphs)
+    seen_tc: set[Any] = set()
+    for table in doc.tables:
+        paragraphs.extend(_iter_table_paragraphs(table, seen_tc))
+    return paragraphs
+
+
+def _iter_table_paragraphs(table: Any, seen_tc: set[Any]) -> list[Paragraph]:
+    paragraphs: list[Paragraph] = []
+    for row in table.rows:
+        for cell in row.cells:
+            tc = getattr(cell, "_tc", None)
+            if tc is not None:
+                if tc in seen_tc:
+                    continue
+                seen_tc.add(tc)
+            paragraphs.extend(cell.paragraphs)
+            for nested in getattr(cell, "tables", []):
+                paragraphs.extend(_iter_table_paragraphs(nested, seen_tc))
+    return paragraphs
+
+
 def apply_ops(doc: Document, ops: list[dict[str, Any]]) -> int:
     applied = 0
     for op in ops:
+        if not isinstance(op, dict):
+            continue
         kind = op.get("op")
         if kind == "replace_run":
             try:
@@ -91,7 +116,7 @@ def apply_ops(doc: Document, ops: list[dict[str, Any]]) -> int:
             replacement = str(op.get("with", ""))
             if not find:
                 continue
-            for para in doc.paragraphs:
+            for para in _iter_all_paragraphs(doc):
                 if _replace_text_in_paragraph(para, find, replacement):
                     applied += 1
     return applied

--- a/tests/test_skill_docx.py
+++ b/tests/test_skill_docx.py
@@ -257,3 +257,54 @@ def test_replace_run_still_touches_only_its_own_run() -> None:
     edit_docx._replace_run(paragraph, 1, "there")
 
     assert [(run.text, run.bold) for run in paragraph.runs] == [("Hello ", None), ("there", True)]
+
+
+def test_replace_text_in_tables(tmp_path: Path) -> None:
+    """replace_text must walk paragraphs in tables and preserve formatting."""
+    edit_docx = _edit_docx_module()
+    from docx import Document
+
+    doc = Document()
+    doc.add_paragraph("Agreement for {{CLIENT}}")
+
+    table = doc.add_table(rows=3, cols=2)
+    table.cell(0, 0).text = "Client Name:"
+    table.cell(0, 1).text = "{{CLIENT}}"
+
+    # Merged row for summary
+    merged_cell = table.cell(1, 0)
+    merged_cell.text = "Notes for {{CLIENT}}"
+    merged_cell.merge(table.cell(1, 1))
+
+    table.cell(2, 0).text = "Amount:"
+    table.cell(2, 1).text = "$5,000"
+
+    ops = [{"op": "replace_text", "find": "{{CLIENT}}", "with": "Acme Corp"}]
+    applied = edit_docx.apply_ops(doc, ops)
+
+    assert applied == 3
+    assert doc.paragraphs[0].text == "Agreement for Acme Corp"
+    assert table.cell(0, 1).text == "Acme Corp"
+    assert table.cell(1, 0).text == "Notes for Acme Corp"
+    assert table.cell(1, 1).text == "Notes for Acme Corp"
+    assert table.cell(2, 1).text == "$5,000"
+
+
+def test_apply_ops_handles_non_dict_elements() -> None:
+    """Malformed or non-dict items in ops must be safely skipped."""
+    edit_docx = _edit_docx_module()
+    from docx import Document
+
+    doc = Document()
+    doc.add_paragraph("Hello World")
+
+    ops = [
+        None,
+        "not-a-dict",
+        123,
+        [],
+        {"op": "replace_text", "find": "World", "with": "AgentOS"},
+    ]
+    applied = edit_docx.apply_ops(doc, ops)
+    assert applied == 1
+    assert doc.paragraphs[0].text == "Hello AgentOS"


### PR DESCRIPTION
## Summary

`edit_docx.py`'s `replace_text` operation walked only `doc.paragraphs` (body-level paragraphs), completely ignoring paragraphs inside tables (`doc.tables`):

```python
        elif kind == "replace_text":
            find = str(op.get("find", ""))
            replacement = str(op.get("with", ""))
            if not find:
                continue
            for para in doc.paragraphs:
                if _replace_text_in_paragraph(para, find, replacement):
                    applied += 1
```

In Word documents, contracts, reports, and invoices, placeholders and fields frequently live inside tables. Sibling scripts `inspect_docx.py` and `create_docx.py` treat tables as primary document structure. When an agent or user performed `replace_text` on such documents, table placeholders remained unreplaced and `applied` silently stayed `0`.

Additionally, if `ops` contained any non-dict entry (e.g. `None` or strings), `op.get("op")` raised an unhandled `AttributeError: 'NoneType' object has no attribute 'get'` instead of gracefully skipping it (unlike `edit_xlsx.py` which guards against non-dict items).

## Changes

**`src/agentos/skills/bundled/docx/scripts/edit_docx.py`** (+27/-2)
- Added `_iter_all_paragraphs(doc)` helper to walk `doc.paragraphs` and all cells in `doc.tables` (including nested tables).
- Tracked visited cell XML elements (`_tc`) so merged cells are not processed repeatedly.
- Added `if not isinstance(op, dict): continue` in `apply_ops` to safely ignore malformed/non-dict entries.

## Tests

**`tests/test_skill_docx.py`** (+51 lines)
- `test_replace_text_in_tables`: verifies `replace_text` successfully updates placeholders across body paragraphs and table cells, preserves table cell content, and handles merged cells cleanly without duplicate processing.
- `test_apply_ops_handles_non_dict_elements`: verifies malformed or non-dict items in `ops` are skipped without raising `AttributeError`.

## Status

- `uv run ruff check src/agentos/skills/bundled/docx tests/test_skill_docx.py` ✅
- `uv run ruff format --check src/agentos/skills/bundled/docx tests/test_skill_docx.py` ✅
- `uv run mypy src/agentos --show-error-codes` ✅ (625 source files, no issues)
- `uv run pytest tests/test_skill_docx.py -v` ✅ (21 passed)

Fixes #1653
