### PR TITLE
fix(patch): enforce workspace lockdown in apply_patch (Closes #1693)

### DIFF
--- a/src/agentos/tools/builtin/patch.py
+++ b/src/agentos/tools/builtin/patch.py
@@ -293,6 +293,8 @@ def _patch_approval_plan(
                     None,
                 )
 
+        filesystem._gate_workspace_lockdown_write("apply_patch", resolved, op.path)
+
         deny_match = match_workspace_write_deny(
             resolved,
             original_path=op.path,

--- a/tests/test_tools/test_apply_patch_gates.py
+++ b/tests/test_tools/test_apply_patch_gates.py
@@ -479,6 +479,181 @@ async def test_apply_patch_unattended_bypass_skips_outside_workspace_approval(
 
 
 @pytest.mark.asyncio
+async def test_apply_patch_workspace_lockdown_blocks_outside_workspace_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("old\n", encoding="utf-8")
+    monkeypatch.setattr(patch_tool, "_default_patch_root", lambda: tmp_path.resolve())
+    token = current_tool_context.set(
+        ToolContext(
+            workspace_dir=str(workspace),
+            workspace_lockdown=True,
+        )
+    )
+    apply_patch = _original_async(patch_tool.apply_patch)
+    try:
+        with pytest.raises(ToolError, match="workspace lockdown"):
+            await apply_patch(
+                """*** Begin Patch
+*** Update File: outside.txt
+@@@ -1,1 +1,1 @@@
+-old
++new
+*** End Patch"""
+            )
+    finally:
+        current_tool_context.reset(token)
+
+    assert outside.read_text(encoding="utf-8") == "old\n"
+    assert get_approval_queue().list_pending("exec") == []
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_workspace_lockdown_blocks_outside_workspace_even_with_bypass(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("old\n", encoding="utf-8")
+    monkeypatch.setattr(patch_tool, "_default_patch_root", lambda: tmp_path.resolve())
+    token = current_tool_context.set(
+        ToolContext(
+            workspace_dir=str(workspace),
+            workspace_lockdown=True,
+            elevated="bypass",
+            interaction_mode=InteractionMode.UNATTENDED,
+        )
+    )
+    apply_patch = _original_async(patch_tool.apply_patch)
+    try:
+        with pytest.raises(ToolError, match="workspace lockdown"):
+            await apply_patch(
+                """*** Begin Patch
+*** Update File: outside.txt
+@@@ -1,1 +1,1 @@@
+-old
++new
+*** End Patch"""
+            )
+    finally:
+        current_tool_context.reset(token)
+
+    assert outside.read_text(encoding="utf-8") == "old\n"
+    assert get_approval_queue().list_pending("exec") == []
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_workspace_lockdown_blocks_outside_workspace_even_with_full_elevation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("old\n", encoding="utf-8")
+    monkeypatch.setattr(patch_tool, "_default_patch_root", lambda: tmp_path.resolve())
+    token = current_tool_context.set(
+        ToolContext(
+            workspace_dir=str(workspace),
+            workspace_lockdown=True,
+            elevated="full",
+        )
+    )
+    apply_patch = _original_async(patch_tool.apply_patch)
+    try:
+        with pytest.raises(ToolError, match="workspace lockdown"):
+            await apply_patch(
+                """*** Begin Patch
+*** Update File: outside.txt
+@@@ -1,1 +1,1 @@@
+-old
++new
+*** End Patch"""
+            )
+    finally:
+        current_tool_context.reset(token)
+
+    assert outside.read_text(encoding="utf-8") == "old\n"
+    assert get_approval_queue().list_pending("exec") == []
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_workspace_lockdown_allows_configured_scratch_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    scratch = tmp_path / "scratch"
+    workspace.mkdir()
+    scratch.mkdir()
+    target = scratch / "scratch_target.txt"
+    target.write_text("old\n", encoding="utf-8")
+    monkeypatch.setattr(patch_tool, "_default_patch_root", lambda: tmp_path.resolve())
+    token = current_tool_context.set(
+        ToolContext(
+            workspace_dir=str(workspace),
+            scratch_dir=str(scratch),
+            workspace_lockdown=True,
+            elevated="bypass",
+            interaction_mode=InteractionMode.UNATTENDED,
+        )
+    )
+    apply_patch = _original_async(patch_tool.apply_patch)
+    try:
+        result = await apply_patch(
+            """*** Begin Patch
+*** Update File: scratch/scratch_target.txt
+@@@ -1,1 +1,1 @@@
+-old
++new
+*** End Patch"""
+        )
+    finally:
+        current_tool_context.reset(token)
+
+    assert result == "Applied patch: 1 file(s) modified"
+    assert target.read_text(encoding="utf-8") == "new\n"
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_workspace_lockdown_blocks_delete_outside_workspace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("old\n", encoding="utf-8")
+    monkeypatch.setattr(patch_tool, "_default_patch_root", lambda: tmp_path.resolve())
+    token = current_tool_context.set(
+        ToolContext(
+            workspace_dir=str(workspace),
+            workspace_lockdown=True,
+            elevated="full",
+        )
+    )
+    apply_patch = _original_async(patch_tool.apply_patch)
+    try:
+        with pytest.raises(ToolError, match="workspace lockdown"):
+            await apply_patch(
+                """*** Begin Patch
+*** Delete File: outside.txt
+*** End Patch"""
+            )
+    finally:
+        current_tool_context.reset(token)
+
+    assert outside.exists()
+    assert outside.read_text(encoding="utf-8") == "old\n"
+
+
+@pytest.mark.asyncio
 async def test_apply_patch_add_file_refuses_existing_file(tmp_path: Path) -> None:
     target = tmp_path / "existing.txt"
     target.write_text("old\n", encoding="utf-8")


### PR DESCRIPTION
Closes #1693

### Problem
When `workspace_lockdown` is enabled, write operations must be strictly restricted to the allowed roots (`workspace_dir` and `scratch_dir`). Other filesystem modification tools (`write_file`, `edit_file`) enforce this via `_gate_workspace_lockdown_write()`.

In `src/agentos/tools/builtin/patch.py`, `_patch_approval_plan` checked `sensitive_path_marker` and `match_workspace_write_deny`, but omitted the workspace lockdown check. As a result:
- In unattended or elevated bypass modes (`elevated="bypass"` or `elevated="full"`), `apply_patch` bypassed outside-workspace approval queues and performed out-of-workspace file writes/modifications/deletions.
- In interactive mode, `apply_patch` requested an outside-workspace approval instead of being rejected outright by the lockdown policy.

### Solution
- Call `filesystem._gate_workspace_lockdown_write("apply_patch", resolved, op.path)` for every patch operation during `_patch_approval_plan`.
- If `workspace_lockdown` is active and any targeted path resolves outside the allowed roots, `apply_patch` now raises `ToolError` immediately before any file modification or approval queuing occurs.

### Testing
- Added regression unit tests to `tests/test_tools/test_apply_patch_gates.py`:
  - `test_apply_patch_workspace_lockdown_blocks_outside_workspace_write`: Verifies standard mode raises `ToolError` and leaves the approval queue empty.
  - `test_apply_patch_workspace_lockdown_blocks_outside_workspace_even_with_bypass`: Verifies unattended bypass does not evade lockdown.
  - `test_apply_patch_workspace_lockdown_blocks_outside_workspace_even_with_full_elevation`: Verifies full elevation does not evade lockdown.
  - `test_apply_patch_workspace_lockdown_allows_configured_scratch_dir`: Verifies writes inside configured `scratch_dir` remain permitted under lockdown.
  - `test_apply_patch_workspace_lockdown_blocks_delete_outside_workspace`: Verifies file deletions outside workspace roots are also blocked.
- Verification checks executed:
  - `pytest tests/test_tools/test_apply_patch_gates.py -q` (37 passed)
  - `ruff check src/agentos/tools/builtin/patch.py tests/test_tools/test_apply_patch_gates.py` (clean)
  - `ruff format --check src/agentos/tools/builtin/patch.py tests/test_tools/test_apply_patch_gates.py` (clean)
  - `mypy src/agentos/tools/builtin/patch.py --show-error-codes` (clean)

