### PR TITLE
fix(filesystem): prioritize exact sheet name over numeric index in _select_spreadsheet_sheets

### DIFF
--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -316,8 +316,7 @@ def _workspace_strict_read_block(
             "workspace": str(roots[0]),
             "allowed_roots": [str(root) for root in roots],
             "message": (
-                f"{tool_name} blocked: {candidate} is outside active read roots "
-                f"({root_labels})."
+                f"{tool_name} blocked: {candidate} is outside active read roots ({root_labels})."
             ),
             "retryable": False,
         }
@@ -743,15 +742,18 @@ def _select_spreadsheet_sheets(
     if requested is None or requested == "":
         return sheets
 
-    if isinstance(requested, int) or (isinstance(requested, str) and requested.isdigit()):
-        index = int(requested) - 1
-        if 0 <= index < len(sheets):
-            return [sheets[index]]
-
     requested_name = str(requested)
     for name, rows, total_rows in sheets:
         if name == requested_name:
             return [(name, rows, total_rows)]
+
+    if (isinstance(requested, int) and not isinstance(requested, bool)) or (
+        isinstance(requested, str) and requested.isdigit()
+    ):
+        index = int(requested) - 1
+        if 0 <= index < len(sheets):
+            return [sheets[index]]
+
     for name, rows, total_rows in sheets:
         if name.lower() == requested_name.lower():
             return [(name, rows, total_rows)]
@@ -795,8 +797,7 @@ def _format_spreadsheet(
             parts.append(f"{idx}\t" + "\t".join(rows.get(idx, [])))
         if end < total_rows:
             parts.append(
-                f"(Showing rows {offset}-{end} of {total_rows}. "
-                f"Use offset={end + 1} to continue.)"
+                f"(Showing rows {offset}-{end} of {total_rows}. Use offset={end + 1} to continue.)"
             )
     return "\n".join(parts)
 
@@ -886,9 +887,7 @@ def _locate_edit(original: str, old_text: str, new_text: str, *, path: str) -> F
     argv_factory=lambda a: ("fs.edit", str(a.get("path", ""))),
     record_payload=False,
 )
-async def edit_file(
-    path: str, old_text: str, new_text: str, approval_id: str | None = None
-) -> str:
+async def edit_file(path: str, old_text: str, new_text: str, approval_id: str | None = None) -> str:
     p = _resolve_path(path)
     approval = await _gate_out_of_workspace_write("edit_file", p, path, approval_id)
     if approval is not None:

--- a/tests/test_tools/test_filesystem_read_workspace.py
+++ b/tests/test_tools/test_filesystem_read_workspace.py
@@ -435,3 +435,45 @@ async def test_write_file_records_workspace_write_on_both_create_and_overwrite(
         current_tool_context.reset(token)
 
 
+def test_select_spreadsheet_sheets_exact_numeric_name_precedence() -> None:
+    sheets: list[tuple[str, dict[int, list[str]], int]] = [
+        ("Overview", {1: ["A", "B"]}, 1),
+        ("1", {1: ["X", "Y"]}, 1),
+        ("Summary", {1: ["1", "2"]}, 1),
+    ]
+    # "1" should match the sheet named "1", not index 0 ("Overview")
+    result = fs._select_spreadsheet_sheets(sheets, "1")
+    assert len(result) == 1
+    assert result[0][0] == "1"
+
+
+def test_select_spreadsheet_sheets_numeric_index_fallback() -> None:
+    sheets: list[tuple[str, dict[int, list[str]], int]] = [
+        ("Overview", {1: ["A", "B"]}, 1),
+        ("Details", {1: ["X", "Y"]}, 1),
+    ]
+    # No sheet named "1", so "1" falls back to 1-based index 1 -> sheets[0]
+    result_str = fs._select_spreadsheet_sheets(sheets, "1")
+    assert result_str[0][0] == "Overview"
+
+    # Integer 2 selects 1-based index 2 -> sheets[1]
+    result_int = fs._select_spreadsheet_sheets(sheets, 2)
+    assert result_int[0][0] == "Details"
+
+
+def test_select_spreadsheet_sheets_case_insensitive_and_missing() -> None:
+    sheets: list[tuple[str, dict[int, list[str]], int]] = [
+        ("Overview", {1: ["A", "B"]}, 1),
+        ("Data Sheet", {1: ["X", "Y"]}, 1),
+    ]
+    # Case-insensitive match
+    result = fs._select_spreadsheet_sheets(sheets, "overview")
+    assert result[0][0] == "Overview"
+
+    # None or empty string returns all sheets
+    assert fs._select_spreadsheet_sheets(sheets, None) == sheets
+    assert fs._select_spreadsheet_sheets(sheets, "") == sheets
+
+    # Unknown sheet raises ToolError
+    with pytest.raises(ToolError, match="Sheet not found: Missing"):
+        fs._select_spreadsheet_sheets(sheets, "Missing")


### PR DESCRIPTION
Closes #1696

### Summary
In `src/agentos/tools/builtin/filesystem.py`, `_select_spreadsheet_sheets` tested `isinstance(requested, int) or (isinstance(requested, str) and requested.isdigit())` before checking exact sheet names. When a workbook contained sheets like `[("Overview", [...]), ("1", [...])]`, calling `read_spreadsheet` with `sheet="1"` evaluated `"1".isdigit() == True` and returned `sheets[0]` (`"Overview"`), shadowing the sheet named `"1"`.

### Changes
1. **Source**: In `_select_spreadsheet_sheets`, moved exact sheet name matching (`name == requested_name`) before the numeric 1-based index fallback.
2. **Tests**: Added regression unit tests in `tests/test_tools/test_filesystem_read_workspace.py` covering exact numeric sheet names, 1-based index fallbacks (string and int), case insensitivity, and missing sheet error handling.

### Verification
- `pytest tests/test_tools/test_filesystem_read_workspace.py -k test_select_spreadsheet_sheets -v`: 3 passed
- `ruff check src/agentos/tools/builtin/filesystem.py tests/test_tools/test_filesystem_read_workspace.py`: passed
- `mypy src/agentos/tools/builtin/filesystem.py`: no issues found
