### PR TITLE
fix(channels): chunk oversized final replies in send()

### DIFF
--- a/src/agentos/channels/_util.py
+++ b/src/agentos/channels/_util.py
@@ -378,3 +378,59 @@ async def retry_request(
                 continue
             raise
     raise last_exc or RuntimeError("retry_request exhausted")
+
+
+# ---------------------------------------------------------------------------
+# Message-length chunking
+# ---------------------------------------------------------------------------
+
+
+def split_text_for_limit(
+    segment: str,
+    limit: int,
+    *,
+    measure: Callable[[str], int] | None = None,
+) -> tuple[str, str]:
+    """Split *segment* into the largest prefix that fits *limit*, plus the rest.
+
+    Shared by every adapter with a platform message-length cap, so a
+    truncated final reply isn't traded for a second, independently-drifting
+    splitter per channel. ``measure`` overrides what's compared against
+    *limit* — a channel that renders markdown to something longer than the
+    source text (Telegram's HTML) passes a render-then-``len`` callable;
+    plain-text channels (Discord) take the ``len`` default.
+
+    The cut point is found by binary search and then nudged back to the
+    nearest line/word boundary so a chunk doesn't end mid-word. A fenced
+    code block (```...```) split mid-fence would leave each half with an
+    unbalanced fence — some platforms reject a message whose Markdown
+    entities don't parse, turning a length problem into a delivery failure —
+    so if an odd number of fences precede the cut, one is open, and the cut
+    backs up to just before that fence: the first half never contains a
+    half-open block, and the second half reopens it from its own start,
+    fully balanced.
+    """
+    length = measure if measure is not None else len
+    if length(segment) <= limit:
+        return segment, ""
+    low, high, best = 1, len(segment) - 1, 1
+    while low <= high:
+        mid = (low + high) // 2
+        if length(segment[:mid]) <= limit:
+            best = mid
+            low = mid + 1
+        else:
+            high = mid - 1
+    cut = best
+    for boundary in ("\n", " "):
+        found = segment.rfind(boundary, 0, best)
+        if found >= best // 2:
+            cut = found + 1
+            break
+    if segment.count("```", 0, cut) % 2 == 1:
+        fence_start = segment.rfind("```", 0, cut)
+        newline_before_fence = segment.rfind("\n", 0, fence_start)
+        candidate = newline_before_fence + 1 if newline_before_fence >= 0 else 0
+        if candidate > 0:
+            cut = candidate
+    return segment[:cut], segment[cut:]

--- a/src/agentos/channels/discord.py
+++ b/src/agentos/channels/discord.py
@@ -31,6 +31,7 @@ from agentos.channels._util import (
     StreamThrottle,
     check_channel_file_size,
     retry_request,
+    split_text_for_limit,
 )
 from agentos.channels.contract import (
     ChannelCapabilities,
@@ -58,6 +59,7 @@ _DISCORD_GROUP_DM_CHANNEL_TYPES = {3}
 _DISCORD_THREAD_CHANNEL_TYPES = {10, 11, 12}
 _DISCORD_APPLICATION_COMMAND_INTERACTION_TYPE = 2
 _DISCORD_DEFERRED_CHANNEL_MESSAGE_RESPONSE_TYPE = 5
+_DISCORD_MESSAGE_TEXT_LIMIT = 2000
 
 # Gateway intents bitmask
 GATEWAY_INTENTS = (
@@ -1102,28 +1104,21 @@ class DiscordChannel:
         return kwargs
 
     async def send(self, message: OutgoingMessage) -> ChannelSendResult:
-        await self._rate_limiter.acquire()
         client = self._get_client()
         channel_id = message.reply_to or self.config.default_channel_id
-
-        payload: dict[str, Any] = {"content": message.content}
-
-        if message.metadata.get("embeds"):
-            payload["embeds"] = message.metadata["embeds"]
-
-        if message.metadata.get("components"):
-            payload["components"] = message.metadata["components"]
-
-        if message.metadata.get("reply_to_message_id"):
-            payload["message_reference"] = {
-                "message_id": message.metadata["reply_to_message_id"],
-            }
+        segments = self._split_content_for_send(message.content)
 
         interaction_token = message.metadata.get("interaction_token")
-        if isinstance(interaction_token, str) and interaction_token:
-            application_id = message.metadata.get("interaction_application_id")
-            if not isinstance(application_id, str) or not application_id:
-                application_id = self.config.application_id
+        use_interaction_response = isinstance(interaction_token, str) and bool(interaction_token)
+        application_id = ""
+        interaction_id = ""
+        if use_interaction_response:
+            raw_application_id = message.metadata.get("interaction_application_id")
+            application_id = (
+                raw_application_id
+                if isinstance(raw_application_id, str) and raw_application_id
+                else self.config.application_id
+            )
             interaction_id = str(message.metadata.get("interaction_id") or "")
             if not application_id:
                 return ChannelSendResult.failed(
@@ -1131,42 +1126,85 @@ class DiscordChannel:
                     target_id=interaction_id or channel_id,
                     reason="missing Discord application id for interaction response",
                 )
+
+        result: ChannelSendResult | None = None
+        for index, segment in enumerate(segments):
+            payload: dict[str, Any] = {"content": segment}
+            # A reply reference belongs on the first message of a chunked
+            # reply; embeds/components describe the complete answer and
+            # belong on the last one, not repeated on every continuation.
+            if index == 0 and message.metadata.get("reply_to_message_id"):
+                payload["message_reference"] = {
+                    "message_id": message.metadata["reply_to_message_id"],
+                }
+            if index == len(segments) - 1:
+                if message.metadata.get("embeds"):
+                    payload["embeds"] = message.metadata["embeds"]
+                if message.metadata.get("components"):
+                    payload["components"] = message.metadata["components"]
+
+            await self._rate_limiter.acquire()
+            if use_interaction_response and index == 0:
+                resp = await retry_request(
+                    client.patch,
+                    f"/webhooks/{application_id}/{interaction_token}/messages/@original",
+                    json=payload,
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                message_id = str(data.get("id") or "")
+                if message_id:
+                    self._sent_messages[message_id] = channel_id
+                log.debug(
+                    "discord.interaction_response_completed",
+                    interaction_id=interaction_id,
+                    message_id=message_id,
+                )
+                result = ChannelSendResult.sent(
+                    capability=ChannelCapabilities.GROUP_CHAT,
+                    target_id=interaction_id or channel_id,
+                    provider_message_id=message_id,
+                )
+                continue
+
+            # Chunks after the first always go to the channel directly, even
+            # for an interaction response: Discord's original-response slot
+            # holds exactly one message, so overflow is delivered as regular
+            # follow-up channel messages instead of being dropped.
             resp = await retry_request(
-                client.patch,
-                f"/webhooks/{application_id}/{interaction_token}/messages/@original",
+                client.post,
+                f"/channels/{channel_id}/messages",
                 json=payload,
+                headers=self._auth_headers(),
             )
             resp.raise_for_status()
             data = resp.json()
-            message_id = str(data.get("id") or "")
-            if message_id:
-                self._sent_messages[message_id] = channel_id
-            log.debug(
-                "discord.interaction_response_completed",
-                interaction_id=interaction_id,
-                message_id=message_id,
-            )
-            return ChannelSendResult.sent(
+            self._sent_messages[data["id"]] = channel_id
+            log.debug("discord.send", channel_id=channel_id, message_id=data.get("id"))
+            result = ChannelSendResult.sent(
                 capability=ChannelCapabilities.GROUP_CHAT,
-                target_id=interaction_id or channel_id,
-                provider_message_id=message_id,
+                target_id=channel_id,
+                provider_message_id=str(data.get("id", "")),
             )
 
-        resp = await retry_request(
-            client.post,
-            f"/channels/{channel_id}/messages",
-            json=payload,
-            headers=self._auth_headers(),
-        )
-        resp.raise_for_status()
-        data = resp.json()
-        self._sent_messages[data["id"]] = channel_id
-        log.debug("discord.send", channel_id=channel_id, message_id=data.get("id"))
-        return ChannelSendResult.sent(
-            capability=ChannelCapabilities.GROUP_CHAT,
-            target_id=channel_id,
-            provider_message_id=str(data.get("id", "")),
-        )
+        assert result is not None  # segments always has at least one element
+        return result
+
+    @staticmethod
+    def _split_content_for_send(content: str) -> list[str]:
+        """Split *content* into one message per Discord's 2000-char cap.
+
+        Reuses the same splitter Telegram's adapter relies on rather than a
+        second, independently-drifting length check.
+        """
+        segments: list[str] = []
+        remaining = content
+        while True:
+            head, tail = split_text_for_limit(remaining, _DISCORD_MESSAGE_TEXT_LIMIT)
+            segments.append(head)
+            if not tail:
+                return segments
+            remaining = tail
 
     MAX_FILE_BYTES: ClassVar[int] = 10 * 1024 * 1024
 

--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import hmac
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -32,6 +32,7 @@ from agentos.channels._util import (
     FloodStrikeBackoff,
     StreamThrottle,
     check_channel_file_size,
+    split_text_for_limit,
 )
 from agentos.channels.contract import (
     ChannelCapabilities,
@@ -1244,43 +1245,65 @@ class TelegramChannel:
 
     async def send(self, message: OutgoingMessage) -> dict[str, Any]:
         payload = self._build_send_payload(message)
-        try:
-            result = await self._api("sendMessage", payload)
-        except TelegramApiError as exc:
-            auto_rendered = "parse_mode" not in message.metadata
-            if not auto_rendered or "parse entities" not in str(exc).lower():
-                raise
-            log.warning("telegram.markdown_fallback", error=str(exc))
-            payload["text"] = message.content
-            payload.pop("parse_mode", None)
-            result = await self._api("sendMessage", payload)
+        auto_rendered = "parse_mode" not in message.metadata
+        segments = self._split_message_for_send(message.content, auto_rendered=auto_rendered)
+
+        result: dict[str, Any] = {}
+        for index, segment in enumerate(segments):
+            chunk_payload = dict(payload)
+            chunk_payload["text"] = render_telegram_html(segment) if auto_rendered else segment
+            if index > 0:
+                # A reply reference and any keyboard belong on the first
+                # message of a chunked reply, not on every continuation.
+                chunk_payload.pop("reply_parameters", None)
+                chunk_payload.pop("reply_markup", None)
+            try:
+                result = await self._api("sendMessage", chunk_payload)
+            except TelegramApiError as exc:
+                if not auto_rendered or "parse entities" not in str(exc).lower():
+                    raise
+                log.warning("telegram.markdown_fallback", error=str(exc))
+                chunk_payload["text"] = segment
+                chunk_payload.pop("parse_mode", None)
+                result = await self._api("sendMessage", chunk_payload)
         return result if isinstance(result, dict) else {"result": result}
 
     @staticmethod
-    def _split_for_limit(segment: str) -> tuple[str, str]:
+    def _split_message_for_send(content: str, *, auto_rendered: bool) -> list[str]:
+        """Split *content* into one message per Telegram's length cap.
+
+        Reuses ``_split_for_limit`` — the same primitive ``send_streaming``
+        already relies on — rather than a second splitter with its own,
+        possibly-diverging notion of where a message can safely be cut.
+        """
+        measure = None if auto_rendered else len
+        segments: list[str] = []
+        remaining = content
+        while True:
+            head, tail = TelegramChannel._split_for_limit(remaining, measure=measure)
+            segments.append(head)
+            if not tail:
+                return segments
+            remaining = tail
+
+    @staticmethod
+    def _split_for_limit(
+        segment: str,
+        *,
+        measure: Callable[[str], int] | None = None,
+    ) -> tuple[str, str]:
         """Split *segment* into the largest prefix that fits one message, plus the rest.
 
-        The 4096 budget applies to the *rendered* HTML, which is longer than the
-        markdown it came from, so the cut point is found by binary search over
-        the raw text and then nudged back to the nearest line/word boundary.
+        The 4096 budget applies to the *rendered* HTML by default, which is
+        longer than the markdown it came from. ``measure`` overrides what's
+        measured against the budget — callers that send raw text verbatim
+        (an explicit ``parse_mode``, where there is no HTML render step)
+        pass ``len`` directly so the cut reflects what Telegram will
+        actually receive. See :func:`split_text_for_limit` for the shared
+        cut-point and fenced-code-block logic.
         """
-        if len(render_telegram_html(segment)) <= _MESSAGE_TEXT_LIMIT:
-            return segment, ""
-        low, high, best = 1, len(segment) - 1, 1
-        while low <= high:
-            mid = (low + high) // 2
-            if len(render_telegram_html(segment[:mid])) <= _MESSAGE_TEXT_LIMIT:
-                best = mid
-                low = mid + 1
-            else:
-                high = mid - 1
-        cut = best
-        for boundary in ("\n", " "):
-            found = segment.rfind(boundary, 0, best)
-            if found >= best // 2:
-                cut = found + 1
-                break
-        return segment[:cut], segment[cut:]
+        length = measure if measure is not None else (lambda text: len(render_telegram_html(text)))
+        return split_text_for_limit(segment, _MESSAGE_TEXT_LIMIT, measure=length)
 
     async def _stream_send(
         self,

--- a/tests/test_channels/test_telegram_discord_send_chunking.py
+++ b/tests/test_channels/test_telegram_discord_send_chunking.py
@@ -1,0 +1,218 @@
+"""Issue #1544: send() had no message-length chunking on Telegram or Discord.
+
+TelegramChannel.send() posted the full payload with no length check at all,
+and DiscordChannel.send() assigned payload["content"] = message.content
+directly. Either the platform API call fails or the message is
+truncated/rejected server-side, and the whole final reply -- the answer the
+user is actually waiting for -- is lost. Reachable whenever the stream
+policy is final_only or streaming is off.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agentos.channels._util import split_text_for_limit
+from agentos.channels.discord import DiscordChannel, DiscordChannelConfig
+from agentos.channels.telegram import TelegramChannel, TelegramChannelConfig
+from agentos.channels.types import OutgoingMessage
+
+
+class _TelegramResponse:
+    def __init__(self, message_id: int) -> None:
+        self._message_id = message_id
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return {"ok": True, "result": {"message_id": self._message_id}}
+
+
+def _telegram_channel() -> tuple[TelegramChannel, AsyncMock]:
+    channel = TelegramChannel(TelegramChannelConfig(token="token"))
+    client = AsyncMock()
+    calls: list[dict[str, Any]] = []
+
+    async def _post(url: str, **kwargs: Any) -> _TelegramResponse:
+        payload = kwargs.get("json", {})
+        calls.append(payload)
+        return _TelegramResponse(len(calls))
+
+    client.post = _post
+    channel._client = client
+    channel._owns_client = False
+    return channel, calls  # type: ignore[return-value]
+
+
+@pytest.mark.asyncio
+async def test_telegram_send_chunks_a_reply_longer_than_the_limit() -> None:
+    channel, calls = _telegram_channel()
+    long_content = "x" * 5000
+
+    await channel.send(OutgoingMessage(content=long_content, reply_to="123"))
+
+    assert len(calls) > 1
+    for call in calls:
+        assert len(call["text"]) <= 4096
+    joined = "".join(str(call["text"]) for call in calls)
+    assert joined == long_content
+
+
+@pytest.mark.asyncio
+async def test_telegram_send_a_short_reply_is_still_a_single_call() -> None:
+    channel, calls = _telegram_channel()
+
+    await channel.send(OutgoingMessage(content="hello", reply_to="123"))
+
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_telegram_send_reply_parameters_only_attach_to_the_first_chunk() -> None:
+    channel, calls = _telegram_channel()
+    long_content = "x" * 5000
+
+    await channel.send(
+        OutgoingMessage(
+            content=long_content,
+            reply_to="123",
+            metadata={"reply_to_message_id": 42},
+        )
+    )
+
+    assert len(calls) > 1
+    assert "reply_parameters" in calls[0]
+    assert all("reply_parameters" not in call for call in calls[1:])
+
+
+@pytest.mark.asyncio
+async def test_telegram_send_does_not_break_a_fenced_code_block_across_chunks() -> None:
+    channel, calls = _telegram_channel()
+    fenced = "intro " + ("a" * 4000) + "\n```python\ncode " + ("b" * 200) + "\n```\n" + ("c" * 200)
+
+    await channel.send(OutgoingMessage(content=fenced, reply_to="123"))
+
+    assert len(calls) > 1
+    for call in calls:
+        assert str(call["text"]).count("```") % 2 == 0
+
+
+def test_split_for_limit_keeps_a_fenced_code_block_whole() -> None:
+    fenced = "intro " + ("a" * 4000) + "\n```python\ncode\n```\n" + ("c" * 200)
+    head, tail = TelegramChannel._split_for_limit(fenced)
+    assert head.count("```") % 2 == 0
+    assert tail.count("```") % 2 == 0
+    assert head + tail == fenced
+
+
+def test_split_text_for_limit_respects_a_raw_length_measure() -> None:
+    """The shared splitter's default `len` measure is what a plain-text
+    channel like Discord needs -- no render step to look through."""
+    content = "y" * 3000
+    head, tail = split_text_for_limit(content, 2000)
+    assert len(head) <= 2000
+    assert head + tail == content
+
+
+class _DiscordResponse:
+    status_code = 200
+
+    def __init__(self, message_id: str) -> None:
+        self._message_id = message_id
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return {"id": self._message_id}
+
+
+def _discord_channel() -> tuple[DiscordChannel, list[dict[str, Any]]]:
+    channel = DiscordChannel(DiscordChannelConfig(token="token", application_id="app"))
+    client = AsyncMock()
+    calls: list[dict[str, Any]] = []
+
+    async def _post(url: str, **kwargs: Any) -> _DiscordResponse:
+        calls.append(kwargs.get("json", {}))
+        return _DiscordResponse(str(len(calls)))
+
+    async def _patch(url: str, **kwargs: Any) -> _DiscordResponse:
+        calls.append(kwargs.get("json", {}))
+        return _DiscordResponse(str(len(calls)))
+
+    client.post = _post
+    client.patch = _patch
+    channel._client = client
+    return channel, calls
+
+
+@pytest.mark.asyncio
+async def test_discord_send_chunks_a_reply_longer_than_the_limit() -> None:
+    channel, calls = _discord_channel()
+    long_content = "x" * 5000
+
+    await channel.send(OutgoingMessage(content=long_content, reply_to="channel-1"))
+
+    assert len(calls) > 1
+    for call in calls:
+        assert len(call["content"]) <= 2000
+    joined = "".join(str(call["content"]) for call in calls)
+    assert joined == long_content
+
+
+@pytest.mark.asyncio
+async def test_discord_send_a_short_reply_is_still_a_single_call() -> None:
+    channel, calls = _discord_channel()
+
+    await channel.send(OutgoingMessage(content="hello", reply_to="channel-1"))
+
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_discord_send_embeds_only_attach_to_the_last_chunk() -> None:
+    channel, calls = _discord_channel()
+    long_content = "x" * 5000
+
+    await channel.send(
+        OutgoingMessage(
+            content=long_content,
+            reply_to="channel-1",
+            metadata={"embeds": [{"title": "t"}], "reply_to_message_id": "99"},
+        )
+    )
+
+    assert len(calls) > 1
+    assert "message_reference" in calls[0]
+    assert all("message_reference" not in call for call in calls[1:])
+    assert all("embeds" not in call for call in calls[:-1])
+    assert calls[-1]["embeds"] == [{"title": "t"}]
+
+
+@pytest.mark.asyncio
+async def test_discord_interaction_response_overflow_goes_to_channel_followups() -> None:
+    """The interaction original-response slot holds exactly one message;
+    overflow chunks must still reach the user as regular channel messages
+    rather than being silently dropped."""
+    channel, calls = _discord_channel()
+    long_content = "x" * 5000
+
+    await channel.send(
+        OutgoingMessage(
+            content=long_content,
+            reply_to="channel-1",
+            metadata={
+                "interaction_token": "tok",
+                "interaction_application_id": "app",
+                "interaction_id": "int-1",
+            },
+        )
+    )
+
+    assert len(calls) > 1
+    joined = "".join(str(call["content"]) for call in calls)
+    assert joined == long_content


### PR DESCRIPTION
Summary
TelegramChannel.send() posted the full payload with no length check at all, and DiscordChannel.send() assigned payload["content"] = message.content directly — neither adapter capped anything
A reply longer than the platform's message-length cap (4096 rendered chars on Telegram, 2000 on Discord) either failed the API call or was truncated/rejected server-side, silently losing the final answer — the one output the user is actually waiting for
Reachable any time streaming is disabled (a final_only/non-streaming stream policy)
Telegram already owned the splitting primitive (_split_for_limit), used by send_streaming — send() just never called it
Extracted the core cut-point algorithm into a new shared agentos.channels._util.split_text_for_limit so Discord's send() could reuse it instead of growing a second, independently-drifting splitter; both TelegramChannel._split_for_limit and Discord's new _split_content_for_send now delegate to it
Discord measures raw length (no render step); Telegram's default measure renders to HTML first, and switches to raw length when a caller supplies an explicit parse_mode
The splitter also now avoids breaking a fenced code block (```...```) across a split — an odd number of fences before the cut means one is open, and the cut backs up to just before it so each half's fences balance independently. Telegram rejects a message whose Markdown entities don't parse, which would otherwise turn a length problem into a delivery failure
Reply context is scoped per chunk rather than repeated on every one: a reply reference goes on the first message, embeds/components/keyboards on the last
Discord's interaction-response path (the original-response slot holds exactly one message) sends its first chunk via the interaction PATCH and any overflow as regular channel follow-up messages, rather than dropping it
Fixes #1544 

Test plan
 Added test_telegram_discord_send_chunking.py (10 tests): chunk count/length bounds for both channels, joined-chunk content equality against the original, short content still sends as a single call, reply reference/embeds attach to the correct chunk only, a fenced code block stays intact across a split, the shared splitter's raw-length mode, and Discord's interaction-overflow-to-followup behavior
 Confirmed the new tests can't even import against the pre-fix code (split_text_for_limit doesn't exist yet), which is a strong signal they exercise the new functionality
 uv run pytest tests/test_channels -q — 505 passed (full suite, including Telegram's existing streaming tests — confirms the shared-splitter refactor didn't change streaming behavior)
 uv run ruff check / uv run mypy clean on changed files