### PR TITLE
fix(session): anchor compaction persist boundary so queued follow-ups survive

### DIFF
--- a/src/agentos/engine/turn_runner/harness.py
+++ b/src/agentos/engine/turn_runner/harness.py
@@ -727,6 +727,7 @@ class _TurnRunnerCompactionPersistAdapter(CompactionPersistPort):
         summary: str,
         kept_entries: list[Any],
         compaction_id: str | None = None,
+        removed_count: int | None = None,
     ) -> None:
         from agentos.engine.cache_break_monitor import notify_compaction
         from agentos.session.compaction_lifecycle import (
@@ -750,6 +751,10 @@ class _TurnRunnerCompactionPersistAdapter(CompactionPersistPort):
             p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()
         ):
             persist_kwargs["trigger_reason"] = "agent_inline_overflow"
+        if "removed_count" in params or any(
+            p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()
+        ):
+            persist_kwargs["removed_count"] = removed_count
         async with self._runner._session_write_context(session_key):
             await persist_method(
                 session_key,

--- a/src/agentos/engine/turn_runner/stream_consumer_stage.py
+++ b/src/agentos/engine/turn_runner/stream_consumer_stage.py
@@ -107,6 +107,7 @@ class CompactionPersistPort(Protocol):
         summary: str,
         kept_entries: list[Any],
         compaction_id: str | None = None,
+        removed_count: int | None = None,
     ) -> None: ...
 
 
@@ -747,6 +748,7 @@ class _CompactionHandler:
                     summary=event.summary,
                     kept_entries=event.kept_entries,
                     compaction_id=event.compaction_id,
+                    removed_count=event.removed_count,
                 )
             except Exception as exc:  # noqa: BLE001 - preserve turn recoverability
                 log.warning("compaction_persist_failed", error=str(exc))

--- a/src/agentos/session/manager.py
+++ b/src/agentos/session/manager.py
@@ -8,7 +8,7 @@ import json
 import os
 import re
 import uuid
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator, Callable, Mapping
 from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
@@ -166,6 +166,63 @@ def _transcript_preimage(entries: list[TranscriptEntry]) -> tuple[tuple[Any, ...
         )
         for entry in entries
     )
+
+
+def _compaction_entry_matches(raw: Mapping[str, Any], entry: TranscriptEntry) -> bool:
+    """Structural identity between an agent-side compaction payload and a DB row."""
+    return raw.get("role") == entry.role and (raw.get("content") or "") == (entry.content or "")
+
+
+def _locate_compaction_boundary(
+    entries: list[TranscriptEntry],
+    kept_entries: list[dict],
+    removed_count: int | None = None,
+) -> tuple[list[TranscriptEntry], list[TranscriptEntry], list[TranscriptEntry]] | None:
+    """Locate which persisted prefix a compaction result may replace.
+
+    The running agent compacted a snapshot of the transcript; by the time the
+    result is persisted the transcript may have grown (``sessions.send`` queues
+    the follow-up before the in-flight turn finishes). Replacing by tail length
+    would overwrite those newer entries, so the boundary is anchored instead:
+
+    1. Agent-reported ``removed_count`` — the preferred anchor: the kept window
+       is expected at ``entries[removed_count : removed_count + kept_count]``
+       and is accepted only when the rows there structurally match the kept
+       payloads. A kept tail that cannot be verified (rewritten synthetic
+       context, diverged transcript) never produces a boundary.
+    2. Content anchoring — otherwise the smallest window of ``entries`` whose
+       rows match ``kept_entries`` pairwise. The agent's kept payloads are
+       literal copies of history rows. Picking the first match means an
+       ambiguous (repeated-content) transcript can only over-keep entries,
+       never drop them.
+
+    Returns ``(removed_entries, snapshot_tail, preserved_entries)`` where
+    ``snapshot_tail`` is the matched window (for id/metadata reuse) and
+    ``preserved_entries`` are the newer entries that must survive verbatim.
+    ``None`` means no trustworthy boundary exists (reset or diverged
+    transcript) and the caller must skip persisting rather than overwrite.
+    """
+    kept_count = len(kept_entries)
+
+    def _window_matches(start: int) -> bool:
+        return all(
+            _compaction_entry_matches(kept_entries[index], entries[start + index])
+            for index in range(kept_count)
+        )
+
+    if removed_count is not None:
+        end = removed_count + kept_count
+        if 0 <= removed_count <= end <= len(entries) and _window_matches(removed_count):
+            return entries[:removed_count], entries[removed_count:end], entries[end:]
+    if kept_count:
+        for start in range(len(entries) - kept_count + 1):
+            if _window_matches(start):
+                return (
+                    entries[:start],
+                    entries[start : start + kept_count],
+                    entries[start + kept_count :],
+                )
+    return None
 
 
 class SessionManager:
