### PR TITLE
fix(telegram): group multiline blockquotes and preserve empty quote l…

### DIFF
--- a/src/agentos/channels/_telegram_formatting.py
+++ b/src/agentos/channels/_telegram_formatting.py
@@ -11,6 +11,10 @@ _HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s+(?P<text>.+?)\s*#*\s*$")
 _ORDERED_LIST_RE = re.compile(r"^(?P<indent>\s*)(?P<number>\d+)[.)]\s+(?P<text>.+)$")
 _UNORDERED_LIST_RE = re.compile(r"^(?P<indent>\s*)[-+*]\s+(?P<text>.+)$")
 _LINK_RE = re.compile(r"\[([^\]\n]+)\]\((https?://[^\s)<]+)\)")
+# CommonMark's blockquote marker: up to 3 leading spaces, `>`, then at most
+# one space before the content. `>quote` (no space) and `>` alone (an empty
+# quote line, used to separate paragraphs within one quote) both match.
+_BLOCKQUOTE_RE = re.compile(r"^ {0,3}>[ ]?(?P<text>.*)$")
 
 
 def _replace_code_spans(text: str) -> tuple[str, list[str]]:
@@ -229,9 +233,27 @@ def render_telegram_html(markdown: str) -> str:
             rendered.append(f"<b>{_render_inline(heading.group('text'))}</b>")
             index += 1
             continue
-        if line.startswith("> "):
-            rendered.append(f"<blockquote>{_render_inline(line[2:])}</blockquote>")
+        quote = _BLOCKQUOTE_RE.match(line)
+        if quote:
+            # Telegram's <blockquote> is a multiline element
+            # (<blockquote>line 1\nline 2</blockquote>); one tag per line
+            # renders as a stack of separate quote bubbles instead of one
+            # contiguous quote, so consecutive quote lines — including bare
+            # `>` lines that separate paragraphs within the quote — are
+            # gathered and joined inside a single tag.
+            quote_lines = [quote.group("text")]
             index += 1
+            while index < len(lines):
+                next_quote = _BLOCKQUOTE_RE.match(lines[index])
+                if not next_quote:
+                    break
+                quote_lines.append(next_quote.group("text"))
+                index += 1
+            rendered.append(
+                "<blockquote>"
+                + "\n".join(_render_inline(quote_line) for quote_line in quote_lines)
+                + "</blockquote>"
+            )
             continue
         ordered = _ORDERED_LIST_RE.match(line)
         if ordered:

--- a/tests/test_channels/test_telegram_formatting.py
+++ b/tests/test_channels/test_telegram_formatting.py
@@ -53,6 +53,58 @@ if x < 2:
     ) in rendered
 
 
+def test_multiline_blockquote_is_grouped_into_a_single_tag() -> None:
+    """Issue #1532: Telegram's <blockquote> is a multiline element -- one tag
+    per source line rendered as a stack of separate quote bubbles instead of
+    one contiguous quote."""
+    rendered = render_telegram_html("> Line 1\n> Line 2")
+
+    assert rendered == "<blockquote>Line 1\nLine 2</blockquote>"
+
+
+def test_blockquote_empty_line_separates_paragraphs_without_leaking_raw_gt() -> None:
+    """A bare `>` line inside a quote must stay part of the quote as an empty
+    line, not fall through to inline rendering and leak a raw `&gt;`."""
+    rendered = render_telegram_html("> Paragraph 1\n>\n> Paragraph 2")
+
+    assert rendered == "<blockquote>Paragraph 1\n\nParagraph 2</blockquote>"
+    assert "&gt;" not in rendered
+
+
+def test_blockquote_marker_without_a_space_is_recognized() -> None:
+    rendered = render_telegram_html(">no space")
+
+    assert rendered == "<blockquote>no space</blockquote>"
+
+
+@pytest.mark.parametrize("indent", ["", " ", "  ", "   "])
+def test_blockquote_allows_up_to_three_leading_spaces(indent: str) -> None:
+    rendered = render_telegram_html(f"{indent}> quote")
+
+    assert rendered == "<blockquote>quote</blockquote>"
+
+
+def test_four_leading_spaces_is_not_a_blockquote_marker() -> None:
+    """Four or more leading spaces is CommonMark's indented-code-block
+    territory, not a blockquote -- the line falls through to plain
+    (escaped) inline rendering, same as before this fix."""
+    rendered = render_telegram_html("    > not a quote")
+
+    assert rendered == "    &gt; not a quote"
+
+
+def test_blockquote_stops_at_the_first_non_quote_line() -> None:
+    rendered = render_telegram_html("> quoted\nnot quoted")
+
+    assert rendered == "<blockquote>quoted</blockquote>\nnot quoted"
+
+
+def test_blockquote_content_still_gets_inline_formatting() -> None:
+    rendered = render_telegram_html("> **bold** and `code`")
+
+    assert rendered == "<blockquote><b>bold</b> and <code>code</code></blockquote>"
+
+
 def test_telegram_send_payload_auto_renders_html() -> None:
     channel = TelegramChannel(TelegramChannelConfig(token="token"))
 


### PR DESCRIPTION

Summary
Blockquote lines were parsed one at a time (if line.startswith("> ")), with each wrapped into its own <blockquote>...</blockquote> tag
Telegram's <blockquote> is a multiline element (<blockquote>line 1\nline 2</blockquote>), so one tag per line rendered as a stack of disjoint quote bubbles instead of a single contiguous quote — a visible defect in delivered messages, not a formatting preference
A bare > line (CommonMark's way of separating paragraphs within one quote) didn't match the strict "> " prefix check at all, so it fell through to plain inline rendering and leaked a raw &gt; into the message text, right in the middle of what was supposed to be a contiguous quote
Replaced the prefix check with _BLOCKQUOTE_RE, matching CommonMark's actual marker (up to 3 leading spaces, >, then at most one optional space) so >quote and indented markers are recognized too
Consecutive matching lines — including empty ones — are now gathered and joined inside a single <blockquote> tag instead of one tag per line
Fixes #1532 

Test plan
 Verified against the exact reproduction from the issue: all three defects (fragmented multiline quotes, leaked &gt; on empty lines, dropped >no space/indented markers) now produce the exact expected output
 Confirmed the CommonMark 3-space indentation boundary is respected — 4+ leading spaces correctly falls through to plain (escaped) rendering, unchanged from before
 Verified the tests catch the regression: stashed the source fix and reran — 6 of 8 new tests genuinely fail against the old code
 Added 8 tests: multiline grouping into one tag, empty-line paragraph separation with no &gt; leak, no-space marker (>quote), three leading-space variants (parametrized), the 4-space non-quote boundary, a quote correctly stopping at the first non-quote line, and inline formatting (bold/code) still working inside a quote
 uv run pytest tests/test_channels -k telegram -q — 125 passed
 uv run ruff check / uv run mypy clean on changed files
