### PR TITLE
fix(tools): safely handle CSV fields exceeding the default 128KB limit

### DIFF
--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -11,6 +11,7 @@ import json
 import os
 import posixpath
 import re
+import threading
 import zipfile
 from pathlib import Path
 from xml.etree import ElementTree as ET
@@ -589,12 +590,36 @@ async def read_spreadsheet(
     )
 
 
+#: csv.field_size_limit() is process-global state shared by every thread in
+#: the executor pool _read_delimited_rows runs on. Guarding the read/raise/
+#: restore excursion below with a lock stops one thread's temporarily-raised
+#: limit from leaking into another thread's concurrent parse.
+_CSV_FIELD_LIMIT_LOCK = threading.Lock()
+
+
 def _read_delimited_rows(path: Path, delimiter: str) -> list[tuple[str, dict[int, list[str]], int]]:
     try:
         text = path.read_text(encoding="utf-8-sig")
     except UnicodeDecodeError as exc:
         raise ToolError(f"Cannot read spreadsheet as UTF-8 text: {path}") from exc
-    parsed = [list(row) for row in csv.reader(io.StringIO(text), delimiter=delimiter)]
+
+    # A single field's raw length can never exceed the file's own length, so
+    # raising the limit to len(text) is enough to parse any legitimate large
+    # cell (an embedded JSON blob, log line, base64 column -- ordinary data,
+    # not a crafted edge case) while staying bounded by memory already spent
+    # reading the file. Never raise it to sys.maxsize: a malformed quote
+    # would then let the parser treat the rest of an arbitrarily large file
+    # as one field with no ceiling at all.
+    with _CSV_FIELD_LIMIT_LOCK:
+        previous_limit = csv.field_size_limit()
+        csv.field_size_limit(max(previous_limit, len(text)))
+        try:
+            parsed = [list(row) for row in csv.reader(io.StringIO(text), delimiter=delimiter)]
+        except csv.Error as exc:
+            raise ToolError(f"Cannot parse {path.name} as delimited text: {exc}") from exc
+        finally:
+            csv.field_size_limit(previous_limit)
+
     rows = dict(enumerate(parsed, start=1))
     return [(path.name, rows, len(parsed))]
 

--- a/tests/test_tools/test_csv_multiline_fields.py
+++ b/tests/test_tools/test_csv_multiline_fields.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import csv
+import threading
 from pathlib import Path
 
 import pytest
 
 from agentos.tools.builtin.filesystem import _read_delimited_rows
+from agentos.tools.types import ToolError
 
 # ── Multiline quoted field ──────────────────────────────────────────────
 
