### PR TITLE
fix(skills): apply the pdf-toolkit table strategy to both axes

### DIFF
--- a/src/agentos/skills/bundled/pdf-toolkit/SKILL.md
+++ b/src/agentos/skills/bundled/pdf-toolkit/SKILL.md
@@ -76,7 +76,22 @@ Output:
 Text uses `pdfplumber` (already in default dependencies) which preserves
 column layout better than naive PDF text extraction. Tables use
 `pdfplumber.extract_tables()` with default settings; for tricky layouts
-pass `--tables-strategy lines|text|explicit` to switch detection mode.
+pass `--tables-strategy lines|text|explicit` to switch detection mode. The
+strategy applies to both axes:
+
+| Strategy | Finds rows and columns from | Use when |
+|---|---|---|
+| `lines` (default) | ruling lines drawn in the PDF | the table has visible borders |
+| `text` | the alignment of the words themselves | the table is borderless |
+| `explicit` | coordinates you supply | detection fails and you know the edges |
+
+`explicit` needs both edge lists, or the run stops with an error:
+
+```bash
+python {baseDir}/scripts/extract.py doc.pdf --tables-strategy explicit \
+  --explicit-vertical-lines "270,315,360" \
+  --explicit-horizontal-lines "78,96,114,132"
+```
 
 For OCR (scanned PDFs), this skill does not include Tesseract — use the
 sibling skill that wraps an OCR engine (out of scope here).

--- a/src/agentos/skills/bundled/pdf-toolkit/scripts/extract.py
+++ b/src/agentos/skills/bundled/pdf-toolkit/scripts/extract.py
@@ -12,7 +12,62 @@ import pdfplumber
 from pypdf import PdfReader
 
 
-def extract(path: Path, tables_strategy: str | None) -> dict[str, Any]:
+def parse_coordinates(raw: str | None, label: str) -> list[float]:
+    """Parse a comma-separated list of page coordinates for the explicit strategy."""
+    if not raw:
+        return []
+    values: list[float] = []
+    for token in raw.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        try:
+            values.append(float(token))
+        except ValueError as exc:
+            raise ValueError(f"{label} expects numbers, got {token!r}") from exc
+    return values
+
+
+def build_table_settings(
+    tables_strategy: str | None,
+    vertical_lines: list[float] | None = None,
+    horizontal_lines: list[float] | None = None,
+) -> dict[str, Any]:
+    """Return the pdfplumber table settings for *tables_strategy*.
+
+    A strategy names how to find the edges of a table, and pdfplumber asks for
+    it once per axis. Setting only ``vertical_strategy`` left the horizontal
+    axis on its ``"lines"`` default, so ``--tables-strategy text`` still needed
+    ruling lines to find its rows and returned nothing on exactly the
+    borderless tables it exists to read.
+
+    ``explicit`` additionally reads the edge positions out of
+    ``explicit_vertical_lines`` / ``explicit_horizontal_lines``; with neither
+    key present pdfplumber dereferences ``None`` and raises ``TypeError`` from
+    inside ``get_edges()``, so the caller has to supply them.
+    """
+    strategy = tables_strategy or "lines"
+    settings: dict[str, Any] = {
+        "vertical_strategy": strategy,
+        "horizontal_strategy": strategy,
+    }
+    if strategy == "explicit":
+        if not vertical_lines or not horizontal_lines:
+            raise ValueError(
+                "--tables-strategy explicit needs both --explicit-vertical-lines and "
+                "--explicit-horizontal-lines (comma-separated page coordinates)"
+            )
+        settings["explicit_vertical_lines"] = list(vertical_lines)
+        settings["explicit_horizontal_lines"] = list(horizontal_lines)
+    return settings
+
+
+def extract(
+    path: Path,
+    tables_strategy: str | None,
+    vertical_lines: list[float] | None = None,
+    horizontal_lines: list[float] | None = None,
+) -> dict[str, Any]:
     reader = PdfReader(str(path))
     metadata: dict[str, Any] = {}
     if reader.metadata is not None:
@@ -21,7 +76,7 @@ def extract(path: Path, tables_strategy: str | None) -> dict[str, Any]:
 
     pages_text: list[dict[str, Any]] = []
     tables: list[dict[str, Any]] = []
-    table_settings = {"vertical_strategy": tables_strategy or "lines"}
+    table_settings = build_table_settings(tables_strategy, vertical_lines, horizontal_lines)
     with pdfplumber.open(str(path)) as pdf:
         for idx, page in enumerate(pdf.pages, start=1):
             content = page.extract_text() or ""
@@ -44,7 +99,17 @@ def _parse_args() -> argparse.Namespace:
         "--tables-strategy",
         choices=("lines", "text", "explicit"),
         default=None,
