### PR TITLE
fix(gateway): sanitize and clamp limit and cursor in logs.tail

### DIFF
--- a/src/agentos/gateway/rpc_logs.py
+++ b/src/agentos/gateway/rpc_logs.py
@@ -179,9 +179,15 @@ async def _handle_logs_trace(params: dict | None, ctx: RpcContext) -> dict[str, 
 async def _handle_logs_tail(params: dict | None, ctx: RpcContext) -> dict[str, Any]:
     """Tail log file with cursor-based pagination and level filter."""
     p = params or {}
-    limit = min(p.get("limit", 100), 1000)
-    level_filter = (p.get("level", "") or "").upper()
-    cursor = p.get("cursor", 0)
+    try:
+        limit = max(1, min(int(p.get("limit", 100)), 1000))
+    except (TypeError, ValueError):
+        limit = 100
+    level_filter = str(p.get("level") or "").upper()
+    try:
+        cursor = max(0, int(p.get("cursor", 0)))
+    except (TypeError, ValueError):
+        cursor = 0
 
     log_file = _find_log_file()
     if log_file is None or not log_file.exists():

--- a/tests/test_gateway/test_rpc_logs.py
+++ b/tests/test_gateway/test_rpc_logs.py
@@ -35,6 +35,78 @@ async def test_logs_tail_missing_file_returns_empty_payload(tmp_path, monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_logs_tail_sanitizes_string_and_invalid_limit(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("AGENTOS_LOG_DIR", str(tmp_path))
+    log_file = tmp_path / "debug.log"
+    log_file.write_text("line1\nline2\nline3\n", encoding="utf-8")
+
+    # Stringified int limit should parse properly without TypeError
+    result = await _handle_logs_tail({"limit": "2", "cursor": 0}, None)  # type: ignore[arg-type]
+    assert result["lines"] == ["line2", "line3"]
+    assert result["has_more"] is True
+
+    # Invalid limit should safely fall back to default (100) without crashing
+    for bad_limit in ("not_a_number", None, []):
+        result = await _handle_logs_tail({"limit": bad_limit, "cursor": 0}, None)  # type: ignore[arg-type]
+        assert result["lines"] == ["line1", "line2", "line3"]
+        assert result["has_more"] is False
+
+
+@pytest.mark.asyncio
+async def test_logs_tail_clamps_limit_bounds_and_prevents_unbounded_dump(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("AGENTOS_LOG_DIR", str(tmp_path))
+    log_file = tmp_path / "debug.log"
+    log_file.write_text("line1\nline2\nline3\n", encoding="utf-8")
+
+    # limit=0 must clamp to 1 and not evaluate as [-0:] (which would dump all lines)
+    result = await _handle_logs_tail({"limit": 0, "cursor": 0}, None)  # type: ignore[arg-type]
+    assert result["lines"] == ["line3"]
+    assert result["has_more"] is True
+
+    # Negative limit must clamp to 1
+    result = await _handle_logs_tail({"limit": -5, "cursor": 0}, None)  # type: ignore[arg-type]
+    assert result["lines"] == ["line3"]
+    assert result["has_more"] is True
+
+    # Oversized limit should cap at 1000
+    result = await _handle_logs_tail({"limit": 5000, "cursor": 0}, None)  # type: ignore[arg-type]
+    assert result["lines"] == ["line1", "line2", "line3"]
+    assert result["has_more"] is False
+
+
+@pytest.mark.asyncio
+async def test_logs_tail_sanitizes_cursor_and_prevents_negative_seek(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("AGENTOS_LOG_DIR", str(tmp_path))
+    log_file = tmp_path / "debug.log"
+    log_file.write_text("hello world\n", encoding="utf-8")
+
+    # Stringified cursor should parse without TypeError
+    result = await _handle_logs_tail({"limit": 10, "cursor": "0"}, None)  # type: ignore[arg-type]
+    assert result["lines"] == ["hello world"]
+
+    # Negative cursor should clamp to 0 instead of raising ValueError: negative seek position
+    result = await _handle_logs_tail({"limit": 10, "cursor": -10}, None)  # type: ignore[arg-type]
+    assert result["lines"] == ["hello world"]
+
+    # Non-integer cursor should fall back to 0
+    result = await _handle_logs_tail({"limit": 10, "cursor": "invalid"}, None)  # type: ignore[arg-type]
+    assert result["lines"] == ["hello world"]
+
+
+@pytest.mark.asyncio
+async def test_logs_tail_handles_non_string_level_filter(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("AGENTOS_LOG_DIR", str(tmp_path))
+    log_file = tmp_path / "debug.log"
+    log_file.write_text("line1\n", encoding="utf-8")
+
+    # Non-string level should not crash with AttributeError
+    result = await _handle_logs_tail({"limit": 10, "cursor": 0, "level": 123}, None)  # type: ignore[arg-type]
+    assert result["lines"] == []
+
+
+@pytest.mark.asyncio
 async def test_logs_status_reports_raw_capture_disabled_by_default(monkeypatch) -> None:
     monkeypatch.delenv("AGENTOS_TURN_CALL_LOG", raising=False)
     monkeypatch.delenv("AGENTOS_TURN_CALL_LOG_DIR", raising=False)


### PR DESCRIPTION
Fixes #1667

## Summary

In `src/agentos/gateway/rpc_logs.py`, `_handle_logs_tail` parsed `limit = min(p.get("limit", 100), 1000)` and `cursor = p.get("cursor", 0)` without type casting or error handling:

1. Passing a stringified or `None` limit (e.g. `limit: "50"`, common from HTTP query params or external JSON-RPC clients) crashed with `TypeError: '<' not supported between instances of 'int' and 'str'`.
2. Passing `limit: 0` caused `filtered[-0:]` to evaluate as `filtered[0:]`, returning an unbounded dump of every line in the log file.
3. Passing a stringified cursor (e.g. `cursor: "0"`) crashed with `TypeError: '>=' not supported between instances of 'str' and 'int'`.
4. Passing a negative cursor (e.g. `cursor: -1`) crashed in `f.seek(cursor)` with `ValueError: negative seek position -1`.
5. Passing a non-string `level` crashed with `AttributeError`.

## Changes

- In `src/agentos/gateway/rpc_logs.py`:
  - Safely cast and clamp `limit` to `[1, 1000]`, falling back to default `100` on non-numeric or missing input (matching `_handle_logs_trace`).
  - Safely cast and clamp `cursor` to `>= 0`, falling back to `0` on invalid input.
  - Coerce `level` to string before checking upper-case level filters.
- In `tests/test_gateway/test_rpc_logs.py`:
  - Add `test_logs_tail_sanitizes_string_and_invalid_limit` verifying string/None/invalid limits do not crash and parse properly.
  - Add `test_logs_tail_clamps_limit_bounds_and_prevents_unbounded_dump` verifying `limit: 0` and negative limits clamp to 1 instead of dumping the whole log.
  - Add `test_logs_tail_sanitizes_cursor_and_prevents_negative_seek` verifying string/negative cursors do not crash `f.seek()`.
  - Add `test_logs_tail_handles_non_string_level_filter`.
