### PR TITLE
fix(compat): support hyphens and underscores in local version labels (#1676)

### DIFF
--- a/src/agentos/compat/version_utils.py
+++ b/src/agentos/compat/version_utils.py
@@ -29,7 +29,7 @@ _VERSION_RE = re.compile(
     r"(?:[._-]?(?P<pre_l>a|b|c|rc|alpha|beta|pre|preview)[._-]?(?P<pre_n>\d+)?)?"
     r"(?:[._-]?(?P<post_l>post)[._-]?(?P<post>\d+)?)?"
     r"(?:[._-]?(?P<dev_l>dev)[._-]?(?P<dev>\d+)?)?"
-    r"(?:\+(?P<local>[a-zA-Z0-9.]+))?"
+    r"(?:\+(?P<local>[a-zA-Z0-9._-]+))?"
     r"\s*$",
     re.IGNORECASE,
 )

--- a/tests/test_compat/test_version_utils.py
+++ b/tests/test_compat/test_version_utils.py
@@ -125,6 +125,11 @@ def test_ordering_is_total_and_sortable() -> None:
         "2026.7.18+devpost",
         "2026.7.18+post.dev",
         "2026.7.18+unknown",
+        "2026.7.18+git-d9ebb22",
+        "2026.7.18+ubuntu-1",
+        "2026.7.18+build_123",
+        "2026.7.18+sha.abc-dirty",
+        "2026.7.18+2026-09-10",
     ],
 )
 def test_local_label_never_sets_post_or_dev(raw: str) -> None:
@@ -145,6 +150,10 @@ def test_local_label_never_sets_post_or_dev(raw: str) -> None:
         "2026.7.18+postgres",
         "2026.7.18+device",
         "2026.7.18+local.post1",
+        "2026.7.18+git-d9ebb22",
+        "2026.7.18+ubuntu-1",
+        "2026.7.18+build_123",
+        "2026.7.18+sha.abc-dirty",
     ],
 )
 def test_local_label_is_ignored_for_ordering(raw: str) -> None:


### PR DESCRIPTION
Fixes #1676

## Summary
Per PEP 440 specification for local version identifiers, local versions consist of ASCII letters and digits separated by dots, hyphens, or underscores.

Previously, `_VERSION_RE` in `version_utils.py` used `(?:\+(?P<local>[a-zA-Z0-9.]+))?`, omitting hyphens (`-`) and underscores (`_`). As a result, valid local version tags (e.g. `2026.7.18+git-d9ebb22`, `2026.7.18+ubuntu-1`, `2026.7.18+build_123`, `2026.7.18+sha.abc-dirty`) failed regex matching entirely, resulting in `parsed=False` and `release=(-1,)` which caused `compare_versions` / `is_newer` to erroneously treat them as corrupted / older than everything.

## What was changed
- Updated `_VERSION_RE` in `src/agentos/compat/version_utils.py` to allow `[a-zA-Z0-9._-]` in the local version segment.
- Added comprehensive unit tests in `tests/test_compat/test_version_utils.py` covering local version labels containing hyphens, underscores, dots, and mixed build identifiers to ensure `parse_version`, `compare_versions`, and `is_newer` behave consistently.

## Quality Gate Verification
- `uv run ruff check src/agentos/compat tests/test_compat` (clean)
- `uv run ruff format --check src/agentos/compat/version_utils.py tests/test_compat/test_version_utils.py` (clean)
- `uv run mypy src/agentos --show-error-codes` (clean)
- `uv run pytest tests/test_compat/test_version_utils.py -q` (62 passed)