-        help="pdfplumber table-detection strategy",
+        help="pdfplumber table-detection strategy, applied to both axes",
+    )
+    parser.add_argument(
+        "--explicit-vertical-lines",
+        default=None,
+        help="Comma-separated x coordinates of the column edges, for --tables-strategy explicit",
+    )
+    parser.add_argument(
+        "--explicit-horizontal-lines",
+        default=None,
+        help="Comma-separated y coordinates of the row edges, for --tables-strategy explicit",
     )
     parser.add_argument("--out", type=Path, default=None)
     parser.add_argument("--json", action="store_true", help="Force JSON output (default)")
@@ -56,7 +121,15 @@ def main() -> int:
     if not args.path.is_file():
         print(f"error: {args.path} not found", file=sys.stderr)
         return 2
-    payload = extract(args.path, args.tables_strategy)
+    try:
+        vertical = parse_coordinates(args.explicit_vertical_lines, "--explicit-vertical-lines")
+        horizontal = parse_coordinates(
+            args.explicit_horizontal_lines, "--explicit-horizontal-lines"
+        )
+        payload = extract(args.path, args.tables_strategy, vertical, horizontal)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
     text = json.dumps(payload, ensure_ascii=False, indent=2)
     if args.out is not None:
         args.out.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_skill_pdf_toolkit.py
+++ b/tests/test_skill_pdf_toolkit.py
@@ -127,3 +127,126 @@ def test_extract_creates_parent_directory(tmp_path: Path, monkeypatch: pytest.Mo
     )
     assert extract.main() == 0
     assert out_file.is_file()
