### PR TITLE
fix(shell): remove warnlist commands from Windows default denylist

### DIFF
--- a/src/agentos/tools/builtin/shell_policy.py
+++ b/src/agentos/tools/builtin/shell_policy.py
@@ -24,13 +24,10 @@ DEFAULT_DENYLIST: list[str] = [
 ]
 
 DEFAULT_DENYLIST_WIN: list[str] = [
-    r"\bdel\b",
-    r"\brmdir\b",
     r"\bFormat-Volume\b",
     r"\bStop-Computer\b",
     r"\bRestart-Computer\b",
     r"\bClear-Disk\b",
-    r"\bgit push --force\b",
 ]
 
 # Patterns that require two-step confirmation (warn, not block)
@@ -48,7 +45,6 @@ DEFAULT_WARNLIST_WIN: list[str] = [
     r"\bdel\b",
     r"\brmdir\b",
     r"\bRemove-Item\b",
-    r"\bClear-Disk\b",
     r"\bgit push --force\b",
 ]
 
@@ -70,10 +66,7 @@ def _legacy_denylist_if_set() -> list[str]:
 
         structlog.get_logger(__name__).warning(
             "shell_policy.legacy_deny_env_detected",
-            message=(
-                "AGENTOS_SHELL_DENYLIST is deprecated; use "
-                "AGENTOS_SAFE_BIN_DENY"
-            ),
+            message=("AGENTOS_SHELL_DENYLIST is deprecated; use AGENTOS_SAFE_BIN_DENY"),
         )
         _LEGACY_ENV_WARNED = True
     return _resolve_env_list(legacy)

--- a/tests/test_tools/test_shell_policy_windows.py
+++ b/tests/test_tools/test_shell_policy_windows.py
@@ -19,12 +19,31 @@ def _windows_policy_env(monkeypatch: pytest.MonkeyPatch):
 @pytest.mark.parametrize(
     "command",
     [
-        r"del C:\Windows\System32\config\SAM",
-        r"DEL C:\Windows\System32\config\SAM",
-        r"dEl C:\Windows\System32\config\SAM",
+        r"del C:\tmp\file.txt",
+        r"DEL C:\tmp\file.txt",
+        r"dEl C:\tmp\file.txt",
+        r"rmdir C:\tmp\stale",
+        r"git push --force origin main",
     ],
 )
-def test_windows_del_variants_are_denied(command: str) -> None:
+def test_windows_warnlist_variants_require_approval(command: str) -> None:
+    result = shell_policy.SafeBinPolicy.from_env().check(command)
+
+    assert result.allowed is True
+    assert result.needs_approval is True
+    assert "requires approval" in result.reason
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "Format-Volume -DriveLetter D",
+        "Clear-Disk -Number 1",
+        "Stop-Computer",
+        "Restart-Computer",
+    ],
+)
+def test_windows_denylist_commands_are_blocked(command: str) -> None:
     result = shell_policy.SafeBinPolicy.from_env().check(command)
 
     assert result.allowed is False
@@ -54,7 +73,7 @@ def test_windows_deny_env_overrides_platform_default(monkeypatch: pytest.MonkeyP
     policy = shell_policy.SafeBinPolicy.from_env()
 
     custom = policy.check("custom-block")
-    default_del = policy.check(r"del C:\Windows\System32\config\SAM")
+    default_del = policy.check(r"del C:\tmp\file.txt")
     assert custom.allowed is False
     assert default_del.allowed is True
     assert default_del.needs_approval is True
@@ -76,7 +95,7 @@ def test_windows_empty_warn_env_preserves_default_denylist(
 ) -> None:
     monkeypatch.setenv("AGENTOS_SAFE_BIN_WARN", "")
 
-    result = shell_policy.SafeBinPolicy.from_env().check(r"del C:\Windows\System32\config\SAM")
+    result = shell_policy.SafeBinPolicy.from_env().check("Format-Volume -DriveLetter D")
 
     assert result.allowed is False
     assert result.needs_approval is False
@@ -90,9 +109,7 @@ def test_legacy_shell_denylist_warns_once(monkeypatch: pytest.MonkeyPatch) -> No
         second = shell_policy.SafeBinPolicy.from_env()
 
     warnings = [
-        event
-        for event in captured
-        if event["event"] == "shell_policy.legacy_deny_env_detected"
+        event for event in captured if event["event"] == "shell_policy.legacy_deny_env_detected"
     ]
     assert len(warnings) == 1
     assert first.check("legacy-block").allowed is False


### PR DESCRIPTION
Closes #1695

### Summary
In `src/agentos/tools/builtin/shell_policy.py`, `del`, `rmdir`, and `git push --force` were duplicated in both `DEFAULT_DENYLIST_WIN` and `DEFAULT_WARNLIST_WIN`. Because `SafeBinPolicy.check()` checks the denylist before the warnlist, `del`, `rmdir`, and `git push --force` on Windows were immediately hard-blocked with `allowed=False, needs_approval=False`, making their warnlist entries dead code and permanently barring users/agents on Windows from running `del` or `rmdir` even with approval.

### Changes
1. **Source**: In `DEFAULT_DENYLIST_WIN`, removed `del`, `rmdir`, and `git push --force`. In `DEFAULT_WARNLIST_WIN`, removed duplicate `Clear-Disk` (retaining it in the denylist).
2. **Tests**: Updated `tests/test_tools/test_shell_policy_windows.py` asserting `del`, `rmdir`, and `git push --force` enter the approval flow (`allowed=True, needs_approval=True`), and catastrophic commands (`Format-Volume`, `Clear-Disk`, `Stop-Computer`, `Restart-Computer`) are hard-blocked (`allowed=False, needs_approval=False`).

### Verification
- `pytest tests/test_tools/test_shell_policy_windows.py -v`: 16 passed
- `ruff check`: passed
- `mypy src/agentos/tools/builtin/shell_policy.py`: passed