@@ -1407,12 +1464,21 @@ class SessionManager:
         compaction_id: str | None = None,
         trigger_reason: str | None = None,
         flush_receipt_status: str | None = None,
+        removed_count: int | None = None,
     ) -> None:
         """Persist a pre-computed compaction result directly (no LLM re-compaction).
 
         Called by TurnRunner when Agent emits CompactionEvent. Writes the Agent's
         actual compaction output to DB, avoiding the double-compaction bug that
         would occur if we called compact() (which re-reads DB and re-runs LLM).
+
+        Re-entrant with concurrent sends: the DB transcript may have grown since
+        the agent loaded its history (``sessions.send`` queues a follow-up before
+        the in-flight turn persists). The rewrite boundary is therefore anchored
+        to the agent's snapshot (content match, else agent-reported
+        ``removed_count``) instead of the transcript tail; newer entries are
+        preserved verbatim. When no trustworthy boundary exists (reset or
+        diverged transcript) the result is skipped rather than overwriting.
         """
         session_key = canonicalize_session_key(session_key)
         import structlog as _structlog
@@ -1425,8 +1491,17 @@ class SessionManager:
             return
 
         entries = await self._storage.get_transcript(node.session_id)
-        removed_entries = entries[: max(0, len(entries) - len(kept_entries))]
-        preserved_entries = entries[len(removed_entries) :]
+        boundary = _locate_compaction_boundary(entries, kept_entries, removed_count)
+        if boundary is None:
+            _log.warning(
+                "persist_compaction.stale_transcript_skipped",
+                session_key=session_key,
+                transcript_len=len(entries),
+                kept=len(kept_entries),
+                reported_removed=removed_count,
+            )
+            return
+        removed_entries, snapshot_tail, preserved_entries = boundary
         if removed_entries and not summary:
             _log.warning(
                 "persist_compaction.empty_summary_not_persisted",
@@ -1476,8 +1551,8 @@ class SessionManager:
         # Insert kept entries, preserving original metadata where possible
         rewritten_entries: list[TranscriptEntry] = []
         for index, raw in enumerate(kept_entries):
-            if index < len(preserved_entries):
-                preserved = preserved_entries[index]
+            if index < len(snapshot_tail):
+                preserved = snapshot_tail[index]
                 if preserved.role == raw.get("role") and preserved.content == raw.get("content"):
                     rewritten_entries.append(preserved)
                     continue
@@ -1491,6 +1566,9 @@ class SessionManager:
                 turn_usage=raw.get("turn_usage"),
             )
             rewritten_entries.append(entry)
+        # Entries appended after the agent's snapshot (queued follow-ups) must
+        # survive the rewrite verbatim, with their identity and order intact.
+        rewritten_entries.extend(preserved_entries)
 
         node.compaction_count = (node.compaction_count or 0) + 1
         node.updated_at = _now_ms()

--- a/tests/test_engine/test_prompt_cache_stability.py
+++ b/tests/test_engine/test_prompt_cache_stability.py
@@ -365,7 +365,7 @@ async def test_forked_compacted_archive_stays_out_of_provider_messages(
     await session_manager.persist_compaction_result(
         parent_key,
         "portable summary without archived row text",
-        [{"role": "assistant", "content": "active kept reply"}],
+        [{"role": "user", "content": "archive-only old message 3"}],
         compaction_id="cmp_provider_boundary",
     )
     await session_manager.branch(parent_key, child_key, fork_transcript=True)
@@ -376,10 +376,10 @@ async def test_forked_compacted_archive_stays_out_of_provider_messages(
         "archive-only old message 0",
         "archive-only old message 1",
         "archive-only old message 2",
-        "active kept reply",
+        "archive-only old message 3",
     ]
     assert [entry.content for entry in await session_manager.get_transcript(child_key)] == [
-        "active kept reply"
+        "archive-only old message 3"
     ]
 
     provider = _CapturingProvider()
@@ -410,9 +410,11 @@ async def test_forked_compacted_archive_stays_out_of_provider_messages(
         ],
         ensure_ascii=False,
     )
