### PR TITLE
fix(skills): cap a watcher run without consuming the backlog

### DIFF
--- a/src/agentos/skills/bundled/cron-watchers/SKILL.md
+++ b/src/agentos/skills/bundled/cron-watchers/SKILL.md
@@ -35,7 +35,9 @@ which is exactly the contract a cron `script` job wants.
 
 All three also take `--limit` (max lines per run, default 10) and
 `--first-run-reports` (report everything on the first run instead of starting
-quiet).
+quiet). `--limit` caps one run, not the backlog: when a feed publishes more
+new items than the cap, the surplus is held back and reported by the following
+runs rather than being skipped.
 
 `--url` must be `http://` or `https://`. Any other scheme is refused with exit
 code 1 — `urlopen` speaks `file:`, `ftp:` and `data:` too, and a watcher

--- a/src/agentos/skills/bundled/cron-watchers/scripts/_watermark.py
+++ b/src/agentos/skills/bundled/cron-watchers/scripts/_watermark.py
@@ -53,17 +53,36 @@ def save_seen(name: str, ids: list[str]) -> None:
     tmp.replace(path)
 
 
-def select_new(name: str, ids: list[str], *, first_run_reports: bool = False) -> list[str]:
+def select_new(
+    name: str,
+    ids: list[str],
+    *,
+    first_run_reports: bool = False,
+    limit: int | None = None,
+) -> list[str]:
     """Return the ids not seen before and record them.
 
     The first run reports nothing by default: a watcher that has never run has
     no idea which of the 50 items on the page are actually new, and dumping all
     of them into a chat is the wrong first impression.
+
+    ``limit`` caps how many ids one run hands back. Only the ids actually
+    returned are committed, so a burst bigger than the cap is reported over the
+    following runs instead of being marked seen without ever being printed.
+    Recording all of them and then slicing at the caller is what made a feed
+    with more than ``--limit`` new items lose the surplus for good.
+
+    The first-run adoption stays uncapped: it is recording the feed's current
+    state rather than reporting it, so capping it would leave the rest of the
+    page to arrive as "new" on the next run — the dump the silent first run
+    exists to prevent.
     """
     seen = set(load_seen(name))
     is_first_run = not seen
     fresh = [item for item in ids if item not in seen]
-    save_seen(name, [*load_seen(name), *fresh])
     if is_first_run and not first_run_reports:
+        save_seen(name, [*load_seen(name), *fresh])
         return []
-    return fresh
+    reported = fresh if limit is None else fresh[: max(0, limit)]
+    save_seen(name, [*load_seen(name), *reported])
+    return reported

--- a/src/agentos/skills/bundled/cron-watchers/scripts/watch_github.py
+++ b/src/agentos/skills/bundled/cron-watchers/scripts/watch_github.py
@@ -110,11 +110,16 @@ def main() -> int:
         if identifier:
             lines[identifier] = line
 
-    fresh = select_new(watermark, list(lines), first_run_reports=args.first_run_reports)
+    fresh = select_new(
+        watermark,
+        list(lines),
+        first_run_reports=args.first_run_reports,
+        limit=args.limit,
+    )
     if not fresh:
         return 0
 
-    for identifier in fresh[: args.limit]:
+    for identifier in fresh:
         print(lines[identifier])
     return 0
 

--- a/src/agentos/skills/bundled/cron-watchers/scripts/watch_http_json.py
+++ b/src/agentos/skills/bundled/cron-watchers/scripts/watch_http_json.py
@@ -117,11 +117,16 @@ def main() -> int:
             continue
         by_id[str(identifier)] = item
 
-    fresh = select_new(args.name, list(by_id), first_run_reports=args.first_run_reports)
+    fresh = select_new(
+        args.name,
+        list(by_id),
+        first_run_reports=args.first_run_reports,
+        limit=args.limit,
+    )
     if not fresh:
         return 0
 
-    for identifier in fresh[: args.limit]:
+    for identifier in fresh:
         print(f"- {_summarize(by_id[identifier], args.field)}")
     return 0
 

--- a/src/agentos/skills/bundled/cron-watchers/scripts/watch_rss.py
+++ b/src/agentos/skills/bundled/cron-watchers/scripts/watch_rss.py
@@ -94,11 +94,16 @@ def main() -> int:
 
     entries = _entries(root)
     by_id = {entry[0]: entry for entry in entries}
