### PR TITLE
fix(tools): delegate apply_patch memory source matching to filesystem helper

### DIFF
--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -71,9 +71,10 @@ def _memory_source_root() -> Path | None:
     return Path(ctx.memory_source_dir).expanduser().resolve()
 
 
-def _memory_roots() -> tuple[Path, ...]:
+def _memory_roots(default_root: Path | None = None) -> tuple[Path, ...]:
     roots: list[Path] = []
-    for root in (_workspace_root(), _memory_source_root()):
+    base = default_root if default_root is not None else _workspace_root()
+    for root in (base, _memory_source_root()):
         if root is None or root in roots:
             continue
         roots.append(root)
@@ -114,17 +115,17 @@ def _resolve_base(path: str | None) -> Path:
     return root if root is not None else Path.cwd()
 
 
-def _memory_source_rel_path(path: Path) -> str | None:
-    resolved = path.resolve(strict=False)
-    for root in _memory_roots():
+def _memory_source_rel_path(path: Path | str, root: Path | None = None) -> str | None:
+    resolved = Path(path).resolve(strict=False)
+    for mem_root in _memory_roots(root):
         try:
-            rel = resolved.relative_to(root)
+            rel = resolved.relative_to(mem_root)
         except ValueError:
             continue
 
         # USER.md is a curated store in its own right -- CuratedMemoryStore
         # loads, sanitizes, and injects it alongside MEMORY.md. Editing it
-        # through a filesystem tool must refresh the frozen snapshot the same
+        # through a filesystem or patch tool must refresh the frozen snapshot the same
         # way, or the change stays invisible to the model until the session
         # ends. (It is also a bootstrap file, so it notifies both paths.)
         if rel.parts in {("MEMORY.md",), ("memory.md",), ("USER.md",)}:

--- a/src/agentos/tools/builtin/patch.py
+++ b/src/agentos/tools/builtin/patch.py
@@ -170,17 +170,11 @@ def _validate_path(path: str, root: Path | None = None) -> Path:
 
 
 def _memory_source_rel_path(path: str, root: Path) -> str | None:
-    resolved = _validate_path(path, root)
-    try:
-        rel = resolved.relative_to(root)
-    except ValueError:
-        return None
+    from agentos.tools.builtin import filesystem
 
-    if rel.parts == ("MEMORY.md",):
-        return "MEMORY.md"
-    if len(rel.parts) >= 2 and rel.parts[0] == "memory" and rel.suffix == ".md":
-        return rel.as_posix()
-    return None
+    resolved = _validate_path(path, root)
+    return filesystem._memory_source_rel_path(resolved, root=root)
+
 
 
 def _bootstrap_source_rel_path(path: str, root: Path) -> str | None:

--- a/tests/test_tools/test_bootstrap_write_notifications.py
+++ b/tests/test_tools/test_bootstrap_write_notifications.py
@@ -77,4 +77,41 @@ async def test_patch_notifies_bootstrap_and_memory_sources(tmp_path) -> None:
         current_tool_context.reset(token)
 
     assert bootstrap_calls == [("main", "USER.md")]
-    assert memory_calls == [("main", "memory/2026-05-01.md")]
+    assert ("main", "USER.md") in memory_calls
+    assert ("main", "memory/2026-05-01.md") in memory_calls
+
+
+@pytest.mark.asyncio
+async def test_patch_notifies_memory_md_and_custom_memory_dir(tmp_path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    memory_dir = tmp_path / "custom_memory"
+    memory_dir.mkdir()
+
+    (workspace_dir / "memory.md").write_text("# Old Memory\n", encoding="utf-8")
+    (memory_dir / "USER.md").write_text("Name:\n", encoding="utf-8")
+
+    memory_calls: list[tuple[str, str]] = []
+    token = current_tool_context.set(
+        ToolContext(
+            agent_id="main",
+            workspace_dir=str(workspace_dir),
+            memory_source_dir=str(memory_dir),
+            on_memory_source_write=lambda agent_id, path: memory_calls.append((agent_id, path)),
+        )
+    )
+    apply_patch = _original_async(patch_tool.apply_patch)
+    try:
+        await apply_patch(
+            """*** Begin Patch
+*** Update File: memory.md
+@@@ -1,1 +1,1 @@@
+-# Old Memory
++# New Memory
+*** End Patch"""
+        )
+    finally:
+        current_tool_context.reset(token)
+
+    assert ("main", "memory.md") in memory_calls
+


### PR DESCRIPTION
Closes #1625

### Problem
`patch._memory_source_rel_path` only checked for exact match `rel.parts == ("MEMORY.md",)` against the patch root. Consequently, patching `USER.md`, `memory.md`, or files in a custom `memory_source_dir` never triggered `on_memory_source_write`, leaving memory snapshots stale while `filesystem.write_file` / `filesystem.edit_file` on the same files properly triggered invalidation.

### Solution
- Following maintainer review on #1625, refactored `patch._memory_source_rel_path` to delegate directly to `filesystem._memory_source_rel_path` rather than re-implementing matching logic.
- Updated `filesystem._memory_source_rel_path` and `_memory_roots` to accept an optional `root` parameter.
- Updated tests in `test_bootstrap_write_notifications.py` to verify `apply_patch` notifies `on_memory_source_write` for `USER.md` and `memory.md`.


