### PR TITLE
fix(session): abort a same-key reset when the safety archive write fails

### DIFF
--- a/src/agentos/session/manager.py
+++ b/src/agentos/session/manager.py
@@ -492,7 +492,7 @@ class SessionManager:
 
     async def _rotate_session_id(self, node: SessionNode) -> SessionNode:
         old_session_id = node.session_id
-        await self._archive_session_identity(node)
+        await self._archive_session_identity(node, require_success=True)
         await self._storage.delete_transcript(old_session_id)
         await self._storage.delete_summaries(old_session_id)
         await self._storage.invalidate_context_states(
@@ -518,14 +518,23 @@ class SessionManager:
         await self._storage.upsert_session(node)
         return node
 
-    async def _archive_session_identity(self, node: SessionNode) -> bool:
+    async def _archive_session_identity(
+        self, node: SessionNode, *, require_success: bool = False
+    ) -> bool:
         """Best-effort raw archive before a same-key transcript reset.
 
         Returns ``True`` when a non-empty archive file was written to disk,
-        ``False`` when there was nothing to archive or the write failed. The
-        reset path uses the return value to decide whether a destructive
-        rotation is safe to fall back to when the memory-flush service is
-        unavailable.
+        ``False`` when there was nothing to archive — an empty session is
+        safe to rotate either way. A write *failure* on a non-empty session
+        is a different outcome from "nothing to archive" and must not be
+        folded into the same ``False``: with ``require_success=True`` (the
+        destructive :meth:`_rotate_session_id` path, which deletes the
+        transcript this archive is the only backup of) a failure raises
+        instead, aborting the reset with a clear error rather than silently
+        proceeding to delete an unarchived transcript.
+        :meth:`rotate_session_id_archive_only` keeps ``require_success``
+        false: it never deletes anything, so a failed backup there costs
+        nothing but the backup itself.
         """
 
         try:
@@ -550,7 +559,22 @@ class SessionManager:
             }
             path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
             return True
-        except Exception:
+        except Exception as exc:
+            import structlog as _structlog
+
+            _structlog.get_logger(__name__).warning(
+                "session.archive_failed",
+                session_key=node.session_key,
+                session_id=node.session_id,
+                error=str(exc),
+                aborting_reset=require_success,
+            )
+            if require_success:
+                raise RuntimeError(
+                    f"Failed to archive session {node.session_key!r} before a "
+                    "destructive reset; aborting rather than deleting an "
+                    "unarchived transcript"
+                ) from exc
             return False
 
     async def rotate_session_id_archive_only(self, session_key: str) -> SessionNode:

--- a/tests/test_session/test_manager.py
+++ b/tests/test_session/test_manager.py
@@ -208,9 +208,12 @@ async def test_apply_intent_reset_same_key_missing_creates_session(manager):
 
 
 @pytest.mark.asyncio