-    fresh = select_new(args.name, list(by_id), first_run_reports=args.first_run_reports)
+    fresh = select_new(
+        args.name,
+        list(by_id),
+        first_run_reports=args.first_run_reports,
+        limit=args.limit,
+    )
     if not fresh:
         return 0
 
-    for guid in fresh[: args.limit]:
+    for guid in fresh:
         _, title, link = by_id[guid]
         print(f"- {title or guid}" + (f"\n  {link}" if link else ""))
     return 0

--- a/tests/test_skills/test_cron_watchers.py
+++ b/tests/test_skills/test_cron_watchers.py
@@ -302,3 +302,109 @@ def test_github_rejects_an_unknown_scope(state_dir):
     result = _run("watch_github.py", "--repo", "o/n", "--scope", "stars", env_home=state_dir)
 
     assert result.returncode == 2  # argparse rejects the choice
+
+
+# ── --limit caps a run, not the backlog (Issue #1674) ───────────────────────
+
+
+def _rss_with(count: int, offset: int = 0) -> str:
+    items = "".join(
+        f"<item><title>Post {n}</title><link>https://example.com/{n}</link><guid>{n}</guid></item>"
+        for n in range(offset, offset + count)
+    )
+    return f'<?xml version="1.0"?><rss><channel>{items}</channel></rss>'
+
+
+def test_rss_reports_the_surplus_on_the_next_run(state_dir, base_url):
+    """More new items than ``--limit`` must not be consumed unreported.
+
+    The watermark used to record every fresh id and the caller then printed
+    only the first ``--limit`` of them, so a feed that published more than the
+    cap between two runs lost the difference for good.
+    """
+    url = _feed(state_dir, base_url, "feed.xml", _rss_with(1))
+    _run("watch_rss.py", "--url", url, "--name", "t", env_home=state_dir)  # adopt silently
+
+    _feed(state_dir, base_url, "feed.xml", _rss_with(6))  # 5 new items, cap of 2
+    first = _run("watch_rss.py", "--url", url, "--name", "t", "--limit", "2", env_home=state_dir)
+    assert first.returncode == 0
+    assert first.stdout.count("Post ") == 2
+
+    reported = first.stdout
+    for _ in range(3):
+        nxt = _run("watch_rss.py", "--url", url, "--name", "t", "--limit", "2", env_home=state_dir)
+        assert nxt.returncode == 0
+        reported += nxt.stdout
+
+    # Every one of the five new posts is reported, each exactly once.
+    for n in range(1, 6):
+        assert reported.count(f"Post {n}\n") == 1, f"Post {n} in {reported!r}"
+
+    # And once the backlog is drained the watcher goes quiet again.
+    assert _run("watch_rss.py", "--url", url, "--name", "t", env_home=state_dir).stdout == ""
+
+
+def test_json_reports_the_surplus_on_the_next_run(state_dir, base_url):
+    args = ("--name", "j", "--id-field", "event_id", "--items-path", "data.events")
+    url = _events(state_dir, base_url, [{"event_id": "seed", "title": "Seed"}])
+    _run("watch_http_json.py", "--url", url, *args, env_home=state_dir)
+
+    _events(
+        state_dir,
+        base_url,
+        [{"event_id": f"e{n}", "title": f"Event {n}"} for n in range(4)],
+    )
+    first = _run("watch_http_json.py", "--url", url, *args, "--limit", "1", env_home=state_dir)
+    assert first.stdout.count("Event ") == 1
+
+    reported = first.stdout
+    for _ in range(3):
+        reported += _run(
+            "watch_http_json.py", "--url", url, *args, "--limit", "1", env_home=state_dir
+        ).stdout
+
+    for n in range(4):
+        assert reported.count(f"Event {n}\n") == 1, f"Event {n} in {reported!r}"
+
+
+def test_a_capped_run_records_only_what_it_reported(state_dir):
+    """The watermark itself, not just the printed lines.
+
+    ``select_new`` is the shared helper all three watchers commit through, so
+    assert on the stored state directly: an id that was held back must not be
+    in the file.
+    """
+    sys.path.insert(0, str(SCRIPTS))
+    try:
+        import _watermark  # type: ignore[import-not-found]
+    finally:
+        sys.path.pop(0)
+
+    # ``state_dir`` already points AGENTOS_STATE_DIR at this test's tmp_path.
+    ids = [f"item-{n:02d}" for n in range(6)]
+
+    _watermark.select_new("cap", ids[:1])  # first run adopts silently
+    assert _watermark.load_seen("cap") == ["item-00"]
+
+    assert _watermark.select_new("cap", ids, limit=2) == ["item-01", "item-02"]
+    assert _watermark.load_seen("cap") == ["item-00", "item-01", "item-02"]
+
+    assert _watermark.select_new("cap", ids, limit=2) == ["item-03", "item-04"]
+    assert _watermark.select_new("cap", ids, limit=2) == ["item-05"]
+    assert _watermark.select_new("cap", ids, limit=2) == []
+    assert _watermark.load_seen("cap") == ids
+
+
+def test_the_first_run_adopts_the_whole_feed_despite_a_low_limit(state_dir, base_url):
+    """The silent first run stays uncapped.
+
+    Capping it would leave the rest of the page to arrive as "new" on the next
+    run — exactly the dump the silent first run exists to prevent.
+    """
+    url = _feed(state_dir, base_url, "feed.xml", _rss_with(5))
+
+    first = _run("watch_rss.py", "--url", url, "--name", "t", "--limit", "1", env_home=state_dir)
+    assert first.stdout == ""
+
+    second = _run("watch_rss.py", "--url", url, "--name", "t", "--limit", "1", env_home=state_dir)
+    assert second.stdout == "", "the adopted feed must not resurface as new"


