### PR TITLE
fix(memory): handle lines=0 correctly in memory_get (Closes #1697)

### DIFF
--- a/src/agentos/tools/builtin/memory_tools.py
+++ b/src/agentos/tools/builtin/memory_tools.py
@@ -1173,8 +1173,8 @@ def create_memory_tools(
         content = file_path.read_text(encoding="utf-8", errors="replace")
         if from_line is not None or lines is not None:
             all_lines = content.splitlines()
-            start = max(0, (from_line - 1)) if from_line else 0
-            end = (start + lines) if lines else len(all_lines)
+            start = max(0, (from_line - 1)) if from_line is not None else 0
+            end = (start + max(0, lines)) if lines is not None else len(all_lines)
             content = "\n".join(all_lines[start:end])
         full_len = len(content)
         if full_len > 8000:

--- a/tests/test_memory_curated_tool.py
+++ b/tests/test_memory_curated_tool.py
@@ -200,3 +200,32 @@ async def test_memory_tool_picks_up_budget_change_without_restart(tmp_path):
 
     now_fits = json.loads(await tools["memory"](action="add", content="y" * 50))
     assert now_fits["success"] is True
+
+
+async def test_memory_get_line_slicing(memory_tools_fixture, tmp_path):
+    tools = memory_tools_fixture
+    (tmp_path / "MEMORY.md").write_text("line1\nline2\nline3\nline4\nline5", encoding="utf-8")
+
+    # lines=0 returns empty string
+    res_zero = await tools["memory_get"](path="MEMORY.md", lines=0)
+    assert res_zero == ""
+
+    # from_line=2, lines=0 returns empty string
+    res_from_zero = await tools["memory_get"](path="MEMORY.md", from_line=2, lines=0)
+    assert res_from_zero == ""
+
+    # from_line=2, lines=2 returns 2 lines starting at line 2
+    res_slice = await tools["memory_get"](path="MEMORY.md", from_line=2, lines=2)
+    assert res_slice == "line2\nline3"
+
+    # from_line=3, lines=None returns line 3 to EOF
+    res_from = await tools["memory_get"](path="MEMORY.md", from_line=3)
+    assert res_from == "line3\nline4\nline5"
+
+    # lines=2 without from_line returns first 2 lines
+    res_head = await tools["memory_get"](path="MEMORY.md", lines=2)
+    assert res_head == "line1\nline2"
+
+    # negative lines clamps to 0 (empty string)
+    res_neg = await tools["memory_get"](path="MEMORY.md", lines=-1)
+    assert res_neg == ""


### PR DESCRIPTION
Closes #1697

### Summary
In `src/agentos/tools/builtin/memory_tools.py`, `memory_get` calculated the end index of the line slice via `end = (start + lines) if lines else len(all_lines)`.
Because `bool(0)` is `False` in Python, passing `lines=0` evaluated `if lines` to `False`, resetting `end` to `len(all_lines)` and returning the entire remainder of the file instead of 0 lines (`""`).

### Changes
1. **Source**: In `memory_get`, update the line slicing to check `lines is not None` and clamp non-positive line counts with `max(0, lines)`:
   ```python
   start = max(0, (from_line - 1)) if from_line is not None else 0
   end = (start + max(0, lines)) if lines is not None else len(all_lines)

2.Tests: Added test_memory_get_line_slicing in tests/test_memory_curated_tool.py verifying lines=0, from_line with lines=0, pagination slicing, and negative line counts.

Verification
pytest tests/test_memory_curated_tool.py -v: 16 passed
ruff check src/agentos/tools/builtin/memory_tools.py tests/test_memory_curated_tool.py: passed
ruff format --check src/agentos/tools/builtin/memory_tools.py tests/test_memory_curated_tool.py: passed
mypy src/agentos/tools/builtin/memory_tools.py: no issues found

