### PR TITLE
fix(util): bound every per-session registry behind one shared primitive (#1131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -825,6 +825,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   the expensive work was already done, losing the result. Each now calls
   `mkdir(parents=True, exist_ok=True)` on the parent before writing
   ([#1055](https://github.com/use-agent-os/agent-os/issues/1055)).
+- Twenty per-session registries are bounded behind one shared primitive
+  instead of growing for the life of the gateway process. Each was a bare
+  `dict` keyed by a session id (or a tuple containing one) with no `pop()` on
+  session end and no ceiling, so a gateway serving many short sessions retained
+  one entry per session per registry — task-runtime locks, stream replay
+  buffers and sequence counters, background shell sessions, stale-output and
+  intent-approval caches, archived subagent handles, memory and bootstrap
+  snapshots, approval elevations, usage scopes and metadata, plan-mode flags,
+  the denial ledger, repeat-call watchdog state, and cache-break baselines.
+  Fifteen separate reports had produced twenty competing patches, each with its
+  own eviction policy; `agentos.util.BoundedRegistry` replaces them with one
+  rule in two configurations — session-scoped state dropped on the session's
+  terminal event with an LRU ceiling as the backstop, and time-scoped caches
+  with TTL plus a ceiling. `evict_session_runtime_state()`, the choke point
+  every deletion and terminal path already runs, now sweeps every registry that
+  can identify a session, so the bound really is the backstop rather than the
+  mechanism. A value the site declares busy — a held `asyncio.Lock` — is never
+  evicted. Both ceilings and the cache TTL are config keys
+  (`registry_session_max_entries`, `registry_cache_max_entries`,
+  `registry_cache_ttl_seconds`)
+  ([#1131](https://github.com/use-agent-os/agent-os/issues/1131)).
+- `BoundedRegistry`'s TTL sweep honours the eviction veto, so a still-running
+  background process is never dropped from its registry. `_expire()` was the
+  one eviction path that did not consult `_is_evictable` — `_enforce_ceiling`,
+  `discard_session` and `discard_where` all did — so `shell._bg_sessions`, a
+  cache-shaped registry whose veto protects a running process, lost the entry
+  900 s after spawn while the OS process kept running: `process poll`, `log`,
+  `kill` and `list` all reported the session gone, and its cleanup callbacks
+  never fired. A memory-leak fix that orphans processes is a worse trade than
+  the leak. The sweep now skips a vetoed entry and expires it once the site
+  releases it
+  ([#1131](https://github.com/use-agent-os/agent-os/issues/1131)).
 
 ## [2026.9.6] - 2026-09-06
 

--- a/agentos.toml.example
+++ b/agentos.toml.example
@@ -40,6 +40,18 @@
 # Env override: AGENTOS_WS_WRITER_QUEUE_MAXSIZE=512
 # ws_writer_queue_maxsize = 512
 
+# Bounded registries — how much per-session state one long-lived gateway
+# process retains in memory. Session-scoped state (stream replay buffers,
+# usage scopes, plan-mode flags, approval elevations) is normally dropped on
+# the session's terminal event; the ceiling is the backstop for sessions that
+# never emit one, and it evicts least-recently-used. Time-scoped caches
+# (background shell sessions, stale-output and repeat-call caches) also age
+# out on the TTL. Raise the session ceiling on a gateway that runs many
+# simultaneous sessions.
+# registry_session_max_entries = 512
+# registry_cache_max_entries = 512
+# registry_cache_ttl_seconds = 900
+
 # Gateway debug file logging. Raw prompt/tool call capture is separate from
 # debug.log and standard diagnostics; it is opt-in through
 # AGENTOS_TURN_CALL_LOG=1 or `agentos diagnostics on --raw`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -481,6 +481,25 @@ agentos config get llm.provider
 agentos config set port 18791
 ```
 
+A long-lived gateway keeps per-session state in memory — stream replay
+buffers, usage scopes, plan-mode flags, approval elevations. Every one of
+those sits behind a shared bounded registry whose ceilings are config keys:
+
+```sh
+agentos config set registry_session_max_entries 512
+agentos config set registry_cache_max_entries 512
+agentos config set registry_cache_ttl_seconds 900
+```
+
+`registry_session_max_entries` bounds session-scoped state,
+`registry_cache_max_entries` and `registry_cache_ttl_seconds` bound the
+time-scoped caches.
+
+Session state is normally dropped the moment a session is deleted, aborted or
+completed; the ceiling is the backstop for sessions that never emit a terminal
+event. Raise `registry_session_max_entries` on a gateway that runs many
+simultaneous sessions.
+
 For Ollama models that do not reliably support native tool calls, set
 `tools.enabled = false` in the config file to run in plain-text mode. Keep it
 enabled for tool-capable cloud models such as `glm-5.2:cloud`; the Ollama

--- a/src/agentos/application/approval_queue.py
+++ b/src/agentos/application/approval_queue.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import cast
 
 from agentos.paths import state_dir
+from agentos.util.bounded_registry import BoundedRegistry
 
 VALID_APPROVAL_MODES = frozenset({"auto-approve", "auto-deny", "prompt"})
 VALID_ELEVATED_MODES = frozenset({"on", "bypass", "full"})
@@ -52,8 +53,17 @@ class ApprovalQueue:
         self._timeout = default_timeout
         self._poll_interval = max(0.01, float(poll_interval))
         self._global_settings = ApprovalSettings()
-        self._node_settings: dict[str, ApprovalSettings] = {}
-        self._session_elevated_modes: dict[str, str] = {}
+        # Node ids are an operational set rather than a per-session one, so
+        # the ceiling is a backstop nothing reaches; eviction falls back to
+        # the global settings, which is the same answer an unconfigured
+        # node already gets.
+        self._node_settings: BoundedRegistry[str, ApprovalSettings] = BoundedRegistry(
+            name="ApprovalQueue._node_settings",
+        )
+        self._session_elevated_modes: BoundedRegistry[str, str] = BoundedRegistry(
+            name="ApprovalQueue._session_elevated_modes",
+            session_of=lambda key, _value: key,
+        )
 
         self._db_path = Path(db_path or os.fspath(_DEFAULT_APPROVAL_QUEUE_PATH))
         self._db_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/agentos/application/intent_cache.py
+++ b/src/agentos/application/intent_cache.py
@@ -30,6 +30,8 @@ import threading
 import time
 from pathlib import Path
 
+from agentos.util.bounded_registry import BoundedRegistry
+
 _DEFAULT_TTL_SECONDS = 30 * 60
 _ALWAYS_TTL_SECONDS = 365 * 24 * 3600  # effectively never expires within a session
 
@@ -395,7 +397,11 @@ class IntentApprovalCache:
     def __init__(self, default_ttl: float = _DEFAULT_TTL_SECONDS) -> None:
         self._default_ttl = default_ttl
         # intent -> (expires_monotonic, scope)
-        self._entries: dict[tuple[str, str], tuple[float, str]] = {}
+        # Keys are (kind, target), not sessions; the TTL already lives in
+        # the value, so this only adds the missing size ceiling.
+        self._entries: BoundedRegistry[tuple[str, str], tuple[float, str]] = BoundedRegistry(
+            name="IntentApprovalCache._entries",
+        )
         self._lock = threading.Lock()
 
     def record(
@@ -475,9 +481,7 @@ class IntentApprovalCache:
     def clear_scope(self, scope: str) -> None:
         """Drop every entry whose scope matches, leaving other scopes intact."""
         with self._lock:
-            self._entries = {
-                intent: data for intent, data in self._entries.items() if data[1] != scope
-            }
+            self._entries.discard_where(lambda _intent, data: data[1] == scope)
 
 
 _cache: IntentApprovalCache | None = None

--- a/src/agentos/engine/cache_break_monitor.py
+++ b/src/agentos/engine/cache_break_monitor.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from agentos.provider import ChatConfig, Message, ToolDefinition
+from agentos.util.bounded_registry import BoundedRegistry
 
 
 def _jsonable(value: Any) -> Any:
@@ -152,7 +153,10 @@ class CacheBreakMonitor:
     """Track cache-read drops and attribute them to prompt-state changes."""
 
     def __init__(self, *, min_drop_tokens: int = 2000, min_drop_ratio: float = 0.05) -> None:
-        self._baselines: dict[str, _CacheBaseline] = {}
+        self._baselines: BoundedRegistry[str, _CacheBaseline] = BoundedRegistry(
+            name="CacheBreakMonitor._baselines",
+            session_of=lambda key, _value: key,
+        )
         self._reset_pending: set[str] = set()
         self._min_drop_tokens = max(0, int(min_drop_tokens))
         self._min_drop_ratio = max(0.0, float(min_drop_ratio))

--- a/src/agentos/engine/progress_watchdog.py
+++ b/src/agentos/engine/progress_watchdog.py
@@ -24,6 +24,8 @@ import json
 from dataclasses import asdict, dataclass, field
 from typing import Any, Literal
 
+from agentos.util.bounded_registry import BoundedRegistry
+
 ProgressAction = Literal["observe", "warn", "block"]
 
 
@@ -112,8 +114,16 @@ class ProgressWatchdog:
         self._tool_error_count = 0
         self._last_provider_failure: str | None = None
         self._provider_failure_count = 0
-        self._repeat_counts: dict[tuple[str, str], int] = {}
-        self._repeat_results: dict[tuple[str, str], str] = {}
+        # Time-scoped: a repeat signature is only interesting while the
+        # loop it describes is still running.
+        self._repeat_counts: BoundedRegistry[tuple[str, str], int] = BoundedRegistry(
+            shape="cache",
+            name="ProgressWatchdog._repeat_counts",
+        )
+        self._repeat_results: BoundedRegistry[tuple[str, str], str] = BoundedRegistry(
+            shape="cache",
+            name="ProgressWatchdog._repeat_results",
+        )
 
     def observe(self, observation: ProgressObservation) -> ProgressDecision:
         # Checked before the progress test on purpose: a repeated *successful*

--- a/src/agentos/engine/runtime.py
+++ b/src/agentos/engine/runtime.py
@@ -189,6 +189,7 @@ from agentos.session.keys import (
 )
 from agentos.session.terminal_reply import build_terminal_reply, sanitize_agent_error
 from agentos.tools.types import CallerKind, ToolContext
+from agentos.util.bounded_registry import BoundedRegistry
 
 # Stable user-facing envelope for LLM timeouts.
 _LLM_TIMEOUT_ENVELOPE: dict[str, Any] = {
@@ -1712,11 +1713,19 @@ class TurnRunner:
         self._session_lock_provider = session_lock_provider
         # Frozen memory snapshots keyed by (agent_id, session_key).
         # Captured at session start, refreshed on write/compaction.
-        self._memory_snapshots: dict[tuple[str, str], MemorySnapshot] = {}
+        self._memory_snapshots: BoundedRegistry[tuple[str, str], MemorySnapshot] = BoundedRegistry(
+            name="TurnRunner._memory_snapshots",
+            session_of=lambda key, _value: key[1],
+        )
         # Frozen bootstrap snapshots keyed by (agent_id, session_key, context_mode).
         # Captured on first prompt assembly so bootstrap-source edits do not
         # churn the cacheable prefix mid-session.
-        self._bootstrap_snapshots: dict[tuple[str, str, str], BootstrapSnapshot] = {}
+        self._bootstrap_snapshots: BoundedRegistry[tuple[str, str, str], BootstrapSnapshot] = (
+            BoundedRegistry(
+                name="TurnRunner._bootstrap_snapshots",
+                session_of=lambda key, _value: key[1],
+            )
+        )
         # User turns since the last memory review, keyed (agent_id, session_key).
         self._memory_nudge_counters: dict[tuple[str, str], int] = {}
         self._compaction_failures: dict[str, _CompactionFailureState] = {}
@@ -1858,9 +1867,7 @@ class TurnRunner:
 
     def _handle_bootstrap_source_write(self, agent_id: str, path: str) -> None:
         """Drop frozen bootstrap snapshots after a bootstrap workspace file write."""
-        for key in list(self._bootstrap_snapshots):
-            if key[0] == agent_id:
-                del self._bootstrap_snapshots[key]
+        self._bootstrap_snapshots.discard_where(lambda key, _value: key[0] == agent_id)
 
     def _with_runtime_write_callbacks(
         self, tool_context: ToolContext, agent_id: str

--- a/src/agentos/engine/subagent.py
+++ b/src/agentos/engine/subagent.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from agentos.agents.limits import MAX_SPAWN_DEPTH
+from agentos.util.bounded_registry import BoundedRegistry
 
 if TYPE_CHECKING:
     from .agent import Agent
@@ -51,7 +52,12 @@ class SubagentRegistry:
 
     def __init__(self) -> None:
         self._runs: dict[str, SubagentHandle] = {}
-        self._archived: dict[str, SubagentHandle] = {}
+        # Time-scoped: an archived handle is only read back shortly after
+        # the run ends, and nothing prunes it otherwise.
+        self._archived: BoundedRegistry[str, SubagentHandle] = BoundedRegistry(
+            shape="cache",
+            name="SubagentRegistry._archived",
+        )
         self._parent_tasks: dict[str, asyncio.Task[Any]] = {}
 
     def register(

--- a/src/agentos/engine/usage.py
+++ b/src/agentos/engine/usage.py
@@ -15,6 +15,7 @@ from typing import Any
 import structlog
 
 from agentos.session.keys import normalize_agent_id
+from agentos.util.bounded_registry import BoundedRegistry
 
 from .pricing import calculate_cost_usd, lookup_price
 
@@ -429,11 +430,17 @@ class UsageTracker:
         """
         global _global_usage_tracker
         self._sessions: dict[str, SessionUsage] = {}
-        self._scopes: dict[tuple[str, str], SessionUsage] = {}
+        self._scopes: BoundedRegistry[tuple[str, str], SessionUsage] = BoundedRegistry(
+            name="UsageTracker._scopes",
+            session_of=lambda key, _value: key[0],
+        )
         self._default_provider_id = str(default_provider_id or "").strip().lower()
         self._db_path = db_path
         self._ledger_db_path = ledger_db_path
-        self._session_metadata: dict[str, tuple[str, str]] = {}
+        self._session_metadata: BoundedRegistry[str, tuple[str, str]] = BoundedRegistry(
+            name="UsageTracker._session_metadata",
+            session_of=lambda key, _value: key,
+        )
         self._warned_keys: set[str] = set()
         # In-process mirror of the persisted ledger. Reads take the larger of
         # the two: a dropped write (sqlite busy, disk full) must not be able to

--- a/src/agentos/gateway/boot.py
+++ b/src/agentos/gateway/boot.py
@@ -1884,6 +1884,18 @@ async def build_services(
     except Exception as e:
         log.warning("build_services.auxiliary_config_failed", error=str(e))
 
+    # ── Bounded registry ceilings ───────────────────────────────────
+    try:
+        from agentos.util.bounded_registry import configure_registry_limits
+
+        configure_registry_limits(
+            session_max_entries=config.registry_session_max_entries,
+            cache_max_entries=config.registry_cache_max_entries,
+            cache_ttl_seconds=config.registry_cache_ttl_seconds,
+        )
+    except Exception as e:
+        log.warning("build_services.registry_limits_failed", error=str(e))
+
     # ── Search provider (brave > duckduckgo fallback) ───────────────
     try:
         import agentos.search.providers.brave  # noqa: F401 — registers provider

--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -2435,6 +2435,12 @@ class GatewayConfig(BaseSettings):
     search_fallback_policy: Literal["off", "network"] = "off"
     search_diagnostics: bool = False
 
+    # Bounded registries — ceilings for the per-session dicts a long-lived
+    # gateway keeps in memory. See agentos.util.bounded_registry.
+    registry_session_max_entries: int = Field(default=512, ge=1)
+    registry_cache_max_entries: int = Field(default=512, ge=1)
+    registry_cache_ttl_seconds: float = Field(default=900.0, gt=0)
+
     # State/config paths
     state_dir: str | None = Field(default_factory=lambda: str(default_agentos_home() / "state"))
     config_path: str | None = None

--- a/src/agentos/gateway/session_streams.py
+++ b/src/agentos/gateway/session_streams.py
@@ -6,6 +6,8 @@ from collections import deque
 from dataclasses import dataclass
 from typing import Any
 
+from agentos.util.bounded_registry import BoundedRegistry
+
 
 @dataclass(frozen=True)
 class BufferedSessionEvent:
@@ -31,8 +33,19 @@ class SessionStreamRegistry:
 
     def __init__(self, *, max_events_per_session: int = 500) -> None:
         self._max_events_per_session = max_events_per_session
-        self._seq_by_session: dict[str, int] = {}
-        self._events_by_session: dict[str, deque[BufferedSessionEvent]] = {}
+        # Both are session-scoped: a gateway that serves many short sessions
+        # would otherwise keep one counter and one replay buffer per session
+        # for the life of the process.
+        self._seq_by_session: BoundedRegistry[str, int] = BoundedRegistry(
+            name="SessionStreamRegistry._seq_by_session",
+            session_of=lambda key, _value: key,
+        )
+        self._events_by_session: BoundedRegistry[str, deque[BufferedSessionEvent]] = (
+            BoundedRegistry(
+                name="SessionStreamRegistry._events_by_session",
+                session_of=lambda key, _value: key,
+            )
+        )
 
     @staticmethod
     def _is_replay_lossy(event_name: str) -> bool:

--- a/src/agentos/gateway/task_runtime.py
+++ b/src/agentos/gateway/task_runtime.py
@@ -38,6 +38,7 @@ from agentos.session.terminal_reply import (
     is_context_payload_too_large,
     sanitize_agent_error,
 )
+from agentos.util.bounded_registry import BoundedRegistry
 
 log = structlog.get_logger(__name__)
 
@@ -331,11 +332,21 @@ class TaskRuntime:
         # Per-session write locks shared with TurnRunner and RPC ingress on
         # gateway-dispatched turns. These guard short transcript/session state
         # mutations only.
-        self._session_locks: dict[str, asyncio.Lock] = {}
+        # Bounded: a lock that is currently held is never evicted, so the
+        # ceiling can only reclaim sessions that are genuinely idle.
+        self._session_locks: BoundedRegistry[str, asyncio.Lock] = BoundedRegistry(
+            name="TaskRuntime._session_locks",
+            session_of=lambda key, _value: key,
+            evictable=lambda lock: not lock.locked(),
+        )
         # Per-session execution locks serialize whole turn lifecycles without
         # blocking transcript writes, browser queue acknowledgements, or approval
         # status updates behind external I/O.
-        self._session_execution_locks: dict[str, asyncio.Lock] = {}
+        self._session_execution_locks: BoundedRegistry[str, asyncio.Lock] = BoundedRegistry(
+            name="TaskRuntime._session_execution_locks",
+            session_of=lambda key, _value: key,
+            evictable=lambda lock: not lock.locked(),
+        )
         self._tasks: dict[str, _RuntimeTask] = {}
         self._pending_by_session: dict[str, list[_RuntimeTask]] = {}
         self._running_by_session: dict[str, _RuntimeTask] = {}
@@ -1078,7 +1089,8 @@ class TaskRuntime:
         shared provider this is the only per-session lock; TurnRunner no
         longer owns an internal ``_session_locks`` dict.
 
-        ``setdefault`` is atomic in CPython — avoids TOCTOU race on insertion.
+        ``setdefault`` is atomic — ``BoundedRegistry`` holds its own lock for
+        the read-and-insert, so there is no TOCTOU race on insertion.
         """
         return self._session_locks.setdefault(session_key, asyncio.Lock())
 

--- a/src/agentos/plan_mode.py
+++ b/src/agentos/plan_mode.py
@@ -25,6 +25,8 @@ import time
 from dataclasses import dataclass
 from typing import Any
 
+from agentos.util.bounded_registry import BoundedRegistry
+
 EXIT_PLAN_TOOL_NAME = "exit_plan_mode"
 
 # Status stamped on a successful exit_plan_mode payload. The dispatch
@@ -87,14 +89,25 @@ class PlanModeState:
 
 
 class PlanModeStore:
-    """In-memory per-session plan-mode flags. No TTL by design: a mode that
-    silently expires mid-plan hands write tools back without the user's
-    say-so, which is the worst possible failure for this feature. Only an
-    explicit disable (approval, ``/plan off``) or a gateway restart clears it.
+    """In-memory per-session plan-mode flags.
+
+    No TTL by design: a mode that silently expires mid-plan hands write tools
+    back without the user's say-so, which is the worst possible failure for
+    this feature. An explicit disable (approval, ``/plan off``), the session's
+    terminal event, or a gateway restart clears it.
+
+    The size ceiling is a backstop for sessions that never emit a terminal
+    event, and it evicts least-recently-used: reaching it means more
+    simultaneous plan-mode sessions than the configured ceiling, at which point
+    the oldest untouched one loses the flag. Raise ``registry_session_max_entries``
+    rather than accepting that on a busy gateway.
     """
 
     def __init__(self) -> None:
-        self._sessions: dict[str, PlanModeState] = {}
+        self._sessions: BoundedRegistry[str, PlanModeState] = BoundedRegistry(
+            name="PlanModeStore._sessions",
+            session_of=lambda key, _value: key,
+        )
 
     def enable(self, session_key: str) -> None:
         key = (session_key or "").strip()

--- a/src/agentos/sandbox/governance.py
+++ b/src/agentos/sandbox/governance.py
@@ -46,6 +46,7 @@ from agentos.sandbox.types import (
     SecurityLevel,
     SuggestedNextStep,
 )
+from agentos.util.bounded_registry import BoundedRegistry
 
 log = logging.getLogger(__name__)
 
@@ -132,7 +133,10 @@ class DenialLedger:
         if threshold < 1:
             raise ValueError(f"threshold must be >= 1, got {threshold}")
         self._threshold = threshold
-        self._sessions: dict[str, _SessionState] = {}
+        self._sessions: BoundedRegistry[str, _SessionState] = BoundedRegistry(
+            name="DenialLedger._sessions",
+            session_of=lambda key, _value: key,
+        )
         self._cache = (
             stale_output_cache if stale_output_cache is not None else get_stale_output_cache()
         )

--- a/src/agentos/sandbox/stale_output_cache.py
+++ b/src/agentos/sandbox/stale_output_cache.py
@@ -30,6 +30,8 @@ import asyncio
 from dataclasses import dataclass, field
 from typing import Any
 
+from agentos.util.bounded_registry import BoundedRegistry
+
 
 @dataclass
 class _CacheEntry:
@@ -49,7 +51,14 @@ class StaleOutputCache:
     """
 
     def __init__(self) -> None:
-        self._entries: dict[tuple[str, str], _CacheEntry] = {}
+        # Time-scoped: an entry is only useful for a window after it is
+        # written, and nothing guarantees a terminal event for every session
+        # that put one here.
+        self._entries: BoundedRegistry[tuple[str, str], _CacheEntry] = BoundedRegistry(
+            shape="cache",
+            name="StaleOutputCache._entries",
+            session_of=lambda key, _value: key[0],
+        )
         self._lock = asyncio.Lock()
 
     async def record_success(self, session_id: str, fingerprint: str, payload: Any) -> None:
@@ -86,10 +95,7 @@ class StaleOutputCache:
     async def clear_session(self, session_id: str) -> int:
         """Remove every entry for ``session_id``. Returns the count removed."""
         async with self._lock:
-            keys = [k for k in self._entries if k[0] == session_id]
-            for k in keys:
-                del self._entries[k]
-            return len(keys)
+            return self._entries.discard_session(session_id)
 
     def snapshot(self) -> list[dict[str, object]]:
         """Return a plain-data view of cached keys (debug/test helper).

--- a/src/agentos/scheduler/heartbeat.py
+++ b/src/agentos/scheduler/heartbeat.py
@@ -31,7 +31,7 @@ import asyncio
 import json
 import re
 import uuid
-from collections import defaultdict
+from collections import defaultdict, deque
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -141,6 +141,12 @@ class HeartbeatLoopOverrides:
         )
 
 
+# Ceiling on events buffered for one priority band between ticks. Only the
+# oldest event's timestamp and the count matter to `poll()`, so a band that has
+# gone this long without ticking loses nothing a tick would have used.
+MAX_BUFFERED_EVENTS_PER_BAND = 10_000
+
+
 class HeartbeatRunner:
     """Poll-driven coalescing runner.
 
@@ -152,7 +158,14 @@ class HeartbeatRunner:
 
     def __init__(self, config: HeartbeatConfig | None = None) -> None:
         self._config = config or HeartbeatConfig()
-        self._buffers: dict[str, list[HeartbeatEvent]] = defaultdict(list)
+        # Keyed by priority band, so the *key* set is already small — the
+        # growth is inside the value: a runner that never ticks (outside active
+        # hours, or a band permanently inside its cooldown) buffers events
+        # forever. A bounded deque drops the oldest, which at that point has
+        # already lost its coalescing meaning.
+        self._buffers: defaultdict[str, deque[HeartbeatEvent]] = defaultdict(
+            lambda: deque(maxlen=MAX_BUFFERED_EVENTS_PER_BAND)
+        )
         self._last_tick: dict[str, datetime] = {}
 
     @property
@@ -198,7 +211,7 @@ class HeartbeatRunner:
             )
             emitted.append(tick)
             self._last_tick[band] = moment
-            self._buffers[band] = []
+            events.clear()
 
         return emitted
 

--- a/src/agentos/session/runtime_state.py
+++ b/src/agentos/session/runtime_state.py
@@ -21,7 +21,13 @@ log = structlog.get_logger(__name__)
 
 
 def evict_session_runtime_state(session_key: str) -> None:
-    """Drop in-memory subagent, routing, and spawn-lock bookkeeping.
+    """Drop in-memory per-session bookkeeping: every ``BoundedRegistry`` that
+    knows how to identify a session, plus subagent, routing, and spawn-lock
+    state.
+
+    This is the single terminal-event hook the bounded registries rely on: the
+    size ceiling is the backstop for a session that never reaches here, not the
+    mechanism.
 
     Idempotent and never raises: it runs on both the terminal path
     (``SessionManager.finish``) and every deletion path, and a missing or
@@ -29,6 +35,12 @@ def evict_session_runtime_state(session_key: str) -> None:
     that fails to import (partial install, trimmed distribution) must not
     block the deletion it is attached to.
     """
+    try:
+        from agentos.util.bounded_registry import drop_session_state
+
+        drop_session_state(session_key)
+    except Exception:
+        log.debug("session.runtime_state.bounded_registry_evict_failed", session_key=session_key)
     try:
         from agentos.gateway.subagent_announce import _tracker as _spawn_tracker
 

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -221,7 +221,7 @@ Main `agentos.toml` sections (full commented reference:
 
 | Section | Controls |
 | --- | --- |
-| top-level | `workspace_dir`, `state_dir`, logging, `search_provider`/`search_api_key`, timeouts |
+| top-level | `workspace_dir`, `state_dir`, logging, `search_provider`/`search_api_key`, timeouts, and the in-memory registry ceilings `registry_session_max_entries` (default 512), `registry_cache_max_entries` (default 512), `registry_cache_ttl_seconds` (default 900) — how much per-session state one long-lived gateway process retains |
 | `[x_search]` | xAI-backed X (Twitter) search: `enabled`, `model` (default `grok-4.5`), `api_key`/`api_key_env` (`XAI_API_KEY`), `reasoning_effort`, `timeout_seconds`, `total_timeout_seconds`, `retries`. The `x_search` tool is hidden until a credential resolves |
 | `[browser]` | Browser automation via `agent-browser`: `enabled`, `headless`, `cdp_port` (0=managed; >0 attaches to your Chrome, localhost only) + `attach_confirmed`, `allowed_domains`, `persist_profile`, `dialog_policy`, `restrict_evaluate`. The `browser` tool is hidden until the binary is installed (`npm install -g agent-browser && agent-browser install`). See docs/features/browser.md |
 | `[llm]` | `provider`, `model`, `api_key`, `base_url`, `proxy`, `[llm.provider_routing]` |

--- a/src/agentos/tools/builtin/shell.py
+++ b/src/agentos/tools/builtin/shell.py
@@ -51,6 +51,7 @@ from agentos.tools.types import (
     UnsupportedSurfaceError,
     current_tool_context,
 )
+from agentos.util.bounded_registry import BoundedRegistry
 
 log = structlog.get_logger(__name__)
 
@@ -89,8 +90,16 @@ PROCESS_ACTIONS: frozenset[str] = frozenset(
     {"eof", "kill", "list", "log", "poll", "remove", "submit", "write"}
 )
 
-# Background process session store
-_bg_sessions: dict[str, _BgSession] = {}
+# Background process session store. Time-scoped: a finished session is only
+# read back for a window after it ends, and a `process remove` is optional, so
+# without a ceiling one entry per background command survives for the life of
+# the process. A session whose process is still running is never evicted.
+_bg_sessions: BoundedRegistry[str, _BgSession] = BoundedRegistry(
+    shape="cache",
+    name="shell._bg_sessions",
+    session_of=lambda _key, session: session.session_key or "",
+    evictable=lambda session: session.done,
+)
 
 
 @dataclass
@@ -1227,7 +1236,7 @@ async def process(
     if action == "remove":
         if not session.done:
             raise ToolError(f"Cannot remove running session: {session.session_id}")
-        del _bg_sessions[session.session_id]
+        _bg_sessions.discard(session.session_id)
         return json.dumps({"status": "removed", "action": action, "session_id": session.session_id})
 
     if action in {"write", "submit"}:

--- a/src/agentos/util/__init__.py
+++ b/src/agentos/util/__init__.py
@@ -1,0 +1,19 @@
+"""Small shared primitives with no AgentOS-subsystem dependencies."""
+
+from agentos.util.bounded_registry import (
+    BoundedRegistry,
+    RegistryLimits,
+    configure_registry_limits,
+    drop_session_state,
+    registry_limits,
+    registry_stats,
+)
+
+__all__ = [
+    "BoundedRegistry",
+    "RegistryLimits",
+    "configure_registry_limits",
+    "drop_session_state",
+    "registry_limits",
+    "registry_stats",
+]

--- a/src/agentos/util/bounded_registry.py
+++ b/src/agentos/util/bounded_registry.py
@@ -1,0 +1,447 @@
+"""One bounded registry for every per-session dict in a long-lived process.
+
+Fifteen separate leak reports had the same shape: a registry keyed by a session
+id (or by a tuple containing one) that is inserted into and never evicted, so a
+gateway serving many short sessions grows one entry per session for the life of
+the process. Fixing them one at a time produced a different eviction policy per
+site — some TTL, some max-size, some LRU, some ``pop()`` on a terminal event —
+which is worse than the leak, because the next contributor has to learn fifteen
+slightly different lifetime rules.
+
+:class:`BoundedRegistry` is that one rule. The sites split into exactly two
+lifetime shapes and the primitive takes one configuration for each:
+
+``"session"``
+    State that belongs to a session and should disappear when the session does.
+    The correct trigger is the session's terminal event, which is what
+    :func:`drop_session_state` delivers; the size ceiling is the backstop for a
+    session that never emits one.
+
+``"cache"``
+    An entry that is only useful for a window after it is written. TTL plus a
+    size ceiling.
+
+Both ceilings come from :func:`registry_limits`, which the gateway configures
+at boot, so there is one place to reason about how much a process retains.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+import weakref
+from collections import OrderedDict
+from collections.abc import Callable, Iterable, Iterator, Mapping
+from dataclasses import dataclass, replace
+from typing import Any, Literal, overload
+
+RegistryShape = Literal["session", "cache"]
+
+DEFAULT_SESSION_MAX_ENTRIES = 512
+DEFAULT_CACHE_MAX_ENTRIES = 512
+DEFAULT_CACHE_TTL_SECONDS = 900.0
+
+
+@dataclass(frozen=True)
+class RegistryLimits:
+    """Process-wide ceilings for the two registry shapes."""
+
+    session_max_entries: int = DEFAULT_SESSION_MAX_ENTRIES
+    cache_max_entries: int = DEFAULT_CACHE_MAX_ENTRIES
+    cache_ttl_seconds: float = DEFAULT_CACHE_TTL_SECONDS
+
+
+_limits = RegistryLimits()
+_limits_lock = threading.Lock()
+
+
+def registry_limits() -> RegistryLimits:
+    """Return the ceilings in force right now."""
+
+    return _limits
+
+
+def configure_registry_limits(
+    *,
+    session_max_entries: int | None = None,
+    cache_max_entries: int | None = None,
+    cache_ttl_seconds: float | None = None,
+) -> RegistryLimits:
+    """Update the process-wide ceilings.
+
+    Registries resolve their limit on every write, so a registry built before
+    the gateway read its config still honours the configured value. A
+    non-positive value is ignored rather than disabling the bound.
+    """
+
+    global _limits
+    with _limits_lock:
+        updates: dict[str, Any] = {}
+        if session_max_entries is not None and session_max_entries > 0:
+            updates["session_max_entries"] = int(session_max_entries)
+        if cache_max_entries is not None and cache_max_entries > 0:
+            updates["cache_max_entries"] = int(cache_max_entries)
+        if cache_ttl_seconds is not None and cache_ttl_seconds > 0:
+            updates["cache_ttl_seconds"] = float(cache_ttl_seconds)
+        _limits = replace(_limits, **updates)
+        return _limits
+
+
+def reset_registry_limits() -> None:
+    """Restore boot defaults. For tests and gateway restarts."""
+
+    global _limits
+    with _limits_lock:
+        _limits = RegistryLimits()
+
+
+_MISSING = object()
+
+
+class BoundedRegistry[KT, VT]:
+    """A dict with an LRU ceiling, an optional TTL, and an eviction counter.
+
+    The read API mirrors the ``dict`` methods the call sites already used, so a
+    migration is a constructor change rather than a rewrite. Every operation
+    holds a re-entrant lock: several adopters are touched from both the event
+    loop and a worker thread.
+    """
+
+    __slots__ = (
+        "__weakref__",
+        "_entries",
+        "_evictable",
+        "_lock",
+        "_max_entries",
+        "_name",
+        "_now",
+        "_session_of",
+        "_shape",
+        "_ttl_seconds",
+        "evictions",
+        "expirations",
+    )
+
+    def __init__(
+        self,
+        *,
+        shape: RegistryShape = "session",
+        name: str = "",
+        max_entries: int | None = None,
+        ttl_seconds: float | None = None,
+        session_of: Callable[[KT, VT], str | None] | None = None,
+        evictable: Callable[[VT], bool] | None = None,
+        time_source: Callable[[], float] = time.monotonic,
+        register: bool = True,
+    ) -> None:
+        """Build a registry.
+
+        ``max_entries`` and ``ttl_seconds`` override the shape's configured
+        ceiling for a site with its own natural bound; leaving them ``None``
+        follows :func:`registry_limits`.
+
+        ``session_of`` maps an entry to the session id it belongs to — it is
+        given both the key and the value, because some registries carry the
+        session id in the value rather than the key — which is what
+        lets :func:`drop_session_state` evict this registry's share of a session
+        deterministically. A registry whose keys are not session-scoped leaves
+        it ``None`` and is simply skipped by that sweep.
+
+        ``evictable`` lets a site veto the removal of a value that is still in
+        use — a held ``asyncio.Lock`` is the motivating case, since dropping one
+        would hand the next caller a fresh lock and silently break the mutual
+        exclusion it was protecting. Both the ceiling sweep and
+        :meth:`discard_session` honour it; an explicit :meth:`discard` of a
+        single key does not, because that caller owns the entry.
+        """
+
+        self._entries: OrderedDict[KT, tuple[VT, float]] = OrderedDict()
+        self._lock = threading.RLock()
+        self._shape: RegistryShape = shape
+        self._name = name
+        self._max_entries = max_entries
+        self._ttl_seconds = ttl_seconds
+        self._session_of = session_of
+        self._evictable = evictable
+        self._now = time_source
+        self.evictions = 0
+        self.expirations = 0
+        if register:
+            _register(self)
+
+    # ── configuration ────────────────────────────────────────────────
+
+    @property
+    def name(self) -> str:
+        return self._name or type(self).__name__
+
+    @property
+    def max_entries(self) -> int:
+        if self._max_entries is not None:
+            return self._max_entries
+        limits = registry_limits()
+        return limits.session_max_entries if self._shape == "session" else limits.cache_max_entries
+
+    @property
+    def ttl_seconds(self) -> float | None:
+        if self._ttl_seconds is not None:
+            return self._ttl_seconds
+        return registry_limits().cache_ttl_seconds if self._shape == "cache" else None
+
+    # ── mapping surface ──────────────────────────────────────────────
+
+    def __len__(self) -> int:
+        with self._lock:
+            self._expire()
+            return len(self._entries)
+
+    def __contains__(self, key: object) -> bool:
+        with self._lock:
+            self._expire()
+            return key in self._entries
+
+    def __iter__(self) -> Iterator[KT]:
+        return iter(self.keys())
+
+    def keys(self) -> list[KT]:
+        with self._lock:
+            self._expire()
+            return list(self._entries)
+
+    def values(self) -> list[VT]:
+        with self._lock:
+            self._expire()
+            return [value for value, _ in self._entries.values()]
+
+    def items(self) -> list[tuple[KT, VT]]:
+        with self._lock:
+            self._expire()
+            return [(key, value) for key, (value, _) in self._entries.items()]
+
+    @overload
+    def get(self, key: KT) -> VT | None: ...
+
+    @overload
+    def get[D](self, key: KT, default: D) -> VT | D: ...
+
+    def get(self, key: KT, default: Any = None) -> Any:
+        with self._lock:
+            self._expire()
+            found = self._entries.get(key)
+            if found is None:
+                return default
+            self._entries.move_to_end(key)
+            return found[0]
+
+    def __getitem__(self, key: KT) -> VT:
+        found = self.get(key, _MISSING)  # type: ignore[arg-type]
+        if found is _MISSING:
+            raise KeyError(key)
+        return found  # type: ignore[return-value]
+
+    def set(self, key: KT, value: VT) -> VT:
+        with self._lock:
+            self._expire()
+            self._entries[key] = (value, self._now())
+            self._entries.move_to_end(key)
+            self._enforce_ceiling()
+            return value
+
+    def __setitem__(self, key: KT, value: VT) -> None:
+        self.set(key, value)
+
+    def setdefault(self, key: KT, default: VT) -> VT:
+        """Insert ``default`` when ``key`` is absent and return the live value.
+
+        Matches ``dict.setdefault``: ``default`` is always evaluated by the
+        caller, so a site that passes a freshly built lock keeps working.
+        """
+
+        with self._lock:
+            self._expire()
+            found = self._entries.get(key)
+            if found is not None:
+                self._entries.move_to_end(key)
+                return found[0]
+            return self.set(key, default)
+
+    @overload
+    def pop(self, key: KT) -> VT: ...
+
+    @overload
+    def pop[D](self, key: KT, default: D) -> VT | D: ...
+
+    def pop(self, key: KT, default: Any = _MISSING) -> Any:
+        with self._lock:
+            self._expire()
+            found = self._entries.pop(key, None)
+            if found is not None:
+                return found[0]
+            if default is _MISSING:
+                raise KeyError(key)
+            return default
+
+    def __delitem__(self, key: KT) -> None:
+        with self._lock:
+            del self._entries[key]
+
+    def discard(self, key: KT) -> bool:
+        """Drop ``key`` if present. Returns whether anything was removed."""
+
+        with self._lock:
+            return self._entries.pop(key, None) is not None
+
+    def discard_where(self, predicate: Callable[[KT, VT], bool]) -> int:
+        """Drop every entry matching ``predicate``. Returns how many went.
+
+        The predicate is given both key and value. Entries the site declared
+        busy via ``evictable`` are left in place.
+        """
+
+        with self._lock:
+            return self._discard(
+                [
+                    key
+                    for key, (value, _) in self._entries.items()
+                    if predicate(key, value) and self._is_evictable(value)
+                ]
+            )
+
+    def _discard(self, keys: list[KT]) -> int:
+        for key in keys:
+            del self._entries[key]
+        return len(keys)
+
+    def discard_session(self, session_id: str) -> int:
+        """Drop every entry belonging to ``session_id``.
+
+        A registry built without ``session_of`` cannot answer the question and
+        removes nothing.
+        """
+
+        session_of = self._session_of
+        if session_of is None:
+            return 0
+        with self._lock:
+            return self._discard(
+                [
+                    key
+                    for key, (value, _) in self._entries.items()
+                    if session_of(key, value) == session_id and self._is_evictable(value)
+                ]
+            )
+
+    def update(self, other: Mapping[KT, VT] | Iterable[tuple[KT, VT]]) -> None:
+        pairs = other.items() if isinstance(other, Mapping) else other
+        with self._lock:
+            for key, value in pairs:
+                self.set(key, value)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._entries.clear()
+
+    # ── observability ────────────────────────────────────────────────
+
+    def stats(self) -> dict[str, Any]:
+        with self._lock:
+            return {
+                "name": self.name,
+                "shape": self._shape,
+                "entries": len(self._entries),
+                "maxEntries": self.max_entries,
+                "ttlSeconds": self.ttl_seconds,
+                "evictions": self.evictions,
+                "expirations": self.expirations,
+            }
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"<BoundedRegistry {self.name} entries={len(self._entries)} max={self.max_entries}>"
+
+    # ── internals ────────────────────────────────────────────────────
+
+    def _expire(self) -> None:
+        ttl = self.ttl_seconds
+        if ttl is None or not self._entries:
+            return
+        cutoff = self._now() - ttl
+        # A site can veto eviction for a busy value (a running background
+        # process, a held lock). Every other path honours that veto; TTL was
+        # the one that did not, so a long-running process was dropped from
+        # its registry mid-flight — unreachable but still running (see #1131
+        # review). `set()` refreshes the timestamp, so an entry the site
+        # keeps re-inserting stays alive; a vetoed entry that is never
+        # touched again is skipped until the site releases it.
+        doomed = [
+            key
+            for key, (value, written) in self._entries.items()
+            if written <= cutoff and self._is_evictable(value)
+        ]
+        for key in doomed:
+            del self._entries[key]
+        self.expirations += len(doomed)
+
+    def _is_evictable(self, value: VT) -> bool:
+        if self._evictable is None:
+            return True
+        try:
+            return bool(self._evictable(value))
+        except Exception:  # noqa: BLE001 - a broken predicate must not pin memory
+            return True
+
+    def _enforce_ceiling(self) -> None:
+        ceiling = self.max_entries
+        if len(self._entries) <= ceiling:
+            return
+        # Least-recently-used first, skipping anything the site says is busy.
+        # A registry that is entirely busy stays over its ceiling rather than
+        # breaking the invariant the value protects; it drains as entries free.
+        for key in list(self._entries):
+            if len(self._entries) <= ceiling:
+                return
+            value, _ = self._entries[key]
+            if not self._is_evictable(value):
+                continue
+            del self._entries[key]
+            self.evictions += 1
+
+
+# ── process-wide teardown ────────────────────────────────────────────
+
+# Weak, so the table that exists to stop leaks cannot become one: a registry
+# owned by a discarded object (a per-test SessionStreamRegistry, a torn-down
+# ApprovalQueue) drops out of here when it is collected.
+_registries: weakref.WeakSet[BoundedRegistry[Any, Any]] = weakref.WeakSet()
+_registries_lock = threading.Lock()
+
+
+def _register(registry: BoundedRegistry[Any, Any]) -> None:
+    with _registries_lock:
+        _registries.add(registry)
+
+
+def _live_registries() -> list[BoundedRegistry[Any, Any]]:
+    with _registries_lock:
+        return list(_registries)
+
+
+def drop_session_state(session_key: str) -> int:
+    """Evict every registry's share of ``session_key``.
+
+    This is the deterministic half of the contract: the gateway calls it once
+    on a session's terminal event (delete / abort / completion) and every
+    session-scoped registry in the process drops that session immediately,
+    rather than ageing out behind a ceiling. Returns the number of entries
+    removed, for logging.
+    """
+
+    key = (session_key or "").strip()
+    if not key:
+        return 0
+    return sum(registry.discard_session(key) for registry in _live_registries())
+
+
+def registry_stats() -> list[dict[str, Any]]:
+    """Per-registry occupancy and eviction counts, for diagnostics."""
+
+    return [registry.stats() for registry in _live_registries()]

--- a/tests/test_ci/test_architecture_import_contracts.py
+++ b/tests/test_ci/test_architecture_import_contracts.py
@@ -8,6 +8,16 @@ from pathlib import Path
 PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "src" / "agentos"
 
 APPROVED_PACKAGE_IMPORTS: frozenset[tuple[str, str]] = frozenset({
+    # agentos.util holds dependency-free shared primitives (BoundedRegistry).
+    # It imports nothing from agentos, so these edges are leaves and cannot
+    # participate in a cycle.
+    ("application", "util"),
+    ("engine", "util"),
+    ("gateway", "util"),
+    ("plan_mode.py", "util"),
+    ("sandbox", "util"),
+    ("session", "util"),
+    ("tools", "util"),
     ("agents", "gateway"),
     ("agents", "identity"),
     ("agents", "onboarding"),

--- a/tests/test_util/test_bounded_registry.py
+++ b/tests/test_util/test_bounded_registry.py
@@ -1,0 +1,428 @@
+"""The one shared contract every bounded registry adopter relies on."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from agentos.util.bounded_registry import (
+    BoundedRegistry,
+    configure_registry_limits,
+    drop_session_state,
+    registry_limits,
+    registry_stats,
+    reset_registry_limits,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_limits():
+    reset_registry_limits()
+    yield
+    reset_registry_limits()
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+# ── the property the issue asks every adopter to reuse ───────────────
+
+
+@pytest.mark.parametrize("inserts,ceiling", [(100, 10), (1000, 8), (5, 5), (17, 1)])
+def test_n_inserts_under_a_max_of_m_leaves_at_most_m(inserts: int, ceiling: int) -> None:
+    registry: BoundedRegistry[str, int] = BoundedRegistry(max_entries=ceiling, register=False)
+
+    for i in range(inserts):
+        registry[f"session-{i}"] = i
+
+    assert len(registry) == min(inserts, ceiling)
+    assert registry.evictions == max(0, inserts - ceiling)
+
+
+def test_explicit_discard_drops_immediately() -> None:
+    registry: BoundedRegistry[str, int] = BoundedRegistry(max_entries=100, register=False)
+    registry["s1"] = 1
+
+    assert registry.discard("s1") is True
+    assert "s1" not in registry
+    assert len(registry) == 0
+    assert registry.discard("s1") is False
+
+
+# ── LRU semantics ────────────────────────────────────────────────────
+
+
+def test_eviction_is_least_recently_used_not_first_inserted() -> None:
+    registry: BoundedRegistry[str, int] = BoundedRegistry(max_entries=3, register=False)
+    registry["a"] = 1
+    registry["b"] = 2
+    registry["c"] = 3
+
+    registry.get("a")  # a is now the most recent
+    registry["d"] = 4  # evicts b
+
+    assert sorted(registry.keys()) == ["a", "c", "d"]
+
+
+def test_rewriting_a_key_refreshes_it_without_growing() -> None:
+    registry: BoundedRegistry[str, int] = BoundedRegistry(max_entries=2, register=False)
+    registry["a"] = 1
+    registry["b"] = 2
+    registry["a"] = 3
+
+    registry["c"] = 4
+
+    assert sorted(registry.keys()) == ["a", "c"]
+    assert registry.get("a") == 3
+
+
+def test_setdefault_keeps_the_live_value() -> None:
+    registry: BoundedRegistry[str, list[int]] = BoundedRegistry(max_entries=4, register=False)
+
+    first = registry.setdefault("a", [])
+    first.append(1)
+    second = registry.setdefault("a", [])
+
+    assert second is first
+    assert second == [1]
+
+
+def test_pop_returns_default_and_raises_without_one() -> None:
+    registry: BoundedRegistry[str, int] = BoundedRegistry(max_entries=4, register=False)
+    registry["a"] = 1
+
+    assert registry.pop("a") == 1
+    assert registry.pop("a", None) is None
+    with pytest.raises(KeyError):
+        registry.pop("a")
+
+
+# ── TTL ──────────────────────────────────────────────────────────────
+
+
+def test_ttl_expires_entries_without_touching_fresh_ones() -> None:
+    clock = _Clock()
+    registry: BoundedRegistry[str, int] = BoundedRegistry(
+        max_entries=100, ttl_seconds=60, time_source=clock, register=False
+    )
+    registry["old"] = 1
+    clock.advance(61)
+    registry["new"] = 2
+
+    assert registry.keys() == ["new"]
+    assert registry.get("old") is None
+    assert registry.expirations == 1
+
+
+def test_ttl_is_measured_from_the_write_not_the_read() -> None:
+    clock = _Clock()
+    registry: BoundedRegistry[str, int] = BoundedRegistry(
+        max_entries=100, ttl_seconds=60, time_source=clock, register=False
+    )
+    registry["a"] = 1
+    clock.advance(30)
+    assert registry.get("a") == 1
+    clock.advance(31)
+
+    assert registry.get("a") is None
+
+
+def test_ttl_sweep_skips_non_evictable_entries() -> None:
+    """A site-vetoed entry survives the TTL sweep, like every other path.
+
+    Regression for the #1131 review: ``_expire`` was the one eviction path
+    that did not consult ``_is_evictable``, so a running background process in
+    a cache-shaped registry was dropped after the TTL while still alive.
+    """
+    clock = _Clock()
+    registry: BoundedRegistry[str, str] = BoundedRegistry(
+        max_entries=100,
+        ttl_seconds=60,
+        time_source=clock,
+        register=False,
+        evictable=lambda value: value != "busy",
+    )
+    registry["running"] = "busy"
+    registry["idle"] = "free"
+    clock.advance(61)
+
+    # The sweep runs on the next read: the idle entry expires, the busy one stays.
+    assert registry.keys() == ["running"]
+    assert registry.get("running") == "busy"
+    assert registry.expirations == 1
+
+
+def test_ttl_sweep_still_expires_a_vetoed_entry_once_released() -> None:
+    clock = _Clock()
+    state = {"busy": True}
+    registry: BoundedRegistry[str, str] = BoundedRegistry(
+        max_entries=100,
+        ttl_seconds=60,
+        time_source=clock,
+        register=False,
+        evictable=lambda value: not state["busy"],
+    )
+    registry["proc"] = "value"
+    clock.advance(61)
+    assert registry.get("proc") == "value"  # vetoed, still pinned
+
+    state["busy"] = False
+    clock.advance(1)
+    assert registry.get("proc") is None
+
+
+def test_a_session_shaped_registry_has_no_ttl() -> None:
+    registry: BoundedRegistry[str, int] = BoundedRegistry(shape="session", register=False)
+
+    assert registry.ttl_seconds is None
+
+
+# ── configured ceilings ──────────────────────────────────────────────
+
+
+def test_ceilings_follow_configuration_even_for_existing_registries() -> None:
+    registry: BoundedRegistry[str, int] = BoundedRegistry(shape="session", register=False)
+    assert registry.max_entries == registry_limits().session_max_entries
+
+    configure_registry_limits(session_max_entries=3)
+    for i in range(10):
+        registry[f"s{i}"] = i
+
+    assert registry.max_entries == 3
+    assert len(registry) == 3
+
+
+def test_cache_shape_reads_the_cache_ceiling_and_ttl() -> None:
+    configure_registry_limits(cache_max_entries=7, cache_ttl_seconds=42)
+    registry: BoundedRegistry[str, int] = BoundedRegistry(shape="cache", register=False)
+
+    assert registry.max_entries == 7
+    assert registry.ttl_seconds == 42
+
+
+def test_an_explicit_limit_wins_over_configuration() -> None:
+    registry: BoundedRegistry[str, int] = BoundedRegistry(max_entries=2, register=False)
+    configure_registry_limits(session_max_entries=1000)
+
+    assert registry.max_entries == 2
+
+
+@pytest.mark.parametrize("bad", [0, -1])
+def test_a_nonpositive_ceiling_is_ignored_rather_than_disabling_the_bound(bad: int) -> None:
+    before = registry_limits().session_max_entries
+
+    configure_registry_limits(session_max_entries=bad)
+
+    assert registry_limits().session_max_entries == before
+
+
+# ── session teardown ─────────────────────────────────────────────────
+
+
+def test_drop_session_state_reaches_every_registered_registry() -> None:
+    plain: BoundedRegistry[str, int] = BoundedRegistry(
+        name="plain", session_of=lambda key, _value: key, register=True
+    )
+    tupled: BoundedRegistry[tuple[str, str], int] = BoundedRegistry(
+        name="tupled", session_of=lambda key, _value: key[0], register=True
+    )
+    unscoped: BoundedRegistry[str, int] = BoundedRegistry(name="unscoped", register=True)
+
+    plain["s1"] = 1
+    plain["s2"] = 2
+    tupled[("s1", "a")] = 1
+    tupled[("s1", "b")] = 2
+    tupled[("s2", "a")] = 3
+    unscoped["s1"] = 1
+
+    removed = drop_session_state("s1")
+
+    assert removed == 3
+    assert plain.keys() == ["s2"]
+    assert tupled.keys() == [("s2", "a")]
+    assert unscoped.keys() == ["s1"], "a registry without session_of is left alone"
+
+
+@pytest.mark.parametrize("session_key", ["", "   ", None])
+def test_drop_session_state_ignores_an_empty_key(session_key: str | None) -> None:
+    registry: BoundedRegistry[str, int] = BoundedRegistry(session_of=lambda key, _value: key)
+    registry[""] = 1
+
+    assert drop_session_state(session_key) == 0  # type: ignore[arg-type]
+    assert len(registry) == 1
+
+
+def test_discard_session_on_an_unscoped_registry_removes_nothing() -> None:
+    registry: BoundedRegistry[str, int] = BoundedRegistry(register=False)
+    registry["s1"] = 1
+
+    assert registry.discard_session("s1") == 0
+    assert len(registry) == 1
+
+
+# ── observability ────────────────────────────────────────────────────
+
+
+def test_stats_report_occupancy_and_evictions() -> None:
+    registry: BoundedRegistry[str, int] = BoundedRegistry(name="demo", max_entries=2, register=True)
+    for i in range(5):
+        registry[f"s{i}"] = i
+
+    stats = registry.stats()
+    assert stats["name"] == "demo"
+    assert stats["entries"] == 2
+    assert stats["maxEntries"] == 2
+    assert stats["evictions"] == 3
+    assert any(row["name"] == "demo" for row in registry_stats())
+
+
+# ── thread safety ────────────────────────────────────────────────────
+
+
+def test_concurrent_writers_never_exceed_the_ceiling() -> None:
+    registry: BoundedRegistry[str, int] = BoundedRegistry(max_entries=16, register=False)
+    errors: list[BaseException] = []
+
+    def worker(offset: int) -> None:
+        try:
+            for i in range(200):
+                registry[f"s{offset}-{i}"] = i
+                registry.get(f"s{offset}-{i}")
+                registry.discard(f"s{offset}-{i - 5}")
+        except BaseException as exc:  # noqa: BLE001 - surfaced below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(n,)) for n in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert errors == []
+    assert len(registry) <= 16
+
+
+# ── busy entries are never evicted ───────────────────────────────────
+
+
+class _Lockish:
+    def __init__(self, held: bool = False) -> None:
+        self.held = held
+
+    def locked(self) -> bool:
+        return self.held
+
+
+def test_a_busy_entry_survives_the_ceiling_sweep() -> None:
+    registry: BoundedRegistry[str, _Lockish] = BoundedRegistry(
+        max_entries=2, evictable=lambda lock: not lock.locked(), register=False
+    )
+    held = _Lockish(held=True)
+    registry["busy"] = held
+    registry["a"] = _Lockish()
+    registry["b"] = _Lockish()
+    registry["c"] = _Lockish()
+
+    assert "busy" in registry
+    assert len(registry) == 2
+
+
+def test_an_all_busy_registry_stays_over_its_ceiling_rather_than_lying() -> None:
+    registry: BoundedRegistry[str, _Lockish] = BoundedRegistry(
+        max_entries=1, evictable=lambda lock: not lock.locked(), register=False
+    )
+    for i in range(4):
+        registry[f"s{i}"] = _Lockish(held=True)
+
+    assert len(registry) == 4
+    assert registry.evictions == 0
+
+    for key in registry.keys():
+        registry.get(key).held = False  # type: ignore[union-attr]
+    registry["s9"] = _Lockish()
+
+    assert len(registry) == 1
+
+
+def test_session_teardown_leaves_a_busy_entry_alone() -> None:
+    registry: BoundedRegistry[str, _Lockish] = BoundedRegistry(
+        session_of=lambda key, _value: key, evictable=lambda lock: not lock.locked(), register=False
+    )
+    registry["s1"] = _Lockish(held=True)
+
+    assert registry.discard_session("s1") == 0
+    assert "s1" in registry
+
+
+def test_explicit_discard_ignores_the_busy_veto() -> None:
+    registry: BoundedRegistry[str, _Lockish] = BoundedRegistry(
+        evictable=lambda lock: not lock.locked(), register=False
+    )
+    registry["s1"] = _Lockish(held=True)
+
+    assert registry.discard("s1") is True
+
+
+def test_a_raising_evictable_predicate_does_not_pin_memory() -> None:
+    def boom(_value: int) -> bool:
+        raise RuntimeError("nope")
+
+    registry: BoundedRegistry[str, int] = BoundedRegistry(
+        max_entries=2, evictable=boom, register=False
+    )
+    for i in range(10):
+        registry[f"s{i}"] = i
+
+    assert len(registry) == 2
+
+
+def test_session_of_can_read_the_session_id_out_of_the_value() -> None:
+    """Some registries key by their own id and carry the session in the value."""
+
+    class _Job:
+        def __init__(self, owner: str) -> None:
+            self.owner = owner
+
+    registry: BoundedRegistry[str, _Job] = BoundedRegistry(
+        session_of=lambda _key, job: job.owner, register=False
+    )
+    registry["job-1"] = _Job("s1")
+    registry["job-2"] = _Job("s2")
+
+    assert registry.discard_session("s1") == 1
+    assert registry.keys() == ["job-2"]
+
+
+def test_dict_round_trip_matches_the_mapping_surface_callers_already_use() -> None:
+    registry: BoundedRegistry[str, int] = BoundedRegistry(max_entries=10, register=False)
+    registry.update({"a": 1, "b": 2})
+
+    snapshot = dict(registry)
+    registry.clear()
+    registry.update(snapshot)
+
+    assert dict(registry) == {"a": 1, "b": 2}
+    assert registry["a"] == 1
+    with pytest.raises(KeyError):
+        registry["missing"]
+
+
+def test_the_teardown_table_does_not_itself_retain_dead_registries() -> None:
+    """The table that exists to stop leaks must not become one."""
+    import gc
+
+    before = len(registry_stats())
+    for _ in range(50):
+        BoundedRegistry(name="ephemeral", session_of=lambda key, _value: key)
+    gc.collect()
+
+    assert len(registry_stats()) <= before + 1

--- a/tests/test_util/test_bounded_registry_adoption.py
+++ b/tests/test_util/test_bounded_registry_adoption.py
@@ -1,0 +1,177 @@
+"""Every site the leak reports named is behind the shared primitive.
+
+The point of #1131 is that these twenty dicts stop having twenty different
+lifetime rules, so the check is structural: each named field is a
+``BoundedRegistry``, and a session's terminal event reaches every one that is
+session-scoped.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from agentos.application.approval_queue import ApprovalQueue
+from agentos.application.intent_cache import IntentApprovalCache
+from agentos.engine.cache_break_monitor import CacheBreakMonitor
+from agentos.engine.progress_watchdog import ProgressWatchdog
+from agentos.engine.subagent import SubagentRegistry
+from agentos.gateway.session_streams import SessionStreamRegistry
+from agentos.plan_mode import PlanModeStore
+from agentos.sandbox.governance import DenialLedger
+from agentos.sandbox.stale_output_cache import StaleOutputCache
+from agentos.tools.builtin import shell
+from agentos.util.bounded_registry import BoundedRegistry, drop_session_state
+
+
+def _field(owner: object, name: str) -> BoundedRegistry:
+    value = getattr(owner, name)
+    assert isinstance(value, BoundedRegistry), f"{type(owner).__name__}.{name} is {type(value)}"
+    return value
+
+
+@pytest.mark.parametrize(
+    "factory,fields",
+    [
+        (SessionStreamRegistry, ["_seq_by_session", "_events_by_session"]),
+        (StaleOutputCache, ["_entries"]),
+        (SubagentRegistry, ["_archived"]),
+        (PlanModeStore, ["_sessions"]),
+        (DenialLedger, ["_sessions"]),
+        (ProgressWatchdog, ["_repeat_counts", "_repeat_results"]),
+        (CacheBreakMonitor, ["_baselines"]),
+        (IntentApprovalCache, ["_entries"]),
+    ],
+)
+def test_named_sites_are_bounded(factory, fields: list[str]) -> None:
+    owner = factory()
+    for name in fields:
+        _field(owner, name)
+
+
+def test_approval_queue_sites_are_bounded(tmp_path) -> None:
+    queue = ApprovalQueue(db_path=str(tmp_path / "approvals.db"))
+    try:
+        _field(queue, "_node_settings")
+        _field(queue, "_session_elevated_modes")
+    finally:
+        queue.close()
+
+
+def test_module_level_shell_session_store_is_bounded() -> None:
+    assert isinstance(shell._bg_sessions, BoundedRegistry)
+
+
+def test_a_running_background_session_survives_the_ttl_sweep() -> None:
+    """A still-running process is never dropped by the TTL (review of #1131).
+
+    ``_bg_sessions`` is cache-shaped with ``evictable=lambda session:
+    session.done``. Before the fix, ``_expire`` ignored the veto, so a dev
+    server or long build was evicted from the registry after the TTL while its
+    OS process kept running — ``process poll``/``log``/``kill`` then reported
+    the session gone. The TTL clock starts at spawn and ``get()`` does not
+    refresh it, so a 15-minute process is the normal case, not the edge.
+    """
+    store: BoundedRegistry = shell._bg_sessions
+    original_now = store._now
+    monkey_now = {"t": 1000.0}
+    store._now = lambda: monkey_now["t"]  # type: ignore[method-assign]
+
+    running = shell._BgSession(  # type: ignore[attr-defined]
+        session_id="sess-running",
+        command="sleep 9999",
+        process=None,  # type: ignore[arg-type]
+        session_key="agent:main:one",
+        done=False,
+    )
+    finished = shell._BgSession(  # type: ignore[attr-defined]
+        session_id="sess-done",
+        command="true",
+        process=None,  # type: ignore[arg-type]
+        session_key="agent:main:one",
+        done=True,
+    )
+    try:
+        store[running.session_id] = running
+        store[finished.session_id] = finished
+
+        ttl = store.ttl_seconds or 900.0
+        monkey_now["t"] = 1000.0 + ttl + 1
+        # Trigger the sweep, then read both keys back.
+        assert store.get("sess-running") is running
+        assert store.get("sess-done") is None
+    finally:
+        store.discard("sess-running")
+        store.discard("sess-done")
+        store._now = original_now  # type: ignore[method-assign]
+
+
+def test_turn_runner_snapshot_fields_are_bounded() -> None:
+    from agentos.engine import runtime
+
+    source = runtime.__file__
+    with open(source, encoding="utf-8") as handle:
+        text = handle.read()
+    for field in ("_memory_snapshots", "_bootstrap_snapshots"):
+        assert f"self.{field}: BoundedRegistry" in text or f"self.{field}: dict" not in text
+
+
+def test_usage_tracker_fields_are_bounded() -> None:
+    from agentos.engine import usage
+
+    with open(usage.__file__, encoding="utf-8") as handle:
+        text = handle.read()
+    assert "self._scopes: dict" not in text
+    assert "self._session_metadata: dict" not in text
+
+
+def test_task_runtime_lock_fields_are_bounded() -> None:
+    from agentos.gateway import task_runtime
+
+    with open(task_runtime.__file__, encoding="utf-8") as handle:
+        text = handle.read()
+    assert "self._session_locks: dict" not in text
+    assert "self._session_execution_locks: dict" not in text
+
+
+# ── the terminal event actually reaches them ─────────────────────────
+
+
+def test_evict_session_runtime_state_drops_bounded_registry_entries() -> None:
+    from agentos.session.runtime_state import evict_session_runtime_state
+
+    streams = SessionStreamRegistry()
+    plan = PlanModeStore()
+    monitor = CacheBreakMonitor()
+
+    streams.record("doomed", "session.event.run_start", {})
+    streams.record("kept", "session.event.run_start", {})
+    plan.enable("doomed")
+    plan.enable("kept")
+    monitor._baselines["doomed"] = object()  # type: ignore[assignment]
+
+    evict_session_runtime_state("doomed")
+
+    assert streams.current_seq("doomed") == 0
+    assert streams.current_seq("kept") == 1
+    assert plan.is_enabled("doomed") is False
+    assert plan.is_enabled("kept") is True
+    assert "doomed" not in monitor._baselines
+
+
+def test_denial_ledger_session_state_is_dropped_on_teardown() -> None:
+    ledger = DenialLedger()
+
+    async def scenario() -> int:
+        await ledger.record_denial("doomed", "fp", "policy")  # type: ignore[arg-type]
+        await ledger.record_denial("kept", "fp", "policy")  # type: ignore[arg-type]
+        drop_session_state("doomed")
+        return await ledger.count_session("kept")
+
+    assert asyncio.run(scenario()) == 1
+
+    async def check() -> int:
+        return await ledger.count_session("doomed")
+
+    assert asyncio.run(check()) == 0


### PR DESCRIPTION
Closes #1131

## Summary

A rebased, blocker-fixed port of @iamhaniofficial's #1355 — the primitive, the twenty-site adoption, and the tests are their work (`Co-authored-by:` on the commit), carried onto current `main` (one CHANGELOG conflict resolved).

**The review on #1355 said this was the best of the five candidates and named one blocker: `_expire()` was the only eviction path that ignored the site's `evictable` veto.**

`_enforce_ceiling`, `discard_session` and `discard_where` all honoured it; `_expire` deleted unconditionally. `shell._bg_sessions` is declared `shape="cache"` with `evictable=lambda session: session.done`, so a still-running background process — the normal case for a dev server, watcher or long build — was dropped from the registry 900 s after spawn, while the OS process kept running. After the sweep, `process poll`, `process log`, `process kill` and `process list` all reported the session gone and the cleanup callbacks never fired. A memory-leak fix that orphans processes is a worse trade than the leak.

**The fix, as the review suggested (option 1):** `_expire()` now skips entries the site vetoed, so `evictable` means one thing on all four paths. A vetoed entry is expired as soon as the site releases it. Two regression tests:

- `test_ttl_sweep_skips_non_evictable_entries` (primitive level: a vetoed entry outlives the sweep, an unvetoed sibling does not)
- `test_a_running_background_session_survives_the_ttl_sweep` (at the `_bg_sessions` level: a running session is still reachable past the TTL, a finished one is expired)

Both fail on the unfixed `_expire` and pass with it.

## Verification

- `uv run pytest tests/test_util -q` — 50 passed.
- `uv run ruff check` and `uv run mypy` clean on the touched files.
- The three `test_shell_process_isolation` failures in `test_tools` are environment-sensitive and fail on a clean tree too (17 failures on unmodified `main` here) — not from this change.

Refs #1355 (the original PR; this supersedes it with the review blocker fixed).