### PR TITLE
fix(sandbox): resolve relative command targets against cwd, not works…

### DIFF
--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -482,6 +482,15 @@ def sensitive_target_in_command(
 ) -> str | None:
     """Return the first sensitive marker for any destructive target, or None.
 
+    ``cwd`` and ``workspace`` answer two different questions and must not be
+    conflated: ``cwd`` is where a *relative* target in the command actually
+    resolves (the process's execution directory), while ``workspace`` is the
+    configured boundary that :func:`sensitive_path_marker` checks a target
+    against for the active-workspace exception (a workspace nested under a
+    broad sensitive prefix, e.g. ``/root/.agentos/workspace``, stays usable).
+    Falling back to one for the other lets a relative destructive target
+    resolve against the wrong base and silently miss a sensitive path.
+
     Multi-target commands (``rm /tmp/ok /etc/bad``) are each checked — the
     presence of a single sensitive path is enough to block the whole command.
     The filesystem root is sensitive here and only here: deleting ``/`` wipes
@@ -493,14 +502,12 @@ def sensitive_target_in_command(
         return None
     from agentos.sandbox.intent_cache import _extract_intents
 
-    effective_workspace = workspace
-    if effective_workspace is None:
-        effective_workspace = cwd if cwd is not None else Path.cwd()
+    resolve_base = cwd if cwd is not None else Path.cwd()
 
-    for _kind, target in _extract_intents(command, base_dir=effective_workspace):
+    for _kind, target in _extract_intents(command, base_dir=resolve_base):
         if _is_root_target(target):
             return _ROOT_TARGET_MARKER
-        marker = sensitive_path_marker(target, workspace=effective_workspace)
+        marker = sensitive_path_marker(target, workspace=workspace)
         if marker is not None:
             return marker
     return None

--- a/tests/test_sandbox/test_sensitive_paths.py
+++ b/tests/test_sandbox/test_sensitive_paths.py
@@ -81,6 +81,64 @@ def test_sensitive_command_targets_honor_active_workspace_exception() -> None:
     )
 
 
+def test_relative_target_resolves_against_cwd_not_workspace() -> None:
+    """Issue #1579's exact reproduction: when both workspace and cwd are
+    given, a relative destructive target must resolve against cwd (where
+    the command actually runs), not workspace. Discarding cwd let a
+    relative target under a sensitive cwd (~/.aws) silently resolve inside
+    an unrelated workspace instead, bypassing the hard block entirely."""
+    home = Path.home()
+
+    marker = sensitive_target_in_command(
+        "rm -rf config",
+        workspace=Path("/tmp/workspace"),
+        cwd=home / ".aws",
+    )
+
+    assert marker == "~/.aws"
+
+
+def test_relative_target_under_an_in_workspace_cwd_stays_allowed() -> None:
+    """The fix must not overcorrect: a relative target resolved against an
+    ordinary cwd that happens to be inside (or equal to) the workspace, and
+    that isn't itself sensitive, must still be allowed."""
+    workspace = Path("/tmp/workspace")
+
+    assert (
+        sensitive_target_in_command(
+            "rm -rf config",
+            workspace=workspace,
+            cwd=workspace / "subdir",
+        )
+        is None
+    )
+
+
+def test_workspace_exception_still_applies_with_cwd_correctly_separated() -> None:
+    """The active-workspace exception (a workspace nested under a broad
+    sensitive prefix like /root) must keep working once cwd and workspace
+    are resolved independently, for both a relative and an absolute target
+    run from inside that workspace."""
+    workspace = Path("/root/.agentos/workspace")
+
+    assert (
+        sensitive_target_in_command(
+            "rm scratch.txt",
+            workspace=workspace,
+            cwd=workspace,
+        )
+        is None
+    )
+    assert (
+        sensitive_target_in_command(
+            f"rm {workspace / 'scratch.txt'}",
+            workspace=workspace,
+            cwd=workspace,
+        )
+        is None
+    )
+
+
 def test_windows_rooted_workspace_targets_keep_leaf_secret_blocks() -> None:
     workspace = Path("/root/.agentos/workspace")
 


### PR DESCRIPTION
Summary
sensitive_target_in_command conflated two different things: cwd (where a relative target in the command actually resolves) and workspace (the configured boundary sensitive_path_marker checks for the active-workspace exception)
Whenever workspace was non-None, cwd was discarded entirely — _extract_intents normalized relative targets against the workspace instead of the directory the command actually runs in
shell.py's real call site passes both (workspace=ctx.workspace_dir, cwd=workdir), which is exactly the case where cwd was being dropped
A relative destructive target run from a sensitive cwd (e.g. workdir set to ~/.aws) resolved under an unrelated workspace instead, matched no sensitive prefix there, and the hard block — the one thing ordinary approval cannot override — silently never fired
Resolved relative targets against cwd (falling back to Path.cwd() only when cwd isn't given), and pass workspace to sensitive_path_marker unchanged and independently, so a relative target under an ordinary in-workspace cwd stays allowed and the existing active-workspace exception (a workspace nested under a broad sensitive prefix like /root) keeps working exactly as before
Fixes #1579 

Test plan
 Verified the exact reproduction is now blocked, the reviewer's explicit "benign case that must stay allowed" (a relative target under an in-workspace cwd) is correctly allowed, and the existing active-workspace exception still works for both relative and absolute targets
 Verified the fix catches the regression: stashed the source fix and reran — the key test fails against the old code with None instead of '~/.aws'
 Added 3 tests matching the reviewer's required matrix: the exact reproduction, the benign in-workspace-relative-target case, and the workspace-exception case for both relative and absolute targets
 uv run pytest tests/test_sandbox/test_sensitive_paths.py -q — 63 passed (all 60 pre-existing tests unchanged)
 uv run pytest tests/test_sandbox tests/test_tools/test_shell_approval_policy.py tests/test_application/test_intent_cache.py -q — 263 passed
 uv run ruff check / uv run mypy clean on changed files