@@ -121,3 +124,86 @@ def test_unicode_line_separator_inside_field_not_treated_as_row_break(
     assert len(rows) == 2, f"Expected 2 rows for {label!r}, got {len(rows)}"
     assert rows[1] == ["a", "b"]
     assert rows[2] == [f"x{sep}y", "z"]
+
+
+# ── Issue #1580: fields exceeding Python's default 128KB field limit ────
+
+
+def test_field_exceeding_default_limit_is_parsed_not_crashed(tmp_path: Path) -> None:
+    """The issue's exact reproduction: a single cell over 131,072 characters
+    used to raise an unhandled _csv.Error instead of being parsed."""
+    csv_file = tmp_path / "large_field.csv"
+    csv_file.write_text("id,payload\n1," + "A" * 131_073, encoding="utf-8")
+
+    [(_, rows, count)] = _read_delimited_rows(csv_file, ",")
+
+    assert count == 2
+    assert rows[1] == ["id", "payload"]
+    assert rows[2] == ["1", "A" * 131_073]
+
+
+def test_field_size_limit_is_restored_after_reading(tmp_path: Path) -> None:
+    """csv.field_size_limit() is process-global; the excursion to
+    accommodate a large field must not leak into later, unrelated csv use
+    elsewhere in the process."""
+    original_limit = csv.field_size_limit()
+    csv_file = tmp_path / "large_field.csv"
+    csv_file.write_text("id,payload\n1," + "A" * (original_limit * 2), encoding="utf-8")
+
+    _read_delimited_rows(csv_file, ",")
+
+    assert csv.field_size_limit() == original_limit
+
+
+def test_field_size_limit_restored_even_when_parsing_raises(tmp_path: Path, monkeypatch) -> None:
+    """The limit must be restored on the error path too, not only on success."""
+    original_limit = csv.field_size_limit()
+    csv_file = tmp_path / "large_field.csv"
+    csv_file.write_text("id,payload\n1," + "A" * (original_limit * 2), encoding="utf-8")
+
+    class _BoomReader:
+        def __iter__(self):
+            raise csv.Error("boom")
+
+    monkeypatch.setattr(csv, "reader", lambda *a, **k: _BoomReader())
+
+    with pytest.raises(ToolError, match="Cannot parse"):
+        _read_delimited_rows(csv_file, ",")
+
+    assert csv.field_size_limit() == original_limit
+
+
+def test_concurrent_reads_do_not_race_on_the_global_field_size_limit(
+    tmp_path: Path,
+) -> None:
+    """Two large-field reads running on separate threads must not observe
+    each other's temporarily-raised limit or its restoration mid-parse."""
+    original_limit = csv.field_size_limit()
+    files = []
+    for index in range(4):
+        size = original_limit + 1000 * (index + 1)
+        path = tmp_path / f"large_{index}.csv"
+        path.write_text(f"id,payload\n{index}," + "A" * size, encoding="utf-8")
+        files.append((path, size))
+
+    results: list[BaseException | int] = [0] * len(files)
+
+    def _worker(slot: int, path: Path, size: int) -> None:
+        try:
+            [(_, rows, _)] = _read_delimited_rows(path, ",")
+            results[slot] = len(rows[2][1])
+        except BaseException as exc:  # noqa: BLE001 - surfaced to the main thread below
+            results[slot] = exc  # type: ignore[assignment]
+
+    threads = [
+        threading.Thread(target=_worker, args=(i, path, size))
+        for i, (path, size) in enumerate(files)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    for (path, size), result in zip(files, results, strict=True):
+        assert result == size, f"{path.name}: expected field length {size}, got {result!r}"
+    assert csv.field_size_limit() == original_limit


### PR DESCRIPTION
Summary
_read_delimited_rows parsed CSV/TSV text with csv.reader under Python's process-wide default 131,072-character field limit and caught only UnicodeDecodeError, so a single cell over that size — one embedded JSON blob, log line, HTML snippet, or base64 column, ordinary data rather than a crafted edge case — raised an unhandled _csv.Error that crashed the tool call instead of surfacing a ToolError
A single field's raw length can never exceed the file's own length, so raising csv.field_size_limit() to len(text) is enough to parse any legitimate large cell while staying bounded by memory the read already spent
Never raised it to sys.maxsize: a malformed quote would otherwise let the parser treat the rest of an arbitrarily large file as one field with no ceiling
The excursion is restored in a finally block so it never outlives the read, and any remaining csv.Error (a genuinely malformed file, not just an oversized field) is now caught and raised as a clear ToolError instead of escaping unhandled
csv.field_size_limit() is process-global, and _read_delimited_rows runs on the default executor's shared thread pool, so the raise/parse/restore excursion is wrapped in a lock — otherwise one thread's temporarily-raised limit (or its restore mid-parse) could leak into another thread's concurrent read
Fixes #1580 

Test plan
 Verified the tests catch the regression: stashed the source fix and reran — all 4 new tests fail against the old code, including a real multi-threaded concurrency test that reproduces the exact _csv.Error: field larger than field limit (131072) crash across concurrent reads
 Added to test_csv_multiline_fields.py: the issue's exact reproduction now parses successfully, the global limit is restored after both success and error paths, and four concurrent large-field reads on separate threads don't race on the shared global state
 uv run pytest tests/test_tools -k "csv or spreadsheet or filesystem" -q — 51 passed, 4 skipped
 uv run ruff check / uv run mypy src/agentos/tools/builtin/filesystem.py — clean
