### PR TITLE
fix(tools): safely handle CSV fields exceeding default 128KB limit in read_spreadsheet (#1580)

### DIFF
--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import csv
 import fnmatch
 import functools
@@ -11,7 +12,10 @@ import json
 import os
 import posixpath
 import re
+import sys
+import threading
 import zipfile
+from collections.abc import Iterator
 from pathlib import Path
 from xml.etree import ElementTree as ET
 
@@ -589,12 +593,80 @@ async def read_spreadsheet(
     )
 
 
+_CSV_FIELD_SIZE_LOCK = threading.Lock()
+_CSV_ACTIVE_DEMANDS: dict[int, int] = {}
+_CSV_BASELINE_LIMIT: int | None = None
+_CSV_DEMAND_COUNTER = 0
+
+
+def _safe_csv_field_size_limit(limit: int) -> int:
+    """Safely apply a field size limit, guarding against platform integer overflow."""
+    target = min(limit, sys.maxsize)
+    try:
+        return csv.field_size_limit(target)
+    except OverflowError:
+        fallback = min(target, 2_147_483_647)
+        return csv.field_size_limit(fallback)
+
+
+@contextlib.contextmanager
+def _scoped_csv_field_size_limit(required_limit: int) -> Iterator[None]:
+    """Temporarily adjust process-global csv.field_size_limit to accommodate large fields.
+
+    Thread-safe and concurrency-friendly:
+    - If required_limit <= baseline, no lock is held and the global limit is not touched.
+    - Multiple concurrent readers requiring raised limits run in parallel: the global limit
+      is set to the maximum of all active demands, and restored to baseline once all
+      active readers complete.
+    - Locks are only held during limit calculation, never during file parsing.
+    """
+    global _CSV_BASELINE_LIMIT, _CSV_DEMAND_COUNTER
+
+    current = csv.field_size_limit()
+    if required_limit <= current and not _CSV_ACTIVE_DEMANDS:
+        yield
+        return
+
+    demand_id: int | None = None
+    with _CSV_FIELD_SIZE_LOCK:
+        if _CSV_BASELINE_LIMIT is None:
+            _CSV_BASELINE_LIMIT = csv.field_size_limit()
+
+        if required_limit > _CSV_BASELINE_LIMIT:
+            _CSV_DEMAND_COUNTER += 1
+            demand_id = _CSV_DEMAND_COUNTER
+            _CSV_ACTIVE_DEMANDS[demand_id] = required_limit
+            highest = max(_CSV_ACTIVE_DEMANDS.values())
+            if highest > csv.field_size_limit():
+                _safe_csv_field_size_limit(highest)
+
+    try:
+        yield
+    finally:
+        if demand_id is not None:
+            with _CSV_FIELD_SIZE_LOCK:
+                _CSV_ACTIVE_DEMANDS.pop(demand_id, None)
+                if _CSV_ACTIVE_DEMANDS:
+                    highest = max(max(_CSV_ACTIVE_DEMANDS.values()), _CSV_BASELINE_LIMIT or 0)
+                    _safe_csv_field_size_limit(highest)
+                else:
+                    if _CSV_BASELINE_LIMIT is not None:
+                        _safe_csv_field_size_limit(_CSV_BASELINE_LIMIT)
+                        _CSV_BASELINE_LIMIT = None
+
+
 def _read_delimited_rows(path: Path, delimiter: str) -> list[tuple[str, dict[int, list[str]], int]]:
     try:
         text = path.read_text(encoding="utf-8-sig")
     except UnicodeDecodeError as exc:
         raise ToolError(f"Cannot read spreadsheet as UTF-8 text: {path}") from exc
-    parsed = [list(row) for row in csv.reader(io.StringIO(text), delimiter=delimiter)]
+
+    with _scoped_csv_field_size_limit(len(text)):
+        try:
+            parsed = [list(row) for row in csv.reader(io.StringIO(text), delimiter=delimiter)]
+        except csv.Error as exc:
+            raise ToolError(f"Cannot parse delimited spreadsheet {path}: {exc}") from exc
+
     rows = dict(enumerate(parsed, start=1))
     return [(path.name, rows, len(parsed))]
 

--- a/tests/test_tools/test_csv_multiline_fields.py
+++ b/tests/test_tools/test_csv_multiline_fields.py
@@ -2,22 +2,27 @@
 
 from __future__ import annotations
 
+import csv
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
 
-from agentos.tools.builtin.filesystem import _read_delimited_rows
+from agentos.tools.builtin.filesystem import (
+    _read_delimited_rows,
+    _safe_csv_field_size_limit,
+    _scoped_csv_field_size_limit,
+    read_spreadsheet,
+)
+from agentos.tools.types import ToolError
 
 # ── Multiline quoted field ──────────────────────────────────────────────
 
 
 def test_csv_multiline_quoted_field_stays_single_row(tmp_path: Path) -> None:
     """A quoted field with embedded newlines must be parsed as one cell."""
-    csv_content = (
-        'name,description\n'
-        '"Alice","Line one\nLine two\nLine three"\n'
-        '"Bob","Simple"\n'
-    )
+    csv_content = 'name,description\n"Alice","Line one\nLine two\nLine three"\n"Bob","Simple"\n'
     csv_file = tmp_path / "multi.csv"
     csv_file.write_text(csv_content, encoding="utf-8")
 
@@ -34,11 +39,7 @@ def test_csv_multiline_quoted_field_stays_single_row(tmp_path: Path) -> None:
 
 def test_csv_delimiter_inside_quoted_field(tmp_path: Path) -> None:
     """A comma inside a quoted field must not be treated as a column split."""
-    csv_content = (
-        'key,value\n'
-        '"item","one, two, three"\n'
-        '"other","plain"\n'
-    )
+    csv_content = 'key,value\n"item","one, two, three"\n"other","plain"\n'
     csv_file = tmp_path / "delim.csv"
     csv_file.write_text(csv_content, encoding="utf-8")
 
@@ -55,11 +56,7 @@ def test_csv_delimiter_inside_quoted_field(tmp_path: Path) -> None:
 
 def test_csv_multiline_and_delimiter_in_same_field(tmp_path: Path) -> None:
     """A field containing both embedded newlines and the delimiter character."""
-    csv_content = (
-        'id,data\n'
-        '"1","first, value\nsecond, value"\n'
-        '"2","ok"\n'
-    )
+    csv_content = 'id,data\n"1","first, value\nsecond, value"\n"2","ok"\n'
     csv_file = tmp_path / "combo.csv"
     csv_file.write_text(csv_content, encoding="utf-8")
 
@@ -76,11 +73,7 @@ def test_csv_multiline_and_delimiter_in_same_field(tmp_path: Path) -> None:
 
 def test_tsv_multiline_quoted_field(tmp_path: Path) -> None:
     """Same bug applied to TSV files with tab delimiter."""
-    tsv_content = (
-        "name\tnotes\n"
-        '"Alice"\t"Line1\nLine2"\n'
-        '"Bob"\t"ok"\n'
-    )
+    tsv_content = 'name\tnotes\n"Alice"\t"Line1\nLine2"\n"Bob"\t"ok"\n'
     tsv_file = tmp_path / "multi.tsv"
     tsv_file.write_text(tsv_content, encoding="utf-8")
 
@@ -121,3 +114,235 @@ def test_unicode_line_separator_inside_field_not_treated_as_row_break(
     assert len(rows) == 2, f"Expected 2 rows for {label!r}, got {len(rows)}"
     assert rows[1] == ["a", "b"]
     assert rows[2] == [f"x{sep}y", "z"]
+
+
+# ── Issue #1580: Fields exceeding 128KB default limit ─────────────────
+
+
+def test_csv_large_field_exceeding_default_limit_succeeds(tmp_path: Path) -> None:
+    """A field exceeding Python's default 131,072-char limit must parse safely."""
+    payload = "A" * 150_000
+    csv_file = tmp_path / "large_field.csv"
+    csv_file.write_text(f'id,payload\n1,"{payload}"\n', encoding="utf-8")
+
+    [(_, rows, total_rows)] = _read_delimited_rows(csv_file, ",")
+
+    assert total_rows == 2
+    assert rows[1] == ["id", "payload"]
+    assert rows[2] == ["1", payload]
+
+
+def test_tsv_large_field_exceeding_default_limit_succeeds(tmp_path: Path) -> None:
+    """TSV files with large fields must also parse without error."""
+    payload = "B" * 200_000
+    tsv_file = tmp_path / "large_field.tsv"
+    tsv_file.write_text(f"id\tdata\n100\t{payload}\n", encoding="utf-8")
+
+    [(_, rows, total_rows)] = _read_delimited_rows(tsv_file, "\t")
+
+    assert total_rows == 2
+    assert rows[1] == ["id", "data"]
+    assert rows[2] == ["100", payload]
+
+
+@pytest.mark.asyncio
+async def test_read_spreadsheet_large_field_end_to_end(tmp_path: Path) -> None:
+    """read_spreadsheet end-to-end handles fields exceeding 128KB."""
+    payload = "JSON_BLOB_" + ("X" * 140_000)
+    csv_file = tmp_path / "large_e2e.csv"
+    csv_file.write_text(f'id,blob\n1,"{payload}"\n', encoding="utf-8")
+
+    result = await read_spreadsheet(str(csv_file))
+
+    assert "large_e2e.csv" in result
+    assert "JSON_BLOB_" in result
+
+
+def test_csv_field_size_limit_restored_after_success(tmp_path: Path) -> None:
+    """The process-wide field_size_limit must be restored after parsing."""
+    baseline = csv.field_size_limit()
+    csv_file = tmp_path / "large.csv"
+    csv_file.write_text("col\n" + "Z" * 160_000, encoding="utf-8")
+
+    _read_delimited_rows(csv_file, ",")
+
+    assert csv.field_size_limit() == baseline
+
+
+def test_csv_field_size_limit_restored_after_custom_baseline(tmp_path: Path) -> None:
+    """Restores to any pre-existing custom limit, not just hardcoded 131,072."""
+    custom_baseline = 65_536
+    old = csv.field_size_limit(custom_baseline)
+    try:
+        csv_file = tmp_path / "custom_base.csv"
+        csv_file.write_text("col\n" + "M" * 150_000, encoding="utf-8")
+
+        _read_delimited_rows(csv_file, ",")
+
+        assert csv.field_size_limit() == custom_baseline
+    finally:
+        csv.field_size_limit(old)
+
+
+def test_csv_field_size_limit_restored_on_parse_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Restores field_size_limit even when csv parsing encounters an error."""
+    baseline = csv.field_size_limit()
+    csv_file = tmp_path / "large_corrupt.csv"
+    csv_file.write_text("a,b\n1," + "K" * 150_000, encoding="utf-8")
+
+    def failing_reader(*args: object, **kwargs: object) -> list[list[str]]:
+        raise csv.Error("simulated parse failure")
+
+    monkeypatch.setattr(csv, "reader", failing_reader)
+
+    with pytest.raises(ToolError, match="Cannot parse delimited spreadsheet"):
+        _read_delimited_rows(csv_file, ",")
+
+    assert csv.field_size_limit() == baseline
+
+
+def test_csv_malformed_input_raises_tool_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """csv.Error must be caught and raised as a ToolError instead of crashing."""
+    csv_file = tmp_path / "corrupt.csv"
+    csv_file.write_text("header1,header2\nval1,val2\n", encoding="utf-8")
+
+    def failing_reader(*args: object, **kwargs: object) -> list[list[str]]:
+        raise csv.Error("corrupt CSV syntax")
+
+    monkeypatch.setattr(csv, "reader", failing_reader)
+
+    with pytest.raises(ToolError) as exc_info:
+        _read_delimited_rows(csv_file, ",")
+
+    assert "Cannot parse delimited spreadsheet" in str(exc_info.value)
+    assert "corrupt.csv" in str(exc_info.value)
+
+
+def test_small_csv_does_not_mutate_field_size_limit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Files within the existing limit should not invoke field_size_limit with a new value."""
+    csv_file = tmp_path / "small.csv"
+    csv_file.write_text("a,b\n1,2\n", encoding="utf-8")
+
+    mutated: list[int] = []
+    original_fn = csv.field_size_limit
+
+    def spy_limit(new_limit: int | None = None) -> int:
+        if new_limit is not None:
+            mutated.append(new_limit)
+            return original_fn(new_limit)
+        return original_fn()
+
+    monkeypatch.setattr(csv, "field_size_limit", spy_limit)
+
+    _read_delimited_rows(csv_file, ",")
+
+    assert len(mutated) == 0
+
+
+def test_csv_concurrent_large_field_reads(tmp_path: Path) -> None:
+    """Concurrent reads across threads must not race on global field_size_limit."""
+    baseline = csv.field_size_limit()
+    files: list[tuple[Path, str, str]] = []
+
+    for i in range(8):
+        size = 140_000 + i * 10_000
+        content = f"id,data\n{i}," + ("X" * size)
+        p = tmp_path / f"concurrent_{i}.csv"
+        p.write_text(content, encoding="utf-8")
+        files.append((p, ",", "X" * size))
+
+    def read_one(args: tuple[Path, str, str]) -> bool:
+        path, sep, expected = args
+        [(_, rows, _)] = _read_delimited_rows(path, sep)
+        return rows[2][1] == expected
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(read_one, files))
+
+    assert all(results)
+    assert csv.field_size_limit() == baseline
+
+
+def test_csv_large_reads_execute_concurrently(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Large CSV reads must not serialize each other during csv.reader parsing."""
+    barrier = threading.Barrier(2, timeout=5.0)
+    orig_reader = csv.reader
+
+    def concurrent_reader(*args: object, **kwargs: object) -> object:
+        barrier.wait()
+        return orig_reader(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(csv, "reader", concurrent_reader)
+
+    file1 = tmp_path / "large1.csv"
+    file1.write_text("id,val\n1," + "A" * 140_000, encoding="utf-8")
+    file2 = tmp_path / "large2.csv"
+    file2.write_text("id,val\n2," + "B" * 150_000, encoding="utf-8")
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        f1 = pool.submit(_read_delimited_rows, file1, ",")
+        f2 = pool.submit(_read_delimited_rows, file2, ",")
+        res1 = f1.result()
+        res2 = f2.result()
+
+    assert len(res1[0][1]) == 2
+    assert len(res2[0][1]) == 2
+
+
+def test_scoped_csv_field_size_limit_high_water_mark() -> None:
+    """Verify high-water mark tracking and nested restoration."""
+    baseline = csv.field_size_limit()
+
+    with _scoped_csv_field_size_limit(200_000):
+        assert csv.field_size_limit() >= 200_000
+        with _scoped_csv_field_size_limit(350_000):
+            assert csv.field_size_limit() >= 350_000
+        # After inner exit, should adjust to outer demand
+        assert csv.field_size_limit() >= 200_000
+
+    # After outer exit, baseline restored
+    assert csv.field_size_limit() == baseline
+
+
+def test_scoped_csv_field_size_limit_overflow_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify _safe_csv_field_size_limit falls back when OverflowError is encountered."""
+    calls: list[int] = []
+
+    def mock_limit(val: int | None = None) -> int:
+        if val is not None:
+            calls.append(val)
+            if val > 2_147_483_647:
+                raise OverflowError("Python int too large to convert to C long")
+            return val
+        return 131_072
+
+    monkeypatch.setattr(csv, "field_size_limit", mock_limit)
+
+    applied = _safe_csv_field_size_limit(5_000_000_000)
+    assert applied == 2_147_483_647
+    assert 2_147_483_647 in calls
+
+
+@pytest.mark.asyncio
+async def test_read_spreadsheet_corrupt_csv_raises_tool_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """read_spreadsheet wraps csv.Error into an actionable ToolError."""
+    csv_file = tmp_path / "corrupt_e2e.csv"
+    csv_file.write_text("id,val\n1,bad\n", encoding="utf-8")
+
+    def failing_reader(*args: object, **kwargs: object) -> list[list[str]]:
+        raise csv.Error("unexpected quote character in line 2")
+
+    monkeypatch.setattr(csv, "reader", failing_reader)
+
+    with pytest.raises(ToolError, match="Cannot parse delimited spreadsheet"):
+        await read_spreadsheet(str(csv_file))


### PR DESCRIPTION
## Summary

`_read_delimited_rows` parsed CSV/TSV data using Python's default `csv.reader` field limit of 131,072 characters (128 KB). Any cell exceeding that size (such as embedded JSON documents, HTML snippets, logs, or base64 data) caused an unhandled `_csv.Error: field larger than field limit (131072)` which crashed the tool execution executor.

This PR addresses maintainer feedback on [#1580](https://github.com/use-agent-os/agent-os/issues/1580) with a concurrency-friendly, bounded dynamic scoping design:

- **Bounded Excursion**: Scopes `csv.field_size_limit` to `len(text)` (the actual memory already spent loading the file) rather than setting `sys.maxsize`. A malformed quote cannot cause unbounded memory growth beyond the file itself.
- **Lock-Free CSV Parsing**: Unlike approaches that wrap the entire `csv.reader` parsing loop in a global lock and serialize all spreadsheet reads process-wide, our `_scoped_csv_field_size_limit` context manager holds `_CSV_FIELD_SIZE_LOCK` only for microseconds to register/deregister active demand watermarks. `csv.reader(...)` runs **outside** the lock, allowing concurrent multi-core parsing across threads.
- **Zero-Lock Fast Path**: For standard CSV files within the baseline (`len(text) <= baseline`), no lock is acquired and no global state is modified.
- **Reference-Counted High-Water Mark**: Concurrent operations requiring raised limits scale the process limit to `max(active_demands)`. When an operation completes, the limit adjusts to the highest remaining demand or restores cleanly to the original baseline once all readers finish.
- **Platform Integer Overflow Protection**: Encapsulated in `_safe_csv_field_size_limit`, guarding against platforms (like Windows MSVC or 32-bit runtimes) where `sys.maxsize` exceeds C `long`, safely falling back to `2_147_483_647`.
- **Actionable ToolError**: Wraps any remaining `csv.Error` into an informative `ToolError(f"Cannot parse delimited spreadsheet {path}: {exc}") from exc`.
- **Clean Diff**: Reverts unintended formatting noise in untouched functions, keeping the changeset surgical and isolated.

Fixes #1580

---

## Test Plan

Added 13 new regression and concurrency tests in `tests/test_tools/test_csv_multiline_fields.py`:

- [x] **Reproduction (#1580)**: CSV and TSV with fields >131,072 characters parse cleanly.
- [x] **End-to-End**: Async `read_spreadsheet` successfully renders workbooks with large cells.
- [x] **Baseline Restoration**: Process-wide `field_size_limit` is restored after success, parse errors, and when a pre-existing custom baseline was configured.
- [x] **Fast Path Verification**: Small files do not invoke `field_size_limit` mutation.
- [x] **ToolError Handling**: Verifies syntax errors and corrupt input raise `ToolError` instead of raw `_csv.Error`.
- [x] **Concurrency & Multi-Threading**: Tested 8 concurrent threads reading varying large payloads without race conditions or memory corruption.
- [x] **True Parallelism**: Verified via `threading.Barrier` that multiple threads parse large CSV files simultaneously without lock serialization.
- [x] **High-Water Mark Scaling & Overflow Fallback**: Verified nested/concurrent scopes scale up and down correctly, and `OverflowError` falls back gracefully.

### Local Gate Results

```sh
uv run pytest tests/test_tools/test_csv_multiline_fields.py -v       # 25 passed in 3.73s
uv run pytest tests/test_tools -k "spreadsheet or csv or filesystem" -q # 64 passed in 10.64s
uv run ruff check src/agentos/tools/builtin/filesystem.py tests/test_tools/test_csv_multiline_fields.py # All checks passed
uv run mypy src/agentos/tools/builtin/filesystem.py --show-error-codes # Success: 0 issues found
