### PR TITLE
fix(tools): match grep_search's include glob against the relative path

### DIFF
--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -1033,7 +1033,14 @@ async def glob_search(pattern: str, path: str | None = None) -> str:
     params={
         "pattern": {"type": "string", "description": "Regex pattern to search for."},
         "path": {"type": "string", "description": "File or directory to search (default: cwd)."},
-        "include": {"type": "string", "description": "Glob pattern to filter files (e.g. '*.py')."},
+        "include": {
+            "type": "string",
+            "description": (
+                "Glob pattern to filter files, matched against the path relative "
+                "to `path` (e.g. '*.py', or path-qualified like 'tests/*.py' or "
+                "'src/**/*.ts')."
+            ),
+        },
         "max_results": {
             "type": "integer",
             "description": "Maximum number of matches to return (default 100).",
@@ -1095,8 +1102,16 @@ async def grep_search(
                     continue
                 if not fp.is_file():
                     continue
-                if include and not fnmatch.fnmatch(fp.name, include):
-                    continue
+                if include:
+                    # Matched against the path relative to `base`, not just
+                    # the bare filename: fnmatch's `*` already spans `/`
+                    # (fnmatch("src/a.py", "*.py") is True), so this keeps
+                    # every bare-filename pattern working while also making
+                    # path-qualified ones like "tests/*.py" or "src/**/*.ts"
+                    # match instead of silently matching nothing.
+                    relative = fp.relative_to(base).as_posix()
+                    if not fnmatch.fnmatch(relative, include):
+                        continue
                 search_file(fp)
 
         return results

--- a/tests/test_tools/test_grep_search_include.py
+++ b/tests/test_tools/test_grep_search_include.py
@@ -1,0 +1,100 @@
+"""grep_search's `include` glob: path-qualified patterns and the bare-filename form.
+
+Issue #1571: `include` was matched against `fp.name` only via
+`fnmatch.fnmatch(fp.name, include)`. Since `fp.name` never contains a
+directory separator, any path-qualified pattern ("tests/*.py",
+"src/**/*.ts") matched nothing and grep_search silently reported no
+matches, indistinguishable from "this code doesn't exist".
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from agentos.tools.builtin import filesystem as fs
+from agentos.tools.types import CallerKind, ToolContext, current_tool_context
+
+
+@contextmanager
+def tool_context(workspace: Path) -> Iterator[None]:
+    token = current_tool_context.set(
+        ToolContext(
+            caller_kind=CallerKind.CLI,
+            channel_kind="cli",
+            channel_id="cli:test",
+            workspace_dir=str(workspace),
+            workspace_strict=True,
+        )
+    )
+    try:
+        yield
+    finally:
+        current_tool_context.reset(token)
+
+
+def _layout(base: Path) -> None:
+    (base / "tests").mkdir()
+    (base / "src" / "utils").mkdir(parents=True)
+    (base / "tests" / "test_basic.py").write_text("def test_foo():\n    pass\n")
+    (base / "src" / "utils.py").write_text("import os\n")
+    (base / "src" / "utils" / "helpers.py").write_text("import sys\n")
+    (base / "notes.txt").write_text("import not-python\n")
+
+
+@pytest.mark.asyncio
+async def test_path_qualified_include_matches_the_relative_path(tmp_path: Path) -> None:
+    """Issue #1571's exact reproduction: a path-qualified include used to
+    match nothing at all."""
+    _layout(tmp_path)
+
+    with tool_context(tmp_path):
+        result = await fs.grep_search("def test_", include="tests/*.py")
+
+    assert "test_basic.py" in result
+    assert "No matches" not in result
+
+
+@pytest.mark.asyncio
+async def test_bare_filename_include_still_matches_at_any_depth(tmp_path: Path) -> None:
+    """Non-regression: fnmatch's `*` already spans `/`, so the documented
+    bare-filename form ('*.py') must keep matching files at every depth,
+    not just those directly under the search root."""
+    _layout(tmp_path)
+
+    with tool_context(tmp_path):
+        result = await fs.grep_search("import", include="*.py")
+
+    assert "utils.py" in result
+    assert "helpers.py" in result
+    assert "notes.txt" not in result
+
+
+@pytest.mark.asyncio
+async def test_recursive_path_qualified_include_matches_nested_files(tmp_path: Path) -> None:
+    """fnmatch has no special recursive-`**` handling -- it is just two
+    consecutive `*` either side of a literal `/`, which requires an extra
+    path segment. "src/**/*.py" therefore matches src/utils/helpers.py
+    (two segments under src) but not src/utils.py (only one)."""
+    _layout(tmp_path)
+
+    with tool_context(tmp_path):
+        result = await fs.grep_search("import", include="src/**/*.py")
+
+    assert "helpers.py" in result
+    assert "utils.py" not in result
+    assert "test_basic.py" not in result
+    assert "notes.txt" not in result
+
+
+@pytest.mark.asyncio
+async def test_path_qualified_include_excludes_non_matching_directories(tmp_path: Path) -> None:
+    _layout(tmp_path)
+
+    with tool_context(tmp_path):
+        result = await fs.grep_search("import", include="tests/*.py")
+
+    assert "No matches" in result


### PR DESCRIPTION


Summary
grep_search matched the include glob against fp.name only (fnmatch.fnmatch(fp.name, include))
fp.name never contains a directory separator, so any path-qualified pattern (tests/*.py, src/**/*.ts) matched nothing, and grep_search silently reported "No matches" — indistinguishable to the caller from "this code does not exist"
Matched against fp.relative_to(base).as_posix() instead
fnmatch's * already spans / (fnmatch("src/a.py", "*.py") is True), so every bare-filename pattern documented today keeps working exactly as before; path-qualified patterns now also work instead of silently matching nothing
Updated the include parameter's description, which previously documented only the bare-filename form
Fixes #1571 
Test plan
 Verified the tests catch the regression: stashed the source fix and reran — the path-qualified tests fail against the old code with the exact reported symptom ("No matches for 'def test_'"), while the bare-filename regression test correctly passed either way
 Added test_grep_search_include.py (4 tests): the issue's exact reproduction (tests/*.py now matches), the required non-regression (*.py still matches at any depth), a src/**/*.py case documenting fnmatch's actual non-recursive ** semantics, and a path-qualified pattern that correctly reports no matches when nothing qualifies
 uv run pytest tests/test_tools -k "filesystem or grep" -q — 25 passed, 4 skipped
 uv run ruff check / uv run mypy clean on changed files
