### PR TITLE
fix(gateway): clamp sessions.list/sessions.preview's limit before it reaches the raw SQL LIMIT

### DIFF
--- a/src/agentos/gateway/rpc_sessions.py
+++ b/src/agentos/gateway/rpc_sessions.py
@@ -63,6 +63,21 @@ _d = get_dispatcher()
 log = structlog.get_logger(__name__)
 _ELEVATED_MODES = frozenset({"on", "bypass", "full"})
 
+#: Ceiling for ``sessions.list``/``sessions.preview``'s ``limit`` param, which
+#: reaches ``SessionStorage.list_sessions``'s raw SQL ``LIMIT ?`` unclamped
+#: otherwise. SQLite treats a negative ``LIMIT`` as "no limit at all", so an
+#: unvalidated negative value returns every session in one response.
+_MAX_SESSIONS_LIST_LIMIT = 5000
+
+
+def _clamp_sessions_limit(raw: Any, *, default: int = 50) -> int:
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return default
+    return min(max(1, value), _MAX_SESSIONS_LIST_LIMIT)
+
+
 _ALLOWED_MEDIA_TYPES = _attachment_ingest.ALLOWED_MEDIA_TYPES
 _MAX_ATTACHMENT_BYTES = _attachment_ingest.MAX_ATTACHMENT_BYTES
 _MAX_STAGED_PDF_BYTES = _attachment_ingest.MAX_STAGED_PDF_BYTES
@@ -761,7 +776,7 @@ async def _handle_sessions_list(params: dict | None, ctx: RpcContext) -> dict:
     if storage is None:
         return {"sessions": [], "count": 0, "ts": now_ms}
 
-    limit = (params or {}).get("limit", 50)
+    limit = _clamp_sessions_limit((params or {}).get("limit", 50))
     project_filter = (params or {}).get("projectId") or (params or {}).get("project_id")
     if project_filter:
         sessions = await storage.list_sessions(limit=limit, project_id=str(project_filter))
@@ -2393,7 +2408,7 @@ async def _preview_last_message(storage: Any, session_id: str) -> str:
 @_d.method("sessions.preview")
 async def _handle_sessions_preview(params: dict | None, ctx: RpcContext) -> dict:
     keys = (params or {}).get("keys")
-    limit = (params or {}).get("limit", 50)
+    limit = _clamp_sessions_limit((params or {}).get("limit", 50))
     now_ms = int(time.time() * 1000)
 
     if ctx.session_manager is None:

--- a/tests/test_gateway/test_rpc_sessions_limit.py
+++ b/tests/test_gateway/test_rpc_sessions_limit.py
@@ -1,0 +1,87 @@
+"""``sessions.list``/``sessions.preview``' ``limit`` param must never reach the
+store unclamped.
+
+``SessionStorage.list_sessions`` passes ``limit`` straight into a raw SQL
+``... LIMIT ? OFFSET ?``. SQLite reads a negative ``LIMIT`` as "no limit at
+all" (the same footgun ``mcp_server/bridge.py``'s ``_clamp_limit`` already
+guards against for the MCP-facing session listing, and that
+``gateway/rpc_cron.py``'s ``cron.runs`` handler has its own clamp for), so an
+unvalidated negative or absurdly large value would return every session in
+one response instead of the bounded page these handlers expect.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agentos.gateway.config import GatewayConfig
+from agentos.gateway.rpc import RpcContext
+from agentos.gateway.rpc_sessions import (
+    _MAX_SESSIONS_LIST_LIMIT,
+    _handle_sessions_list,
+    _handle_sessions_preview,
+)
+
+
+class _RecordingStorage:
+    """Records the ``limit`` it actually receives instead of executing a query."""
+
+    def __init__(self) -> None:
+        self.received_limit: int | None = None
+
+    async def list_sessions(self, limit: int = 50, **_kwargs: Any) -> list[Any]:
+        self.received_limit = limit
+        return []
+
+
+def _ctx(storage: Any) -> RpcContext:
+    ctx = RpcContext(conn_id="test", config=GatewayConfig())
+    ctx.session_manager = type("_Manager", (), {"storage": storage})()
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_sessions_list_negative_limit_is_clamped_to_one() -> None:
+    storage = _RecordingStorage()
+
+    await _handle_sessions_list({"limit": -1}, _ctx(storage))
+
+    assert storage.received_limit == 1
+
+
+@pytest.mark.asyncio
+async def test_sessions_list_oversized_limit_is_capped() -> None:
+    storage = _RecordingStorage()
+
+    await _handle_sessions_list({"limit": 10_000_000}, _ctx(storage))
+
+    assert storage.received_limit == _MAX_SESSIONS_LIST_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_sessions_list_default_limit_is_fifty() -> None:
+    storage = _RecordingStorage()
+
+    await _handle_sessions_list(None, _ctx(storage))
+
+    assert storage.received_limit == 50
+
+
+@pytest.mark.asyncio
+async def test_sessions_preview_negative_limit_is_clamped_to_one() -> None:
+    storage = _RecordingStorage()
+
+    await _handle_sessions_preview({"limit": -1}, _ctx(storage))
+
+    assert storage.received_limit == 1
+
+
+@pytest.mark.asyncio
+async def test_sessions_preview_oversized_limit_is_capped() -> None:
+    storage = _RecordingStorage()
+
+    await _handle_sessions_preview({"limit": 10_000_000}, _ctx(storage))
+
+    assert storage.received_limit == _MAX_SESSIONS_LIST_LIMIT


### PR DESCRIPTION
## Linked issue

Fixes #1660

- [x] This pull request fully resolves the linked issue.

## Summary

Both `_handle_sessions_list` and `_handle_sessions_preview` read `(params or {}).get("limit", 50)` with no validation and passed it straight through to `SessionStorage.list_sessions`, which uses it directly in `"SELECT * FROM sessions {where} ORDER BY updated_at DESC LIMIT ? OFFSET ?"`.

SQLite treats a negative `LIMIT` as "no limit at all" — the same footgun `mcp_server/bridge.py`'s `_clamp_limit` already guards against for its own session listing, and `gateway/rpc_cron.py`'s `cron.runs` handler now guards against too. Every other RPC handler in `gateway/` that reads a `limit` param already clamps it (`rpc_chat.py`, `rpc_logs.py` twice, `rpc_skills.py`) — these two in `rpc_sessions.py` were the outliers. A negative or oversized limit returned every session in one response instead of the bounded page these handlers expect.

Fixed by clamping to `[1, _MAX_SESSIONS_LIST_LIMIT]` at both call sites.

## Tests

Added `tests/test_gateway/test_rpc_sessions_limit.py`: negative limit clamps to 1 and an oversized one caps at the ceiling, for both handlers, plus the ordinary default. Confirmed directly that the old code passed `-1` straight through to the storage layer unclamped on both `sessions.list` and `sessions.preview`.

    ruff check src/agentos/gateway/rpc_sessions.py tests/test_gateway/test_rpc_sessions_limit.py   # All checks passed!
    mypy src/agentos/gateway/rpc_sessions.py --show-error-codes   # Success: no issues found
    pytest tests/test_gateway tests/test_session tests/test_mcp_server -q
    # 1715 passed, 2 pre-existing/unrelated failures (same on unmodified main)