### PR DESCRIPTION
Fixes #1674

## The bug

`select_new` committed **every** fresh id to the watermark:

```python
fresh = [item for item in ids if item not in seen]
save_seen(name, [*load_seen(name), *fresh])   # records all of them
```

and each of the three watchers then printed only the first `--limit`:

```python
for guid in fresh[: args.limit]:
```

So anything past the cap was marked seen without ever being reported. The watermark file already claimed those ids were handled, which means no later run could bring them back — there is no error, no warning, and no recovery.

Reproduced with the shared helper, default `--limit 10`:

```
run1 reported: []                 # first run adopts the feed silently, by design
run1 seen: 5
run2 fresh: 20 -> printed: 10
run2 seen after: 25
run3 fresh: []
silently dropped forever: ['item-15', 'item-16', ..., 'item-24']
```

| Run | New in feed | Printed | Committed | Recoverable later |
|---|---|---|---|---|
| before | 20 | 10 | 25 | no — 10 items gone |
| after | 20 | 10 | 15 | yes — the other 10 arrive next run |

This lands on the ordinary case, not a corner: a `--every 15m` job against a busy feed, a repo with a burst of issues, an events endpoint emitting more than 10 objects between polls. `watch_github.py` is the sharpest — it asks GitHub for `per_page=30` against a default `--limit` of 10, so a single run can consume 20 items unseen.

All three bundled watchers share the pattern, so all three are fixed here.

## The fix

Commit only what the run actually hands back, and let the watchers pass their cap down instead of slicing the result afterwards:

```python
    if is_first_run and not first_run_reports:
        save_seen(name, [*load_seen(name), *fresh])
        return []
    reported = fresh if limit is None else fresh[: max(0, limit)]
    save_seen(name, [*load_seen(name), *reported])
    return reported
```

```python
    fresh = select_new(
        args.name, list(by_id), first_run_reports=args.first_run_reports, limit=args.limit
    )
    for guid in fresh:
```

Left deliberately intact:

- **The silent first run stays uncapped.** It records the feed's current state rather than reporting it; capping it would leave the rest of the page to arrive as "new" on the next run, which is exactly the dump the silent first run exists to prevent. There is a test pinning this.
- **`MAX_REMEMBERED_IDS` and the trim in `save_seen`** — untouched.
- **`limit=None` still means no cap**, so any other caller of `select_new` behaves as before.

One small behaviour change worth naming: `max(0, limit)` means a negative `--limit` now reports nothing rather than being read as a Python slice ("all but the last N"), which nobody asks a `--limit` for. `--limit 0` reports nothing and now also commits nothing, so it is a genuine no-op instead of a run that quietly eats the feed.

`cron-watchers/SKILL.md` is updated in the same change — it is what documents `--limit` to the agent, and "max lines per run" alone does not say what happens to the surplus.

## Tests

