### PR TITLE
fix(tools): stop mapping an inline approval timeout to a denial

### DIFF
--- a/src/agentos/application/approval_queue.py
+++ b/src/agentos/application/approval_queue.py
@@ -168,6 +168,16 @@ class ApprovalQueue:
         return entry
 
     async def wait(self, approval_id: str, timeout: float | None = None) -> bool:
+        """Wait up to *timeout* for *approval_id* to resolve.
+
+        Returns ``True``/``False`` once resolved, or ``False`` if *this call's*
+        wait window elapses first. A per-call timeout is not a decision — the
+        approval is still open for whoever eventually clicks approve/deny, so
+        it must not be persisted as a denial here. Doing that used to make a
+        slow-to-review approval permanently undeniable-or-approvable the
+        moment any one caller's wait timed out, even though nothing about the
+        approval itself was ever resolved.
+        """
         entry = self.get(approval_id)
         if entry.resolved:
             return entry.approved
@@ -176,7 +186,7 @@ class ApprovalQueue:
         while True:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
-                break
+                return False
             try:
                 await asyncio.wait_for(
                     entry._event.wait(),
@@ -187,31 +197,6 @@ class ApprovalQueue:
             entry = self.get(approval_id)
             if entry.resolved:
                 return entry.approved
-        return self._deny_on_timeout_if_unresolved(approval_id)
-
-    def _deny_on_timeout_if_unresolved(self, approval_id: str) -> bool:
-        self._conn.execute("BEGIN IMMEDIATE")
-        row = self._get_row(approval_id)
-        if row is None:
-            self._conn.rollback()
-            raise KeyError(f"Approval not found: {approval_id}")
-        entry = self._row_to_entry(row)
-        if entry.resolved:
-            self._conn.rollback()
-            self._pending[approval_id] = entry
-            entry._event.set()
-            return entry.approved
-        self._conn.execute(
-            "UPDATE approval_queue "
-            "SET resolved = 1, approved = 0 "
-            "WHERE approval_id = ? AND resolved = 0",
-            (approval_id,),
-        )
-        self._conn.commit()
-        entry = self.get(approval_id)
-        entry._event.set()
-        self._pending[approval_id] = entry
-        return entry.approved
 
     def resolve(
         self,

--- a/src/agentos/tools/builtin/shell.py
+++ b/src/agentos/tools/builtin/shell.py
@@ -1523,12 +1523,28 @@ async def _check_exec_approval(
                 )
                 _elevate_current_call.set(True)
                 return None
+            if not entry.resolved:
+                # The wait window elapsed with no human decision yet — this
+                # is not a denial. Recording one here would let a slow
+                # reviewer's eventual approval land on a queue entry the
+                # ledger already believes was rejected, and would falsely
+                # count as a repeat-intent denial (see post_denial_guard).
+                return {
+                    "status": "approval_pending",
+                    "approval_id": approval_id,
+                    "command": command,
+                    "warning": warning,
+                    "message": (
+                        "Approval is still pending after waiting "
+                        f"{int(_APPROVAL_RETRY_WAIT_SECONDS)}s. Ask the user to approve."
+                    ),
+                }
             return {
                 "status": "approval_denied",
                 "approval_id": approval_id,
                 "command": command,
                 "warning": warning,
-                "message": "Approval was denied or timed out.",
+                "message": "Approval was denied.",
             }
         status = "approval_required"
         message = (

--- a/tests/test_gateway/test_approval_queue_persistence.py
+++ b/tests/test_gateway/test_approval_queue_persistence.py
@@ -94,15 +94,41 @@ async def test_approval_queue_wait_same_process_event_fast_path(tmp_path) -> Non
 
 
 @pytest.mark.asyncio
-async def test_approval_queue_wait_preserves_timeout_denies(tmp_path) -> None:
+async def test_approval_queue_wait_timeout_leaves_the_approval_open(tmp_path) -> None:
+    """Issue #1568: a per-call wait() timeout is not a human decision. It
+    used to permanently mark the entry resolved/denied in SQLite the moment
+    any one caller's wait window elapsed, so a reviewer who took longer than
+    that window to click Approve could never actually approve it -- the row
+    was already closed out as denied. A timeout must leave the approval
+    exactly as open as it was before the call."""
     db_path = tmp_path / "approval_queue.sqlite"
     queue = ApprovalQueue(db_path=str(db_path), default_timeout=1.0, poll_interval=0.01)
     approval_id = queue.request("exec", {"toolName": "exec_command", "command": "rm x"})
     try:
         assert await queue.wait(approval_id, timeout=0.02) is False
         entry = queue.get(approval_id)
-        assert entry.resolved is True
+        assert entry.resolved is False
         assert entry.approved is False
+        assert [row["id"] for row in queue.list_pending("exec")] == [approval_id]
+    finally:
+        queue.close()
+
+
+@pytest.mark.asyncio
+async def test_approval_queue_stays_approvable_after_a_wait_timeout(tmp_path) -> None:
+    """The reviewer's eventual decision, made after some caller's wait()
+    already timed out once, must still land."""
+    db_path = tmp_path / "approval_queue.sqlite"
+    queue = ApprovalQueue(db_path=str(db_path), default_timeout=1.0, poll_interval=0.01)
+    approval_id = queue.request("exec", {"toolName": "exec_command", "command": "rm x"})
+    try:
+        assert await queue.wait(approval_id, timeout=0.02) is False
+
+        queue.resolve(approval_id, True)
+
+        entry = queue.get(approval_id)
+        assert entry.resolved is True
+        assert entry.approved is True
     finally:
         queue.close()
 

--- a/tests/test_tools/test_shell_approval_policy.py
+++ b/tests/test_tools/test_shell_approval_policy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import sys
 from pathlib import Path
@@ -8,7 +9,7 @@ import pytest
 
 from agentos.gateway.approval_queue import get_approval_queue, reset_approval_queue
 from agentos.sandbox.config import SandboxSettings
-from agentos.sandbox.integration import configure_runtime, reset_runtime
+from agentos.sandbox.integration import configure_runtime, get_runtime, reset_runtime
 from agentos.sandbox.intent_cache import get_intent_cache, reset_intent_cache
 from agentos.tools.builtin import code_exec, filesystem, shell
 from agentos.tools.builtin.code_exec import execute_code
@@ -881,3 +882,125 @@ async def test_root_wipe_is_hard_blocked_at_the_exec_approval_boundary() -> None
         assert result["status"] == "blocked"
         assert result["reason"] == "sensitive_path"
         assert result["sensitive_path"] == "/"
+
+
+@pytest.mark.asyncio
+async def test_inline_web_approval_timeout_returns_pending_not_denied(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #1563: an operator who simply takes longer than the inline wait
+    window to review a command must not be recorded as having rejected it.
+    The wait timing out is not a decision -- the approval is still open, so
+    the tool must return approval_pending (matching the retry branch's own
+    behavior for the same "still unresolved" case) instead of collapsing
+    "denied" and "timed out" into the same approval_denied status.
+    """
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.caller_kind = CallerKind.WEB
+    session_id = str(ctx.session_key)
+    monkeypatch.setattr(shell, "_APPROVAL_RETRY_WAIT_SECONDS", 0.05)
+    monkeypatch.setattr(
+        shell,
+        "check_safe_bin",
+        lambda command: PolicyResult(
+            allowed=True, reason=f"command requires approval: {command}", needs_approval=True
+        ),
+    )
+    configure_runtime(
+        SandboxSettings(sandbox=False, security_grading=False, allow_legacy_mode=True),
+        workspace=tmp_path,
+    )
+    runtime = get_runtime()
+    assert runtime is not None
+
+    result_raw = await shell.exec_command("rm target.txt")
+    result = json.loads(result_raw)
+
+    assert result["status"] == "approval_pending"
+    assert "approval_id" in result
+    # The regression is what reaches the audit ledger, not just the returned
+    # status -- a false HUMAN_REJECTED here would let post_denial_guard treat
+    # the agent's honest retry as a repeat-intent denial.
+    assert await runtime.ledger.count_session(session_id) == 0
+
+
+@pytest.mark.asyncio
+async def test_inline_web_approval_still_reports_denied_once_actually_denied(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A real human denial (not a timeout) must still come back as
+    approval_denied and still be recorded."""
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.caller_kind = CallerKind.WEB
+    session_id = str(ctx.session_key)
+    monkeypatch.setattr(shell, "_APPROVAL_RETRY_WAIT_SECONDS", 5.0)
+    monkeypatch.setattr(
+        shell,
+        "check_safe_bin",
+        lambda command: PolicyResult(
+            allowed=True, reason=f"command requires approval: {command}", needs_approval=True
+        ),
+    )
+    configure_runtime(
+        SandboxSettings(sandbox=False, security_grading=False, allow_legacy_mode=True),
+        workspace=tmp_path,
+    )
+    runtime = get_runtime()
+    assert runtime is not None
+
+    async def _deny_shortly_after_request() -> None:
+        for _ in range(200):
+            pending = get_approval_queue().list_pending("exec")
+            if pending:
+                get_approval_queue().resolve(pending[0]["id"], False)
+                return
+            await asyncio.sleep(0.01)
+        raise AssertionError("approval never appeared in the queue")
+
+    denier = asyncio.create_task(_deny_shortly_after_request())
+    result_raw = await shell.exec_command("rm target.txt")
+    await denier
+    result = json.loads(result_raw)
+
+    assert result["status"] == "approval_denied"
+    assert await runtime.ledger.count_session(session_id) == 1
+
+
+@pytest.mark.asyncio
+async def test_inline_timeout_leaves_the_approval_resolvable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #1568's other half, at the shell tool boundary: the approval_id
+    returned from a timed-out inline wait must still be genuinely
+    resolvable -- a human clicking Approve after the agent's wait window
+    elapsed must not find the queue entry already closed out as denied."""
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.caller_kind = CallerKind.WEB
+    monkeypatch.setattr(shell, "_APPROVAL_RETRY_WAIT_SECONDS", 0.05)
+    monkeypatch.setattr(
+        shell,
+        "check_safe_bin",
+        lambda command: PolicyResult(
+            allowed=True, reason=f"command requires approval: {command}", needs_approval=True
+        ),
+    )
+    configure_runtime(
+        SandboxSettings(sandbox=False, security_grading=False, allow_legacy_mode=True),
+        workspace=tmp_path,
+    )
+
+    pending_raw = await shell.exec_command("rm target.txt")
+    pending = json.loads(pending_raw)
+    assert pending["status"] == "approval_pending"
+
+    get_approval_queue().resolve(pending["approval_id"], True)
+
+    entry = get_approval_queue().get(pending["approval_id"])
+    assert entry.resolved is True
+    assert entry.approved is True


### PR DESCRIPTION
Summary
Two bugs combined to cause this, and fixing either alone would not have closed it — both needed fixing together.

1. ApprovalQueue.wait() (#1568): when its own wait window elapsed with the entry still unresolved, it called _deny_on_timeout_if_unresolved, which permanently wrote resolved=1, approved=0 to SQLite. A per-call timeout is not a human decision — the approval is still open for whoever eventually reviews it — but this made that impossible: the row was already closed out as denied the moment any one caller's wait timed out, so a reviewer who took longer than that window to click Approve could never actually approve it. Removed the side effect; wait() now just returns False on its own timeout and leaves the entry exactly as open as it was before the call.

2. _check_exec_approval's inline Web UI approval branch (shell.py): after awaiting queue.wait(), it checked only entry.approved, collapsing "the human denied it" and "the wait timed out with no decision yet" into the same approval_denied status — unlike the retry branch a few lines below in the same function, which already checks entry.resolved first and returns approval_pending for the still-unresolved case. Added the same check to the inline branch. exec_command/background_process only record a HUMAN_REJECTED denial for approval_denied, so this also stops the sandbox ledger from recording a denial the human never made — which post_denial_guard would otherwise treat as a repeat-intent signal against the agent's own honest retry.

Fixing only #2 would not have been enough on its own: entry.resolved was already being forced true by ApprovalQueue.wait()'s side effect before shell.py ever got to look at it.

Fixes #1563, fixes #1568 

Test plan
 Verified both regressions are caught: stashed the source fixes and reran — 2 of 3 shell-level tests and 1 approval-queue test genuinely fail against the old code, each showing the reported approval_denied instead of approval_pending
 Per the reviewer's explicit ask, assertions check what reached the sandbox ledger, not just the returned status — zero denials recorded for a timeout, exactly one for a real denial
 Added a persistence-layer test proving a timed-out approval stays genuinely resolvable afterward (a human's later Approve/Deny still lands)
 uv run pytest tests/test_tools/test_shell_approval_policy.py tests/test_gateway/test_approval_queue_persistence.py tests/test_sandbox tests/test_application/test_approval_rpc.py tests/test_gateway/test_rpc_approvals.py -q — 190 passed
 uv run pytest tests/test_tools -k shell -q — 131 passed
 uv run ruff check / uv run mypy clean on changed files
