### PR TITLE
fix(telegram): remove the unread per-sender profile cache

### DIFF
--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -208,9 +208,6 @@ class TelegramChannel:
     _dedupe: EventDedupeCache = field(init=False, repr=False)
     _connected: bool = field(default=False, init=False, repr=False)
     _last_message_at: datetime | None = field(default=None, init=False, repr=False)
-    _known_sender_profiles: dict[str, dict[str, str]] = field(
-        default_factory=dict, init=False, repr=False
-    )
     bot_user_id: str | None = None
     bot_username: str | None = None
 
@@ -238,11 +235,6 @@ class TelegramChannel:
             "chat_id": str(message.channel_id or message.metadata.get("chat_id") or ""),
         }
 
-    def _remember_sender(self, message: IncomingMessage) -> None:
-        profile = self._sender_profile(message)
-        if profile["sender_id"]:
-            self._known_sender_profiles[profile["sender_id"]] = profile
-
     def record_access_denial(self, message: IncomingMessage, reason: str) -> None:
         """Create a durable pairing request for an unauthorized Telegram DM."""
         if reason != "not_paired" or bool(message.metadata.get("is_group")):
@@ -251,7 +243,6 @@ class TelegramChannel:
         sender_id = profile["sender_id"]
         if not sender_id:
             return
-        self._known_sender_profiles[sender_id] = profile
         try:
             result = self.pairing_store.request(
                 self.config.name,
@@ -705,7 +696,6 @@ class TelegramChannel:
         return payload
 
     def enqueue(self, message: IncomingMessage) -> None:
-        self._remember_sender(message)
         msg_id = str(message.metadata.get("message_id", ""))
         update_id = message.metadata.get("update_id")
         dedupe_key = f"{update_id}:{msg_id}" if update_id is not None else msg_id

--- a/tests/test_channels/test_telegram_sender_profiles_removed.py
+++ b/tests/test_channels/test_telegram_sender_profiles_removed.py
@@ -1,0 +1,51 @@
+"""Issue #1542: TelegramChannel._known_sender_profiles grew without bound
+and was never read by anything in the codebase -- two writes (enqueue() via
+_remember_sender(), and record_access_denial()), zero reads. Deleting the
+field and its writers removes the leak entirely rather than just bounding
+dead state, since there is no reader to preserve.
+"""
+
+from __future__ import annotations
+
+from agentos.channels.telegram import TelegramChannel, TelegramChannelConfig
+from agentos.channels.types import IncomingMessage
+
+
+def _channel() -> TelegramChannel:
+    return TelegramChannel(TelegramChannelConfig(token="token"))
+
+
+def test_known_sender_profiles_field_no_longer_exists() -> None:
+    channel = _channel()
+
+    assert not hasattr(channel, "_known_sender_profiles")
+
+
+def test_enqueue_still_queues_and_dedupes_without_the_removed_bookkeeping() -> None:
+    channel = _channel()
+    msg = IncomingMessage(
+        sender_id="user-1",
+        channel_id="chat-1",
+        content="hello",
+        metadata={"message_id": "m1", "update_id": 1},
+    )
+
+    channel.enqueue(msg)
+    channel.enqueue(msg)
+
+    assert channel._queue.qsize() == 1
+
+
+def test_record_access_denial_still_creates_a_pairing_request() -> None:
+    channel = _channel()
+    msg = IncomingMessage(
+        sender_id="user-1",
+        channel_id="chat-1",
+        content="hi",
+        metadata={"sender_username": "someone", "is_group": False},
+    )
+
+    channel.record_access_denial(msg, "not_paired")
+
+    snapshot = channel.pairing_store.snapshot(channel.config.name)
+    assert any(entry["sender_id"] == "user-1" for entry in snapshot["pending"])


### PR DESCRIPTION
Summary
_known_sender_profiles was written on every inbound update (enqueue() → _remember_sender()) and again in record_access_denial(), but never read anywhere in the codebase
Confirmed via grep: exactly two writes, zero reads, across src/ and tests/ alike
This is not a cache missing an eviction policy — it's dead state that grew without bound on attacker-reachable input (any user who messages a public bot), with no functional benefit to offset it
Bounding it (as the currently-open PR does) would keep the leak alive at a smaller size and leave the next reader to work out what the cache is for and why nothing reads it
Since nothing reads it, removed the field, _remember_sender() entirely, its call site in enqueue(), and the redundant write in record_access_denial() — which already builds the same profile dict to pass to pairing_store.request directly, so nothing else needed to change there
This also drops a dict write from the inbound hot path
Fixes #1542 

Test plan
 Added test_telegram_sender_profiles_removed.py: confirms the field no longer exists on TelegramChannel, enqueue() still queues and dedupes correctly without it, and record_access_denial() still creates a pairing request correctly
 uv run pytest tests/test_channels -k telegram -q — 118 passed
 uv run ruff check / uv run mypy clean on changed files