+
+
+def _make_borderless_table_pdf(path: Path) -> None:
+    """A table with no ruling lines — the layout ``--tables-strategy text`` is for."""
+    from reportlab.lib.pagesizes import LETTER
+    from reportlab.platypus import SimpleDocTemplate, Table
+
+    doc = SimpleDocTemplate(str(path), pagesize=LETTER)
+    doc.build([Table([["Name", "Qty"], ["Widget", "3"], ["Gadget", "7"]])])
+
+
+def _import_extract() -> object:
+    sys.path.insert(0, str(SCRIPTS))
+    try:
+        import extract  # type: ignore[import-not-found]
+    finally:
+        sys.path.pop(0)
+    return extract
+
+
+def test_table_strategy_applies_to_both_axes() -> None:
+    """A strategy names how to find edges, and pdfplumber asks per axis.
+
+    Setting only ``vertical_strategy`` left the horizontal axis on its
+    ``"lines"`` default, so ``text`` mode still hunted for ruling lines to
+    find its rows.
+    """
+    extract = _import_extract()
+
+    for strategy in ("lines", "text"):
+        settings = extract.build_table_settings(strategy)
+        assert settings["vertical_strategy"] == strategy
+        assert settings["horizontal_strategy"] == strategy
+
+    # The default is still lines, on both axes.
+    assert extract.build_table_settings(None) == {
+        "vertical_strategy": "lines",
+        "horizontal_strategy": "lines",
+    }
+
+
+def test_text_strategy_finds_a_borderless_table(tmp_path: Path) -> None:
+    """The regression the flag exists for: a table with no ruling lines.
+
+    Under the one-axis settings this came back as ``"tables": []`` — the
+    horizontal axis was still looking for lines the table does not draw.
+    """
+    extract = _import_extract()
+
+    pdf_file = tmp_path / "table.pdf"
+    _make_borderless_table_pdf(pdf_file)
+
+    payload = extract.extract(pdf_file, tables_strategy="text")
+    rows = [cell for table in payload["tables"] for row in table["rows"] for cell in row]
+    assert "Widget" in rows
+    assert "Gadget" in rows
+
+    # ``lines`` still reports nothing here, which is correct: there are none.
+    assert extract.extract(pdf_file, tables_strategy="lines")["tables"] == []
+
+
+def test_explicit_strategy_carries_the_edge_coordinates(tmp_path: Path) -> None:
+    """``explicit`` reads the edges from the settings, so they must be sent."""
+    extract = _import_extract()
+
+    settings = extract.build_table_settings("explicit", [270.0, 315.0], [78.0, 96.0])
+    assert settings["explicit_vertical_lines"] == [270.0, 315.0]
+    assert settings["explicit_horizontal_lines"] == [78.0, 96.0]
+
+    pdf_file = tmp_path / "table.pdf"
+    _make_borderless_table_pdf(pdf_file)
+    payload = extract.extract(
+        pdf_file,
+        tables_strategy="explicit",
+        vertical_lines=[270.0, 315.0, 360.0],
+        horizontal_lines=[78.0, 96.0, 114.0, 132.0],
+    )
+    assert payload["tables"], "explicit edges should yield a table"
+    assert payload["tables"][0]["rows"][0] == ["Name", "Qty"]
+
+
+@pytest.mark.parametrize(
+    ("vertical", "horizontal"),
+    [(None, None), ([270.0], None), (None, [78.0])],
+)
+def test_explicit_strategy_without_edges_is_a_clear_error(
+    vertical: list[float] | None, horizontal: list[float] | None
+) -> None:
+    """Missing edges used to surface as ``TypeError`` from inside pdfplumber.
+
+    ``get_edges()`` called ``len(None)`` on the absent
+    ``explicit_vertical_lines``, so every ``--tables-strategy explicit`` run
+    ended in a traceback naming a pdfplumber internal.
+    """
+    extract = _import_extract()
+
+    with pytest.raises(ValueError, match="explicit-vertical-lines"):
+        extract.build_table_settings("explicit", vertical, horizontal)
+
+
+def test_explicit_strategy_reports_the_error_on_stderr(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    extract = _import_extract()
+
+    pdf_file = tmp_path / "doc.pdf"
+    _make_one_page_pdf(pdf_file, "TEST")
+    monkeypatch.setattr(sys, "argv", ["extract.py", str(pdf_file), "--tables-strategy", "explicit"])
+    assert extract.main() == 2
+    assert "explicit-vertical-lines" in capsys.readouterr().err
+
+
+def test_explicit_coordinates_reject_non_numbers() -> None:
+    extract = _import_extract()
+
+    assert extract.parse_coordinates("270, 315.5 ,360", "--explicit-vertical-lines") == [
+        270.0,
+        315.5,
+        360.0,
+    ]
+    assert extract.parse_coordinates(None, "--explicit-vertical-lines") == []
+    with pytest.raises(ValueError, match="expects numbers"):
+        extract.parse_coordinates("270,left-edge", "--explicit-vertical-lines")


### PR DESCRIPTION
Fixes #1673

## The bug

`extract.py` built the pdfplumber settings from one axis:

```python
table_settings = {"vertical_strategy": tables_strategy or "lines"}
```

pdfplumber asks for a strategy **once per axis**. `horizontal_strategy` was never set, so it stayed on its `"lines"` default no matter what `--tables-strategy` said. `text` mode therefore switched only how columns were found and kept looking for ruling lines to find its rows — and a borderless table has none, which is the entire reason a caller reaches for `text`:

```python
>>> page.extract_tables({"vertical_strategy": "text"})                                # what the script sent
[]
>>> page.extract_tables({"vertical_strategy": "text", "horizontal_strategy": "text"}) # both axes
[[['Name', 'Qty'], ['', ''], ['Widget', '3'], ['', ''], ['Gadget', '7']]]
```

`explicit` was worse. That mode reads its edge positions out of `explicit_vertical_lines` / `explicit_horizontal_lines`, and the script had no way to supply either, so pdfplumber dereferenced `None`:

```
  File "pdfplumber/table.py", line 609, in get_edges
    if len(lines) < 2:
TypeError: object of type 'NoneType' has no len()
```

`explicit` is one of the three values `argparse` advertises in `choices` and one of the three `SKILL.md` tells the agent to reach for. Every single invocation of it ended in that traceback.

| `--tables-strategy` | Before | After |
|---|---|---|
| *(default)* | works | works |
| `lines` | works | works |
| `text` | `"tables": []` on a borderless table | finds the table |
| `explicit` | `TypeError` from a pdfplumber internal | works with edges; clear error without |

So of the three documented detection modes, only the default did anything.

## The fix

Send the chosen strategy on both axes, and give `explicit` the coordinates it reads:

```python
strategy = tables_strategy or "lines"
settings: dict[str, Any] = {
    "vertical_strategy": strategy,
    "horizontal_strategy": strategy,
}
if strategy == "explicit":
    if not vertical_lines or not horizontal_lines:
        raise ValueError(
            "--tables-strategy explicit needs both --explicit-vertical-lines and "
            "--explicit-horizontal-lines (comma-separated page coordinates)"
        )
    settings["explicit_vertical_lines"] = list(vertical_lines)
    settings["explicit_horizontal_lines"] = list(horizontal_lines)
```

`--explicit-vertical-lines` / `--explicit-horizontal-lines` are new and optional, so nothing that runs today changes shape. I chose to **add** the two flags rather than drop `explicit` from `choices`: removing it would take away a documented surface, and the mode is genuinely useful once it can be told where the edges are. Chosen without them, it now stops at `main()` with the message above and exit code 2 instead of a traceback naming a pdfplumber internal.

The default is untouched — no `--tables-strategy` still means `lines` on both axes, which is what every existing caller gets.

`pdf-toolkit/SKILL.md` is updated in the same change: it is what tells the agent these three modes exist, and it previously said only "switch detection mode". It now carries a table of what each strategy reads and the `explicit` invocation with its two edge lists.

## Tests

`tests/test_skill_pdf_toolkit.py`, 6 new tests (14 in the file, all offline — the fixture PDF is built in `tmp_path` with reportlab, already a test dependency):

- `test_table_strategy_applies_to_both_axes` — `lines` and `text` reach both axes; `None` still means `lines` on both.
- `test_text_strategy_finds_a_borderless_table` — the end-to-end regression: a reportlab table with no ruling lines, extracted through `extract()`. Also asserts `lines` still reports nothing there, which is the correct answer for that page and guards the opposite direction.
- `test_explicit_strategy_carries_the_edge_coordinates` — the edges reach the settings dict, and real coordinates against the fixture yield `['Name', 'Qty']`.
- `test_explicit_strategy_without_edges_is_a_clear_error` — parametrized over neither / vertical-only / horizontal-only, since one list alone is just as unusable as none.
- `test_explicit_strategy_reports_the_error_on_stderr` — `main()` returns 2 and names the flag, rather than raising.
- `test_explicit_coordinates_reject_non_numbers` — **passes either way by design.** It covers `parse_coordinates`, a helper this PR introduces, so there is no pre-fix state for it to fail against; it is there to keep the parser honest about whitespace, blanks and junk.

Reverting only the fixed branch — `build_table_settings` restored to `return {"vertical_strategy": tables_strategy or "lines"}` — fails 7 of the 8 new test cases, the whole set except the one named above.

## Verification

```
$ uv run pytest tests/test_skill_pdf_toolkit.py -q
..............                                                           [100%]
14 passed in 0.53s

$ uv run ruff check .
All checks passed!

$ uv run mypy --show-error-codes src
Success: no issues found in 625 source files

$ uv run pytest -q
6 failed, 10258 passed, 34 skipped, 4 warnings, 3 errors in 266.04s (0:04:26)
```

The 6 failures and 3 errors are pre-existing in my environment, not from this change — `src/agentos/memory/models/embeddings/.../model.onnx` is an unhydrated Git LFS pointer here (`version https://git-lfs.github.com/spec/v1`, 133 bytes). A `git worktree` at pristine `upstream/main` (`0377d742`) produces exactly the same set:

```
$ git worktree add --detach /tmp/base upstream/main && cd /tmp/base
$ uv run pytest -q tests/test_agentos_router/test_pilot_encoder.py \
    tests/test_public_release_hygiene.py tests/test_scripts/test_build_wheelhouse_zip.py \
    tests/test_pilot_benchmark.py
FAILED tests/test_agentos_router/test_pilot_encoder.py::test_encode_sync_returns_embed_dim_float32_rows
FAILED tests/test_agentos_router/test_pilot_encoder.py::test_encode_sync_right_truncates_at_256_tokens
FAILED tests/test_public_release_hygiene.py::test_tracked_public_files_do_not_carry_this_machines_timezone
FAILED tests/test_scripts/test_build_wheelhouse_zip.py::test_real_minilm_export_passes_embedding_asset_check
FAILED tests/test_scripts/test_build_wheelhouse_zip.py::test_built_wheel_packages_hydrated_minilm_onnx
FAILED tests/test_scripts/test_build_wheelhouse_zip.py::test_built_wheel_packages_hydrated_pilot_bundle
ERROR tests/test_pilot_benchmark.py::test_pathological_paste_stays_within_8192_char_bound
ERROR tests/test_pilot_benchmark.py::test_ordinary_lengths_respect_the_char_bound
ERROR tests/test_pilot_benchmark.py::test_warm_p50_meets_hard_ceiling_at_2048
6 failed, 56 passed, 3 errors in 8.69s
```

Note on `ruff format`: running it repo-wide with the ruff resolved here (0.15.9, against the `ruff>=0.5` floor) reformats 449 unrelated files and then *fails* `ruff check`. I formatted only the two files this PR touches; both report "already formatted".

## One adjacent case, deliberately left alone

`SKILL.md` also tells the reader to "strip signatures explicitly with `--clear-signatures`" in the form-fill section, and `form_fill.py` has no such flag — `--clear-signatures` exits 2 with "unrecognized arguments". Same class of defect (documented surface the script does not implement), different script and a different decision to make: whether to implement signature stripping or drop the sentence. Out of scope here; happy to file it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139Xmz6XXHprAsMVbc2cBx3
