### PR TITLE
fix(code_exec): stop truncating the code shown in the approval prompt

### DIFF
--- a/src/agentos/tools/builtin/code_exec.py
+++ b/src/agentos/tools/builtin/code_exec.py
@@ -611,7 +611,14 @@ async def execute_code(
         try:
             approval_response = await _check_exec_approval(
                 tool_name="execute_code",
-                command=code[:200],
+                # The full script, not a prefix: the approval record stored
+                # and rendered to the human is params["command"], and a
+                # truncated payload showed a reviewer only the (often
+                # harmless-looking) first 200 characters — imports, a
+                # docstring — never the destructive statement further down
+                # that actually triggered the prompt. Approval exists for
+                # informed consent, which a truncated payload cannot give.
+                command=code,
                 workdir=None,
                 warning=warning,
                 approval_id=approval_id,

--- a/tests/test_tools/test_shell_approval_policy.py
+++ b/tests/test_tools/test_shell_approval_policy.py
@@ -277,6 +277,31 @@ async def test_approved_destructive_code_exec_uses_host_grant_when_sandbox_enabl
 
 
 @pytest.mark.asyncio
+async def test_destructive_code_exec_approval_is_not_truncated(
+    tmp_path: Path,
+) -> None:
+    """Issue #1567: the approval record stored (and shown to the human) must
+    contain the full script, not just its first 200 characters. A script
+    whose destructive statement lands past that boundary used to present as
+    harmless imports/docstring in the approval prompt -- the human approved
+    an operation they were never actually shown."""
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.workspace_dir = str(tmp_path)
+    preamble = "# harmless-looking preamble\n" * 10
+    assert len(preamble) > 200
+    code = preamble + "import os\nos.remove('target.txt')"
+
+    pending = json.loads(await execute_code(code))
+
+    assert pending["status"] == "approval_required"
+    approval_id = str(pending["approval_id"])
+    entry = get_approval_queue().get(approval_id)
+    assert entry.params["command"] == code
+    assert "os.remove" in entry.params["command"]
+
+
+@pytest.mark.asyncio
 async def test_approved_background_process_uses_host_grant_when_sandbox_enabled(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Summary
execute_code passed command=code[:200] into _check_exec_approval
That string is what params["command"] stores and what the human reviewing the approval actually sees, so a script whose first 200 characters were imports or a docstring presented as harmless while the destructive statement that triggered the prompt — further down in the script — was never shown to the reviewer
Approval exists for informed consent, and a truncated payload cannot give it
The security-scanning half of the original report does not hold: execute_code already runs _check_code_sensitive_access(code) over the full script before the approval call is ever reached, so a sensitive path anywhere in the code is caught there, not missed — only the approval payload was truncated
Fixed by passing the full code instead of code[:200]
Fixes #1567 

Test plan
 Verified no renderer downstream re-truncates the untruncated payload: _audit_command's cap in shell.py is log-only, and neither rpc_approvals.py nor the CLI approval surfaces slice params["command"] further
 Verified the fix directly: a script with a >200-char harmless-looking preamble followed by a destructive os.remove() call now reaches _check_exec_approval in full, not truncated
 Verified the new test catches the regression: stashed the source fix and reran — the test fails against the old code, with the log output showing the exact bug (operator would see only the preamble, never the destructive call)
 Added test_destructive_code_exec_approval_is_not_truncated: confirms the stored approval entry's params["command"] equals the full script
 uv run pytest tests/test_tools/test_shell_approval_policy.py tests/test_tools/test_code_exec_output_redaction.py tests/test_tools/test_code_exec_tempdir_cleanup.py -q — 79 passed
 uv run ruff check / uv run mypy clean on changed files
