### PR TITLE
fix(gateway): validate name parameter in projects.update

### DIFF
--- a/src/agentos/gateway/rpc_projects.py
+++ b/src/agentos/gateway/rpc_projects.py
@@ -123,8 +123,8 @@ async def _handle_projects_update(params: dict | None, ctx: RpcContext) -> dict:
     expected = params.get("expectedUpdatedAt", params.get("expected_updated_at"))
     if name is None and knowledge is None:
         raise ValueError("params.name or params.knowledge is required")
-    if name is not None and not isinstance(name, str):
-        raise ValueError("params.name must be a string")
+    if name is not None and (not isinstance(name, str) or not name.strip()):
+        raise ValueError("params.name must be a non-empty string")
     if knowledge is not None and not isinstance(knowledge, str):
         raise ValueError("params.knowledge must be a string")
     if expected is not None and (isinstance(expected, bool) or not isinstance(expected, int)):

--- a/tests/test_gateway/test_rpc_projects.py
+++ b/tests/test_gateway/test_rpc_projects.py
@@ -169,6 +169,23 @@ class TestProjectsListGetUpdateDelete:
         assert fresh.payload["project"]["knowledge"] == "Shared facts."
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("bad_name", ["", "   ", "\t\n"])
+    async def test_update_rejects_empty_or_whitespace_name(self, dispatcher, ctx, bad_name):
+        project = await _create_project(dispatcher, ctx)
+        res = await dispatcher.dispatch(
+            "r1",
+            "projects.update",
+            {"projectId": project["project_id"], "name": bad_name},
+            ctx,
+        )
+        assert res.ok is False
+        assert res.error.code == "INVALID_REQUEST"
+        fresh = await dispatcher.dispatch(
+            "r2", "projects.get", {"projectId": project["project_id"]}, ctx
+        )
+        assert fresh.payload["project"]["name"] == "Research"
+
+    @pytest.mark.asyncio
     async def test_delete_reports_detached_sessions(self, dispatcher, ctx, manager):
         project = await _create_project(dispatcher, ctx)
         await manager.create(


### PR DESCRIPTION
### Summary
Rejects empty or whitespace-only `name` parameters in `_handle_projects_update` (`src/agentos/gateway/rpc_projects.py`), aligning parameter validation with `projects.create`.

Fixes #1670

### Changes
- Updated `_handle_projects_update` in `src/agentos/gateway/rpc_projects.py` to validate that `name` is a non-empty string when provided (`if name is not None and (not isinstance(name, str) or not name.strip()): raise ValueError(...)`).
- Added unit test `test_update_rejects_empty_or_whitespace_name` in `tests/test_gateway/test_rpc_projects.py`.

### Verification
- `uv run pytest tests/test_gateway/test_rpc_projects.py -q` (18 passed)
- `uv run ruff check src tests` (All checks passed)
- `uv run ruff format src tests` (Formatted)
- `uv run mypy src/agentos --show-error-codes` (No issues found)
