### PR TITLE
fix(gateway): clamp logs.tail limit and cursor parameters

### DIFF
--- a/src/agentos/gateway/rpc_logs.py
+++ b/src/agentos/gateway/rpc_logs.py
@@ -179,9 +179,15 @@ async def _handle_logs_trace(params: dict | None, ctx: RpcContext) -> dict[str, 
 async def _handle_logs_tail(params: dict | None, ctx: RpcContext) -> dict[str, Any]:
     """Tail log file with cursor-based pagination and level filter."""
     p = params or {}
-    limit = min(p.get("limit", 100), 1000)
+    try:
+        limit = max(1, min(int(p.get("limit", 100)), 1000))
+    except (TypeError, ValueError):
+        limit = 100
+    try:
+        cursor = max(0, int(p.get("cursor", 0)))
+    except (TypeError, ValueError):
+        cursor = 0
     level_filter = (p.get("level", "") or "").upper()
-    cursor = p.get("cursor", 0)
 
     log_file = _find_log_file()
     if log_file is None or not log_file.exists():

--- a/tests/test_gateway/test_rpc_logs.py
+++ b/tests/test_gateway/test_rpc_logs.py
@@ -217,3 +217,26 @@ async def test_logs_status_is_mounted_on_dispatcher(monkeypatch) -> None:
     assert response.ok is True
     assert isinstance(response.payload, dict)
     assert response.payload["raw_turn_call_log"]["enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_logs_tail_clamps_limit_and_cursor(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("AGENTOS_LOG_DIR", str(tmp_path))
+    log_file = tmp_path / "debug.log"
+    log_file.write_text("line1\nline2\nline3\nline4\nline5\n", encoding="utf-8")
+
+    # Negative limit clamps to 1
+    res_neg_limit = await _handle_logs_tail({"limit": -10, "cursor": 0}, None)  # type: ignore[arg-type]
+    assert res_neg_limit["lines"] == ["line5"]
+
+    # Invalid limit falls back to 100 (returns all 5 lines)
+    res_inv_limit = await _handle_logs_tail({"limit": "invalid", "cursor": 0}, None)  # type: ignore[arg-type]
+    assert len(res_inv_limit["lines"]) == 5
+
+    # Negative cursor clamps to 0
+    res_neg_cursor = await _handle_logs_tail({"limit": 2, "cursor": -50}, None)  # type: ignore[arg-type]
+    assert res_neg_cursor["lines"] == ["line4", "line5"]
+
+    # Invalid cursor clamps to 0
+    res_inv_cursor = await _handle_logs_tail({"limit": 2, "cursor": "invalid"}, None)  # type: ignore[arg-type]
+    assert res_inv_cursor["lines"] == ["line4", "line5"]


### PR DESCRIPTION
### Summary
Clamps and sanitizes `limit` and `cursor` parameters in `_handle_logs_tail` (`src/agentos/gateway/rpc_logs.py`) to prevent negative line slicing, `TypeError` exceptions on non-integer inputs, and `OSError` on negative seek offsets.

Fixes #1665

### Changes
- Updated `_handle_logs_tail` in `src/agentos/gateway/rpc_logs.py` to clamp `limit` to range `[1, 1000]` and `cursor` to `>= 0`.
- Added unit tests in `tests/test_gateway/test_rpc_logs.py` covering negative, invalid, and out-of-bound `limit` and `cursor` inputs.

### Verification
- `uv run pytest tests/test_gateway/test_rpc_logs.py -q` (12 passed)
- `uv run ruff check src tests` (All checks passed)
- `uv run ruff format src tests` (Formatted)
- `uv run mypy src/agentos --show-error-codes` (No issues found)