-    assert "active kept reply" in messages_payload
+    assert "archive-only old message 3" in messages_payload
     assert "portable summary without archived row text" in messages_payload
-    assert "archive-only old message" not in messages_payload
+    assert "archive-only old message 0" not in messages_payload
+    assert "archive-only old message 1" not in messages_payload
+    assert "archive-only old message 2" not in messages_payload
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine/turn_runner/test_stream_consumer_stage_unit.py
+++ b/tests/test_engine/turn_runner/test_stream_consumer_stage_unit.py
@@ -96,6 +96,7 @@ class _RecordingCompactionPersist:
         summary: str,
         kept_entries: list[Any],
         compaction_id: str | None = None,
+        removed_count: int | None = None,
     ) -> None:
         self.calls.append(
             {

--- a/tests/test_session/test_manager.py
+++ b/tests/test_session/test_manager.py
@@ -175,7 +175,7 @@ async def test_reset_same_key_archive_preserves_compacted_canonical_transcript(
     await manager.persist_compaction_result(
         "agent:main:main",
         "short summary",
-        [{"role": "assistant", "content": "latest reply"}],
+        [{"role": "user", "content": "msg 3"}],
         compaction_id="cmp_reset_archive",
     )
 
@@ -453,7 +453,7 @@ async def test_branch_fork_transcript_copies_compacted_archive(manager):
     await manager.persist_compaction_result(
         "agent:main:main",
         "short summary",
-        [{"role": "assistant", "content": "latest reply"}],
+        [{"role": "user", "content": "msg 3"}],
         compaction_id="cmp_branch_archive",
         trigger_reason="agent_inline_overflow",
     )
@@ -465,7 +465,7 @@ async def test_branch_fork_transcript_copies_compacted_archive(manager):
 
     assert child.parent_session_key == "agent:main:main"
     assert [entry.content for entry in await manager.get_transcript("agent:main:direct:u1")] == [
-        "latest reply"
+        "msg 3"
     ]
     assert [
         entry.content for entry in await manager.get_canonical_transcript("agent:main:direct:u1")
@@ -1167,7 +1167,7 @@ async def test_persist_compaction_result_rewrite_failure_keeps_session_state_ato
         await manager.persist_compaction_result(
             "agent:main:main",
             "short summary",
-            [{"role": "assistant", "content": "latest reply"}],
+            [{"role": "user", "content": "msg 3"}],
         )
 
     assert await manager.get_transcript("agent:main:main") == original_transcript
@@ -1193,20 +1193,20 @@ async def test_persist_compaction_result_stores_summary_out_of_band(manager):
     await manager.persist_compaction_result(
         "agent:main:main",
         "short summary",
-        [{"role": "assistant", "content": "latest reply"}],
+        [{"role": "user", "content": "msg 3"}],
         compaction_id="cmp_inline_1",
         trigger_reason="agent_inline_overflow",
     )
 
     transcript = await manager.get_transcript("agent:main:main")
     assert all(entry.role != "system" for entry in transcript)
-    assert transcript[-1].content == "latest reply"
+    assert transcript[-1].content == "msg 3"
     canonical = await manager.get_canonical_transcript("agent:main:main")
     assert [entry.content for entry in canonical] == [
         "msg 0",
         "msg 1",
         "msg 2",
-        "latest reply",
+        "msg 3",
     ]
     async with manager._storage.conn.execute(
         "SELECT compaction_id, compaction_index FROM compacted_transcript_entries "
@@ -1279,6 +1279,148 @@ async def test_persist_compaction_result_without_summary_does_not_rewrite_transc
     assert current_node.session_id == node.session_id
     assert current_node.compaction_count == original_node.compaction_count
     assert current_node.updated_at == original_node.updated_at
+
+
+@pytest.mark.asyncio
+async def test_persist_compaction_result_preserves_queued_followup_message(manager):
+    """Regression (#1645): a follow-up message persisted after the running agent
+    loaded its history must survive inline compaction with its identity intact."""
+    await manager.create("agent:main:main")
+    for index in range(3):
+        role = "user" if index % 2 == 0 else "assistant"
+        await manager.append_message("agent:main:main", role, f"msg {index}", token_count=5)
+    snapshot = await manager.get_transcript("agent:main:main")
+    kept_payloads = [{"role": entry.role, "content": entry.content} for entry in snapshot[1:]]
+
+    # sessions.send persists the queued follow-up before the running turn's
+    # compaction result lands; the agent never saw it.
+    followup = await manager.append_message(
+        "agent:main:main", "user", "queued follow-up", token_count=5
+    )
+
+    await manager.persist_compaction_result(
+        "agent:main:main",
+        "short summary",
+        kept_payloads,
+        compaction_id="cmp_inline_race",
+    )
+
+    transcript = await manager.get_transcript("agent:main:main")
+    assert [entry.content for entry in transcript] == ["msg 1", "msg 2", "queued follow-up"]
+    assert transcript[-1].message_id == followup.message_id
+    assert transcript[0].message_id == snapshot[1].message_id
+    canonical = await manager.get_canonical_transcript("agent:main:main")
+    assert [entry.content for entry in canonical] == [
+        "msg 0",
+        "msg 1",
+        "msg 2",
+        "queued follow-up",
+    ]
+    summaries = await manager.get_summaries("agent:main:main")
+    assert len(summaries) == 1
+    assert summaries[0].removed_count == 1
+    assert summaries[0].covered_through_id == snapshot[0].id
+
+
+@pytest.mark.asyncio
+async def test_persist_compaction_result_removed_count_anchors_boundary(manager):
+    """Agent-reported removed_count anchors the snapshot boundary so a full
+    compaction (empty kept tail) cannot swallow a queued follow-up message."""
+    await manager.create("agent:main:main")
+    for index in range(3):
+        await manager.append_message("agent:main:main", "user", f"msg {index}", token_count=5)
+    followup = await manager.append_message(
+        "agent:main:main", "user", "queued follow-up", token_count=5
+    )
+
+    await manager.persist_compaction_result(
+        "agent:main:main",
+        "short summary",
+        [],
+        compaction_id="cmp_inline_full",
+        removed_count=3,
+    )
+
+    transcript = await manager.get_transcript("agent:main:main")
+    assert [entry.content for entry in transcript] == ["queued follow-up"]
+    assert transcript[-1].message_id == followup.message_id
+    canonical = await manager.get_canonical_transcript("agent:main:main")
+    assert [entry.content for entry in canonical] == [
+        "msg 0",
+        "msg 1",
+        "msg 2",
+        "queued follow-up",
+    ]
+    summaries = await manager.get_summaries("agent:main:main")
+    assert len(summaries) == 1
+    assert summaries[0].removed_count == 3
+
+
+@pytest.mark.asyncio
+async def test_persist_compaction_result_skips_stale_transcript(manager):
+    """A compaction whose kept tail cannot be located in the transcript (reset or
+    diverged history) must not overwrite it with a stale result."""
+    await manager.create("agent:main:main")
+    for index in range(3):
+        await manager.append_message("agent:main:main", "user", f"msg {index}", token_count=5)
+    transcript_before = await manager.get_transcript("agent:main:main")
+    original_node = await manager._storage.get_session("agent:main:main")
+
+    await manager.persist_compaction_result(
+        "agent:main:main",
+        "short summary",
+        [{"role": "assistant", "content": "not in transcript"}],
+    )
+
+    # An unverifiable kept tail is not rescued by an agent-reported count either.
+    await manager.persist_compaction_result(
+        "agent:main:main",
+        "short summary",
+        [{"role": "assistant", "content": "not in transcript"}],
+        removed_count=2,
+    )
+
+    assert await manager.get_transcript("agent:main:main") == transcript_before
+    assert await manager.get_summaries("agent:main:main") == []
+    current_node = await manager._storage.get_session("agent:main:main")
+    assert current_node is not None
+    assert original_node is not None
+    assert current_node.compaction_count == original_node.compaction_count
+    assert current_node.updated_at == original_node.updated_at
+
+
+@pytest.mark.asyncio
+async def test_persist_compaction_result_repeated_content_anchors_first_window(manager):
+    """Ambiguous content matches anchor on the first window so the rewrite can
+    only over-keep, never drop, transcript entries."""
+    await manager.create("agent:main:main")
+    for content in ("msg 0", "msg 1", "msg 2", "msg 1", "msg 2"):
+        await manager.append_message("agent:main:main", "user", content, token_count=5)
+    snapshot = await manager.get_transcript("agent:main:main")
+    kept_payloads = [{"role": entry.role, "content": entry.content} for entry in snapshot[1:3]]
+    followup = await manager.append_message(
+        "agent:main:main", "user", "queued follow-up", token_count=5
+    )
+
+    await manager.persist_compaction_result(
+        "agent:main:main",
+        "short summary",
+        kept_payloads,
+        compaction_id="cmp_inline_ambiguous",
+    )
+
+    transcript = await manager.get_transcript("agent:main:main")
+    assert [entry.content for entry in transcript] == [
+        "msg 1",
+        "msg 2",
+        "msg 1",
+        "msg 2",
+        "queued follow-up",
+    ]
+    assert transcript[-1].message_id == followup.message_id
+    summaries = await manager.get_summaries("agent:main:main")
+    assert len(summaries) == 1
+    assert summaries[0].removed_count == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #1645

## Problem

`persist_compaction_result` derived the rewrite boundary from **tail-length arithmetic** — `len(entries) - len(kept_entries)`. That assumes the current DB transcript still matches the agent's snapshot. It doesn't under re-entrancy: `sessions.send` persists a queued follow-up **before** the in-flight turn persists its `CompactionEvent`, so by persist time the transcript is `snapshot + follow-up` and the arithmetic under-counts by one. The stale kept tail then overwrites the newer entries:

- the queued follow-up vanishes from both the live and canonical transcript
- the summary claims coverage of content it never saw
- the follow-up's message id changes after a restart-resume

## Fix

Anchor the boundary to the agent's snapshot instead of the transcript tail (`_locate_compaction_boundary` in `session/manager.py`):

1. **Agent-reported `removed_count`** (forwarded from `CompactionEvent` through the persist port / harness adapter, with the existing signature-introspection fallback) is the preferred anchor — accepted only when the rows at `entries[removed_count : removed_count + kept_count]` structurally match the kept payloads, so rewritten/synthetic kept tails can never fabricate a boundary.
2. **Content anchoring** otherwise: the smallest window of transcript rows matching `kept_entries` pairwise (agent payloads are literal copies of history rows). Picking the first match means a repeated-content transcript can only over-keep, never drop.
3. **Skip on uncertainty**: no trustworthy boundary (reset or diverged transcript) → log a warning and skip persisting instead of overwriting.

Entries appended after the snapshot are re-appended verbatim with their original `message_id`; summary coverage covers only the archived prefix. Unverifiable results are never persisted, matching the stale-result acceptance behavior.

## Tests

New regression tests in `tests/test_session/test_manager.py` (RED→GREEN proven against the pre-fix code):

- queued follow-up appended between snapshot and persist survives in both live and canonical transcripts, original message id intact, summary coverage excludes it
- stale/diverged result (kept not in transcript, with and without `removed_count`) is skipped, transcript untouched
- agent-reported `removed_count` anchors the boundary for a full compaction (empty kept tail) without swallowing the follow-up
- repeated-content ambiguity over-keeps rather than over-archives when no count is provided

Existing fixtures using a rewritten kept payload (`"latest reply"` / synthetic tail) were updated to literal history rows, which is what real agent compaction payloads are — including the provider-boundary test in `tests/test_engine/test_prompt_cache_stability.py`.

## Gate

- `ruff check` + `ruff format --check`: clean on all touched files
- `mypy` on the 3 touched source files: clean
- Full suite: `10238 passed`; the 25 failed + 3 errored are environment-dependent (pilot/onnx, wheelhouse build, live smoke, onboarding status) and fail identically on a clean `origin/main` checkout — verified by running the same node ids on a second worktree at `origin/main` (25 failed + 3 errors there too, zero divergence)