### PR TITLE
fix(sandbox): resolve relative command targets against cwd in sensitive_target_in_command (Closes #1692)

### DIFF
--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -23,9 +23,12 @@ from agentos.redact import CREDENTIAL_FILE_NAMES
 # the entire sensitive-path block layer. ONLY for trusted single-operator
 # environments / E2E testing where sandbox=false + sensitive_path checks
 # block valid agent commands like ``ls /etc/...``. Default off.
-_DISABLED = os.environ.get(
-    "AGENTOS_SENSITIVE_PATHS_DISABLED", ""
-).lower() in ("1", "true", "yes", "on")
+_DISABLED = os.environ.get("AGENTOS_SENSITIVE_PATHS_DISABLED", "").lower() in (
+    "1",
+    "true",
+    "yes",
+    "on",
+)
 
 
 # Host credential FILES, taken from the redaction layer's list so the two
@@ -207,9 +210,7 @@ def _path_contains(path: str, root: str) -> bool:
         return False
     normalized_path = path.rstrip("/")
     normalized_root = root.rstrip("/")
-    return normalized_path == normalized_root or normalized_path.startswith(
-        normalized_root + "/"
-    )
+    return normalized_path == normalized_root or normalized_path.startswith(normalized_root + "/")
 
 
 def _segment_sweeps_its_parent(segment: str) -> bool:
@@ -296,9 +297,7 @@ def _workspace_contains(path: str, workspace: str | Path | None) -> bool:
     candidate_paths = _comparison_path_candidates(str(path))
     workspace_paths = _comparison_path_candidates(str(workspace))
     return any(
-        _path_contains(candidate, root)
-        for candidate in candidate_paths
-        for root in workspace_paths
+        _path_contains(candidate, root) for candidate in candidate_paths for root in workspace_paths
     )
 
 
@@ -316,9 +315,7 @@ def _workspace_nested_under_marker(workspace: str | Path | None, marker: str) ->
         pass
     for workspace_text in _comparison_path_candidates(str(workspace)):
         for marker_text in _comparison_path_candidates(marker):
-            if workspace_text != marker_text and _path_contains(
-                workspace_text, marker_text
-            ):
+            if workspace_text != marker_text and _path_contains(workspace_text, marker_text):
                 return True
     return False
 
@@ -366,9 +363,7 @@ def sensitive_path_marker(
     marker = is_sensitive_path(text)
     if marker is None:
         return None
-    if _workspace_contains(text, workspace) and _workspace_nested_under_marker(
-        workspace, marker
-    ):
+    if _workspace_contains(text, workspace) and _workspace_nested_under_marker(workspace, marker):
         leaf_marker = _sensitive_leaf_marker(text)
         return leaf_marker
     return marker
@@ -390,8 +385,7 @@ def _scan_text_for_marker(
         (match.group(0), match.start()) for match in _ABSOLUTE_OR_TILDE_PATH_RE.finditer(text)
     )
     with_context.extend(
-        (match.group("path"), match.start("path"))
-        for match in _DOTENV_LITERAL_RE.finditer(text)
+        (match.group("path"), match.start("path")) for match in _DOTENV_LITERAL_RE.finditer(text)
     )
 
     for raw in candidates:
@@ -493,11 +487,12 @@ def sensitive_target_in_command(
         return None
     from agentos.sandbox.intent_cache import _extract_intents
 
-    effective_workspace = workspace
-    if effective_workspace is None:
-        effective_workspace = cwd if cwd is not None else Path.cwd()
+    base_dir = cwd if cwd is not None else (workspace if workspace is not None else Path.cwd())
+    effective_workspace = (
+        workspace if workspace is not None else (cwd if cwd is not None else Path.cwd())
+    )
 
-    for _kind, target in _extract_intents(command, base_dir=effective_workspace):
+    for _kind, target in _extract_intents(command, base_dir=base_dir):
         if _is_root_target(target):
             return _ROOT_TARGET_MARKER
         marker = sensitive_path_marker(target, workspace=effective_workspace)

--- a/tests/test_sandbox/test_sensitive_paths.py
+++ b/tests/test_sandbox/test_sensitive_paths.py
@@ -53,13 +53,10 @@ def test_active_workspace_exception_keeps_leaf_secret_blocks() -> None:
         "/.env*",
     }
     assert sensitive_path_marker(str(workspace / "id_rsa"), workspace=workspace) == "/id_rsa"
-    assert (
-        sensitive_path_in_text(
-            f"cat {workspace / '.env.local'}",
-            workspace=workspace,
-        )
-        in {"/.env.local", "/.env*"}
-    )
+    assert sensitive_path_in_text(
+        f"cat {workspace / '.env.local'}",
+        workspace=workspace,
+    ) in {"/.env.local", "/.env*"}
 
 
 def test_sensitive_command_targets_honor_active_workspace_exception() -> None:
@@ -72,13 +69,10 @@ def test_sensitive_command_targets_honor_active_workspace_exception() -> None:
         )
         is None
     )