-async def test_apply_intent_reset_same_key_archive_failure_does_not_block(
+async def test_apply_intent_reset_same_key_aborts_when_archive_write_fails(
     manager, tmp_path, monkeypatch
 ):
+    """Issue #1539: a write failure while archiving a non-empty session must
+    abort the reset rather than proceed to delete the only copy of the
+    transcript it was supposed to be backing up."""
     archive_file = tmp_path / "not-a-directory"
     archive_file.write_text("occupied", encoding="utf-8")
     monkeypatch.setenv("AGENTOS_SESSION_ARCHIVE_DIR", str(archive_file))
@@ -218,11 +221,53 @@ async def test_apply_intent_reset_same_key_archive_failure_does_not_block(
     old_session_id = node.session_id
     await manager.append_message("agent:main:main", "user", "hello")
 
+    with pytest.raises(RuntimeError, match="Failed to archive"):
+        await manager.apply_intent("agent:main:main", SessionIntent.RESET_SAME_KEY)
+
+    # Nothing was deleted and the session identity did not rotate.
+    assert await manager._storage.count_transcript_entries(old_session_id) == 1
+    unchanged = await manager.get_session("agent:main:main")
+    assert unchanged is not None
+    assert unchanged.session_id == old_session_id
+
+
+@pytest.mark.asyncio
+async def test_apply_intent_reset_same_key_empty_session_is_still_safe_to_rotate(
+    manager, tmp_path, monkeypatch
+):
+    """An empty session has nothing to archive -- that is not a write
+    failure, and must not be treated as one. The same broken archive
+    directory used above must not block a reset with nothing to back up."""
+    archive_file = tmp_path / "not-a-directory"
+    archive_file.write_text("occupied", encoding="utf-8")
+    monkeypatch.setenv("AGENTOS_SESSION_ARCHIVE_DIR", str(archive_file))
+    node = await manager.create("agent:main:main")
+    old_session_id = node.session_id
+
     applied, rotated = await manager.apply_intent("agent:main:main", SessionIntent.RESET_SAME_KEY)
 
     assert rotated is True
     assert applied.session_id != old_session_id
-    assert await manager._storage.count_transcript_entries(old_session_id) == 0
+
+
+@pytest.mark.asyncio
+async def test_rotate_session_id_archive_only_tolerates_a_write_failure(
+    manager, tmp_path, monkeypatch
+):
+    """The non-destructive archive-only path never deletes anything, so a
+    failed backup there costs nothing but the backup -- it must keep its
+    existing best-effort behavior rather than start raising too."""
+    archive_file = tmp_path / "not-a-directory"
+    archive_file.write_text("occupied", encoding="utf-8")
+    monkeypatch.setenv("AGENTOS_SESSION_ARCHIVE_DIR", str(archive_file))
+    node = await manager.create("agent:main:main")
+    old_session_id = node.session_id
+    await manager.append_message("agent:main:main", "user", "hello")
+
+    rotated_node = await manager.rotate_session_id_archive_only("agent:main:main")
+
+    assert rotated_node.session_id != old_session_id
+    assert await manager._storage.count_transcript_entries(old_session_id) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Summary
_rotate_session_id called _archive_session_identity and discarded the return value, then unconditionally deleted the transcript and summaries
_archive_session_identity catches every exception and returns False on any I/O failure — a full disk, a permissions error, a bad archive path — so a transient write failure produced no exception, no log, and no archive, immediately followed by an irreversible delete of the only copy of the data that archive was supposed to back up
False meant two different things caller-side: "there was nothing to archive" (safe to proceed) and "the write failed" (not safe). Folding both into one boolean is what let the failure case slip through unnoticed
Added require_success to _archive_session_identity: when true (the destructive _rotate_session_id path), a write failure now raises instead of returning False, aborting the reset with a clear error rather than silently deleting an unarchived transcript
An empty session (nothing to archive) still returns False and rotates normally — that path never held data the delete could destroy
rotate_session_id_archive_only, which never deletes anything, keeps require_success=False: a failed backup there costs nothing but the backup itself, so it stays best-effort rather than starting to fail a reset that was never destructive in the first place
Both outcomes are now logged, where before a failure produced no visible trace at all
Fixes #1539 

Test plan
 Found the existing test that had encoded the bug as intended behavior (test_apply_intent_reset_same_key_archive_failure_does_not_block) and rewrote it to assert the corrected behavior
 Verified the rewritten test catches the regression: stashed the source fix and reran — it fails against the old code with DID NOT RAISE RuntimeError
 Added a test confirming an empty session still rotates safely despite the same broken archive directory (the "nothing to archive" case must not be treated as a failure)
 Added a test confirming the non-destructive rotate_session_id_archive_only keeps tolerating archive failures, unchanged
 uv run pytest tests/test_session -q — 236 passed
 uv run pytest tests/test_gateway -k "reset or session" -q — 292 passed
 uv run ruff check / uv run mypy clean on changed files