`tests/test_skills/test_cron_watchers.py`, 4 new tests (22 in the file). All offline: the fixtures are served over a loopback `ThreadingHTTPServer` on an OS-assigned port, and state is isolated under `AGENTOS_STATE_DIR` — the existing convention in this file.

- `test_rss_reports_the_surplus_on_the_next_run` — end to end through `watch_rss.py`: 5 new items with `--limit 2`, drained over four runs, then asserts each of the five was reported **exactly once** and that the watcher goes quiet afterwards. The "exactly once" half matters: committing too little would show up as duplicates rather than loss.
- `test_json_reports_the_surplus_on_the_next_run` — the same drain through `watch_http_json.py`, since each watcher wires the cap through itself.
- `test_a_capped_run_records_only_what_it_reported` — asserts on the stored state via `load_seen()`, not just stdout, and walks the whole backlog down to empty. `select_new` is the one place all three watchers commit through, so this is the test that pins the mechanism.
- `test_the_first_run_adopts_the_whole_feed_despite_a_low_limit` — **passes either way by design.** It guards the direction the issue does *not* report: the fix must not start capping the silent first-run adoption, or the remainder of the page resurfaces as new on the following run.

`watch_github.py` is covered by the shared-helper test rather than an end-to-end one — reaching it would need a stubbed `api.github.com`, and the existing file mocks nothing; its two tests stop at argument validation. Its fix is the same three-line wiring as the other two.

Reverting only the commit side of `select_new` — `save_seen` back above the first-run check, recording all of `fresh` — fails 3 of the 4, the whole set except the guard named above.

## Verification

```
$ uv run pytest tests/test_skills/test_cron_watchers.py -q
......................                                                   [100%]
22 passed in 10.49s

$ uv run ruff check .
All checks passed!

$ uv run mypy --show-error-codes src
Success: no issues found in 625 source files

$ uv run pytest -q
6 failed, 10254 passed, 34 skipped, 4 warnings, 3 errors in 269.39s (0:04:29)
```

The 6 failures and 3 errors are pre-existing in my environment, not from this change — `src/agentos/memory/models/embeddings/.../model.onnx` is an unhydrated Git LFS pointer here (`version https://git-lfs.github.com/spec/v1`, 133 bytes). A `git worktree` at pristine `upstream/main` (`0377d742`) produces exactly the same set:

```
$ git worktree add --detach /tmp/base upstream/main && cd /tmp/base
$ uv run pytest -q tests/test_agentos_router/test_pilot_encoder.py \
    tests/test_public_release_hygiene.py tests/test_scripts/test_build_wheelhouse_zip.py \
    tests/test_pilot_benchmark.py
FAILED tests/test_agentos_router/test_pilot_encoder.py::test_encode_sync_returns_embed_dim_float32_rows
FAILED tests/test_agentos_router/test_pilot_encoder.py::test_encode_sync_right_truncates_at_256_tokens
FAILED tests/test_public_release_hygiene.py::test_tracked_public_files_do_not_carry_this_machines_timezone
FAILED tests/test_scripts/test_build_wheelhouse_zip.py::test_real_minilm_export_passes_embedding_asset_check
FAILED tests/test_scripts/test_build_wheelhouse_zip.py::test_built_wheel_packages_hydrated_minilm_onnx
FAILED tests/test_scripts/test_build_wheelhouse_zip.py::test_built_wheel_packages_hydrated_pilot_bundle
ERROR tests/test_pilot_benchmark.py::test_pathological_paste_stays_within_8192_char_bound
ERROR tests/test_pilot_benchmark.py::test_ordinary_lengths_respect_the_char_bound
ERROR tests/test_pilot_benchmark.py::test_warm_p50_meets_hard_ceiling_at_2048
6 failed, 56 passed, 3 errors in 8.69s
```

## One adjacent case, deliberately left alone

`save_seen` trims to `MAX_REMEMBERED_IDS` with `[-500:]`, keeping the **tail** of the list, and `load_seen`'s docstring says the file is "oldest first". But the watchers pass ids in feed order, and a feed lists newest first — so on a feed with more than 500 entries the trim keeps the oldest ids and evicts the newest, which would make recently-seen items resurface as new. It needs its own decision (sort on write, or cap on read) and it is a different mechanism from the one this issue is about, so I left it alone. Happy to file it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139Xmz6XXHprAsMVbc2cBx3
