### PR TITLE
fix(cli): exit non-zero when cron run reports failure

### DIFF
--- a/src/agentos/cli/cron_cmd.py
+++ b/src/agentos/cli/cron_cmd.py
@@ -11,8 +11,8 @@ from typing import Annotated, Any
 import typer
 from rich.table import Table
 
-from agentos.cli.gateway_rpc import confirm_or_exit, run_gateway_sync
-from agentos.cli.output import print_json
+from agentos.cli.gateway_rpc import confirm_or_exit, rpc_error_exit_code, run_gateway_sync
+from agentos.cli.output import emit_error, print_json
 from agentos.cli.ui import ACCENT_HEADER, console
 
 cron_app = typer.Typer(help="Inspect and manage scheduled AgentOS runs.")
@@ -1147,6 +1147,22 @@ def cron_run(
         return await client.call("cron.run", {"id": job_id})
 
     payload = run_gateway_sync(_run, json_output=json_output)
+    if isinstance(payload, dict) and payload.get("success") is False:
+        # cron.run returns an honest failure payload over a successful RPC;
+        # map that to a non-zero CLI exit so scripts/agents don't treat a
+        # missing (or otherwise refused) job as success. See #1684.
+        status = str(payload.get("status") or "")
+        message = str(
+            payload.get("error") or payload.get("reason") or "Cron run failed"
+        )
+        code = "NOT_FOUND" if status == "not_found" else "CRON_RUN_FAILED"
+        emit_error(
+            message,
+            json_output=json_output,
+            code=code,
+            details=payload,
+        )
+        raise typer.Exit(rpc_error_exit_code(code) if code == "NOT_FOUND" else 1)
     _emit_success(payload, json_output=json_output, title="Cron run result")
 
 

--- a/tests/test_cli/test_cron_run_exit.py
+++ b/tests/test_cli/test_cron_run_exit.py
@@ -1,0 +1,110 @@
+"""CLI cron run must exit non-zero when the gateway reports a failed run.
+
+Regression for https://github.com/use-agent-os/agent-os/issues/1684 —
+``cron.run`` returns an honest ``success: false`` payload over a successful
+RPC; the CLI used to print it via ``_emit_success`` and still exit 0.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from typer.testing import CliRunner
+
+from agentos.cli.main import app
+
+runner = CliRunner()
+
+
+class _RunPayloadGateway:
+    calls: list[tuple[str, dict[str, Any]]] = []
+    payload: dict[str, Any] = {}
+
+    def __init__(self) -> None:
+        pass
+
+    async def connect(self, url: str, *, token=None) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+    async def call(self, method: str, params: dict | None = None) -> Any:
+        type(self).calls.append((method, params or {}))
+        return type(self).payload
+
+
+def _install(monkeypatch, payload: dict[str, Any]) -> type[_RunPayloadGateway]:
+    _RunPayloadGateway.calls = []
+    _RunPayloadGateway.payload = payload
+    monkeypatch.setattr("agentos.cli.gateway_client.GatewayClient", _RunPayloadGateway)
+    return _RunPayloadGateway
+
+
+def test_cron_run_missing_job_exits_nonzero(monkeypatch) -> None:
+    fake = _install(
+        monkeypatch,
+        {
+            "success": False,
+            "status": "not_found",
+            "reason": "not_found",
+            "error": "Cron job not found",
+        },
+    )
+
+    result = runner.invoke(
+        app,
+        ["cron", "run", "missing-job-xyz", "--yes", "--json"],
+    )
+
+    assert result.exit_code == 2
+    err = json.loads(result.stderr)
+    assert err["error"]["code"] == "NOT_FOUND"
+    assert "Cron job not found" in err["error"]["message"]
+    assert ("cron.run", {"id": "missing-job-xyz"}) in fake.calls
+
+
+def test_cron_run_other_failure_exits_nonzero(monkeypatch) -> None:
+    _install(
+        monkeypatch,
+        {
+            "success": False,
+            "status": "disabled",
+            "reason": "disabled",
+            "error": "Cron job is disabled",
+        },
+    )
+
+    result = runner.invoke(
+        app,
+        ["cron", "run", "job-disabled", "--yes", "--json"],
+    )
+
+    assert result.exit_code == 1
+    err = json.loads(result.stderr)
+    assert err["error"]["code"] == "CRON_RUN_FAILED"
+
+
+def test_cron_run_accepted_success_still_exits_zero(monkeypatch) -> None:
+    fake = _install(
+        monkeypatch,
+        {
+            "success": True,
+            "status": "accepted",
+            "reply": "done",
+            "error": None,
+            "duration_ms": 12,
+        },
+    )
+
+    result = runner.invoke(
+        app,
+        ["cron", "run", "job-1", "--yes", "--json"],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["success"] is True
+    assert payload["status"] == "accepted"
+    assert ("cron.run", {"id": "job-1"}) in fake.calls


### PR DESCRIPTION
## Summary
- **The bug:** `agentos cron run <missing-id> --yes --json` returns an honest `{"success": false, "status": "not_found", ...}` but still **exits 0**.
- **Repro on main:** `cron status missing --json` → exit 2; `cron run missing --yes --json` → exit 0 + failure payload.
- **The fix:** After a successful `cron.run` RPC, if the wire payload has `success: false`, emit an error and exit non-zero (`not_found` → `NOT_FOUND` / exit 2; other refusals → exit 1). Leave the RPC contract unchanged so Control UI consumers keep the structured result.

Fixes #1684

Distinct from #1598 / #1599 (`cron remove` inventing `removed: true`).

## Test plan
- [x] `tests/test_cli/test_cron_run_exit.py` — missing → exit 2; disabled → exit 1; accepted success → exit 0
- [ ] CI green on this PR