-    assert (
-        sensitive_target_in_command(
-            f"rm {workspace / '.env'}",
-            workspace=workspace,
-        )
-        in {"/.env", "/.env*"}
-    )
+    assert sensitive_target_in_command(
+        f"rm {workspace / '.env'}",
+        workspace=workspace,
+    ) in {"/.env", "/.env*"}
 
 
 def test_windows_rooted_workspace_targets_keep_leaf_secret_blocks() -> None:
@@ -91,23 +85,17 @@ def test_windows_rooted_workspace_targets_keep_leaf_secret_blocks() -> None:
         )
         is None
     )
-    assert (
-        sensitive_target_in_command(
-            r"rm \root\.agentos\workspace\.env",
-            workspace=workspace,
-        )
-        in {"/.env", "/.env*"}
-    )
+    assert sensitive_target_in_command(
+        r"rm \root\.agentos\workspace\.env",
+        workspace=workspace,
+    ) in {"/.env", "/.env*"}
 
 
 def test_posix_sensitive_paths_stay_blocked_on_windows_runners() -> None:
     workspace = Path("/root/.agentos/workspace")
 
     assert sensitive_path_in_text("cat /dev/sda 2>/dev/null") == "/dev"
-    assert (
-        sensitive_path_in_text("cat /root/.ssh/id_rsa", workspace=workspace)
-        == "~/.ssh"
-    )
+    assert sensitive_path_in_text("cat /root/.ssh/id_rsa", workspace=workspace) == "~/.ssh"
 
 
 def test_every_rm_in_a_compound_command_is_checked() -> None:
@@ -494,3 +482,25 @@ def test_env_var_and_tilde_spellings_report_the_same_marker(
 
     assert tilde == f"~/{name}"
     assert expanded == tilde
+
+
+def test_sensitive_target_in_command_resolves_relative_to_cwd_when_workspace_set(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    ssh_dir = Path.home() / ".ssh"
+
+    # Command executed in ~/.ssh targeting relative file 'config' must be flagged as ~/.ssh
+    assert sensitive_target_in_command("rm config", cwd=ssh_dir, workspace=workspace) == "~/.ssh"
+
+    # Command executed in workspace targeting benign file must not be flagged
+    assert sensitive_target_in_command("rm config.json", cwd=workspace, workspace=workspace) is None
+
+    # Command executed in subdirectory of workspace targeting benign file must not be flagged
+    subdir = workspace / "sub"
+    subdir.mkdir()
+    assert sensitive_target_in_command("rm notes.txt", cwd=subdir, workspace=workspace) is None
+
+    # Command executed without workspace resolves relative to cwd
+    assert sensitive_target_in_command("rm config", cwd=ssh_dir, workspace=None) == "~/.ssh"


### PR DESCRIPTION
Closes #1692


### Problem
In `src/agentos/sandbox/sensitive_paths.py`, `sensitive_target_in_command()` previously defined:
```python
effective_workspace = workspace
if effective_workspace is None:
    effective_workspace = cwd if cwd is not None else Path.cwd()
for _kind, target in _extract_intents(command, base_dir=effective_workspace):
    ...
When workspace was passed (such as during shell tool execution in shell.py:1402), effective_workspace defaulted to workspace. This caused _extract_intents to resolve relative command targets (e.g., rm config) against workspace rather than against cwd where the command is executing.

If a command was executed within a sensitive directory (such as cwd=~/.ssh), relative destructive commands targeting sensitive files resolved against workspace, causing sensitive_target_in_command() to return None and allowing unapproved destructive operations on sensitive host files.

Solution
Decoupled base_dir (which determines the execution directory used by _extract_intents to resolve relative paths) from effective_workspace (used by sensitive_path_marker to handle active workspace containment exceptions).
base_dir now resolves to cwd whenever cwd is provided (falling back to workspace or Path.cwd() if None).
Commands executing in a sensitive working directory targeting relative paths now resolve against cwd and trigger the appropriate sensitive path marker ("~/.ssh", etc.).
Testing
Added regression test test_sensitive_target_in_command_resolves_relative_to_cwd_when_workspace_set in tests/test_sandbox/test_sensitive_paths.py:
Verified rm config executed with cwd=~/.ssh and an explicit non-sensitive workspace returns "~/.ssh".
Verified benign relative files in workspace or workspace subdirectories return None.
Verified commands executed with workspace=None still resolve relative targets against cwd.
Verified quality gates:
pytest tests/test_sandbox/test_sensitive_paths.py -k test_sensitive_target_in_command_resolves_relative_to_cwd_when_workspace_set -v (Passed)
ruff check src/agentos/sandbox/sensitive_paths.py tests/test_sandbox/test_sensitive_paths.py (Clean)
ruff format --check src/agentos/sandbox/sensitive_paths.py tests/test_sandbox/test_sensitive_paths.py (Clean)
mypy src/agentos/sandbox/sensitive_paths.py --show-error-codes (Clean)