### PR TITLE
fix(filesystem): resolve relative paths against CWD when workspace root is None

### DIFF
--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -104,7 +104,7 @@ def _resolve_path(path: str) -> Path:
         return alias
     if root is not None and not raw.is_absolute():
         return (root / raw).resolve(strict=False)
-    return raw.resolve(strict=False) if raw.is_absolute() else raw
+    return raw.resolve(strict=False)
 
 
 def _resolve_base(path: str | None) -> Path:
@@ -316,8 +316,7 @@ def _workspace_strict_read_block(
             "workspace": str(roots[0]),
             "allowed_roots": [str(root) for root in roots],
             "message": (
-                f"{tool_name} blocked: {candidate} is outside active read roots "
-                f"({root_labels})."
+                f"{tool_name} blocked: {candidate} is outside active read roots ({root_labels})."
             ),
             "retryable": False,
         }
@@ -795,8 +794,7 @@ def _format_spreadsheet(
             parts.append(f"{idx}\t" + "\t".join(rows.get(idx, [])))
         if end < total_rows:
             parts.append(
-                f"(Showing rows {offset}-{end} of {total_rows}. "
-                f"Use offset={end + 1} to continue.)"
+                f"(Showing rows {offset}-{end} of {total_rows}. Use offset={end + 1} to continue.)"
             )
     return "\n".join(parts)
 
@@ -886,9 +884,7 @@ def _locate_edit(original: str, old_text: str, new_text: str, *, path: str) -> F
     argv_factory=lambda a: ("fs.edit", str(a.get("path", ""))),
     record_payload=False,
 )
-async def edit_file(
-    path: str, old_text: str, new_text: str, approval_id: str | None = None
-) -> str:
+async def edit_file(path: str, old_text: str, new_text: str, approval_id: str | None = None) -> str:
     p = _resolve_path(path)
     approval = await _gate_out_of_workspace_write("edit_file", p, path, approval_id)
     if approval is not None:

--- a/tests/test_tools/test_filesystem_read_workspace.py
+++ b/tests/test_tools/test_filesystem_read_workspace.py
@@ -435,3 +435,33 @@ async def test_write_file_records_workspace_write_on_both_create_and_overwrite(
         current_tool_context.reset(token)
 
 
+def test_resolve_path_without_workspace_resolves_against_cwd() -> None:
+    token = current_tool_context.set(None)
+    try:
+        assert fs._workspace_root() is None
+        p = fs._resolve_path("some_relative_file.txt")
+        assert p.is_absolute()
+        assert p == (Path.cwd() / "some_relative_file.txt").resolve()
+    finally:
+        current_tool_context.reset(token)
+
+
+def test_resolve_path_traversal_blocks_sensitive_paths_when_workspace_is_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_sub = Path.home() / ".agentos" / "test_workspace_none"
+    home_sub.mkdir(parents=True, exist_ok=True)
+    monkeypatch.chdir(home_sub)
+
+    token = current_tool_context.set(None)
+    try:
+        assert fs._workspace_root() is None
+        p = fs._resolve_path("../../.ssh/config")
+        assert p.is_absolute()
+        block = fs._sensitive_access_block("read_file", p, "../../.ssh/config")
+        assert block is not None
+        assert block["status"] == "blocked"
+        assert block["reason"] == "sensitive_path"
+        assert block["sensitive_path"] == "~/.ssh"
+    finally:
+        current_tool_context.reset(token)


### PR DESCRIPTION
Closes #1694

### Summary
In `src/agentos/tools/builtin/filesystem.py`, `_resolve_path(path)` executed `return raw.resolve(strict=False) if raw.is_absolute() else raw` when `_workspace_root()` was `None`. Relative paths like `../../.ssh/config` remained unrooted relative `Path` objects (`is_absolute() == False`). Downstream sensitive path detection checks bypassed directory-level sensitive markers because the path was neither absolute nor prefixed with `~`.

### Changes
1. **Source**: In `_resolve_path`, ensure relative paths resolve against CWD via `raw.resolve(strict=False)` when no workspace is configured.
2. **Tests**: Added regression tests in `tests/test_tools/test_filesystem_read_workspace.py` verifying that relative paths resolve to absolute paths when workspace is `None` and that directory traversal to `../../.ssh/config` is blocked.

### Verification
- `pytest tests/test_tools/test_filesystem_read_workspace.py -k test_resolve_path -v`: 3 passed
- `ruff check`: passed
- `mypy src/agentos/tools/builtin/filesystem.py`: passed

