### PR TITLE
fix(patch): preserve blank lines in Add File blocks during patch parsing (Closes #1691)

### DIFF
--- a/src/agentos/tools/builtin/patch.py
+++ b/src/agentos/tools/builtin/patch.py
@@ -87,6 +87,8 @@ def _parse_patch(patch_text: str) -> list[PatchOp]:
                 raw = body[i]
                 if raw.startswith("+"):
                     content_lines.append(raw[1:])
+                elif raw == "":
+                    content_lines.append("")
                 i += 1
             ops.append(AddFile(path=path, content="\n".join(content_lines)))
 

--- a/tests/test_tools/test_apply_patch_gates.py
+++ b/tests/test_tools/test_apply_patch_gates.py
@@ -574,3 +574,45 @@ def test_parse_hunk_header_rejects_malformed_input(header: str) -> None:
 
     with pytest.raises(ValueError, match="Invalid hunk header"):
         _parse_hunk_header(header)
+
+
+def test_parse_patch_preserves_blank_lines_in_add_file() -> None:
+    from agentos.tools.builtin.patch import AddFile, _parse_patch
+
+    patch_text = """*** Begin Patch
+*** Add File: sample.py
++def foo():
++    pass
+
++def bar():
++    pass
+*** End Patch"""
+
+    ops = _parse_patch(patch_text)
+    assert len(ops) == 1
+    assert isinstance(ops[0], AddFile)
+    assert ops[0].content == "def foo():\n    pass\n\ndef bar():\n    pass"
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_add_file_preserves_blank_lines(tmp_path: Path) -> None:
+    token = current_tool_context.set(ToolContext(workspace_dir=str(tmp_path)))
+    apply_patch = _original_async(patch_tool.apply_patch)
+    try:
+        result = await apply_patch(
+            """*** Begin Patch
+*** Add File: sample.py
++def foo():
++    pass
+
++def bar():
++    pass
+*** End Patch"""
+        )
+    finally:
+        current_tool_context.reset(token)
+
+    assert result == "Applied patch: 1 file(s) added"
+    target = tmp_path / "sample.py"
+    assert target.exists()
+    assert target.read_text(encoding="utf-8") == "def foo():\n    pass\n\ndef bar():\n    pass"


### PR DESCRIPTION
Closes #1691

### Problem
In `src/agentos/tools/builtin/patch.py`, `_parse_patch` parsed `*** Add File:` blocks by checking `if raw.startswith("+"): content_lines.append(raw[1:])`.
Diff generators, text editors, and LLMs often output blank lines without a leading `+` (or strip trailing whitespace on empty lines), leaving `raw == ""`. Because `raw.startswith("+")` evaluated to `False`, blank lines between functions, classes, or paragraphs were silently skipped, resulting in stripped empty lines from newly added files.

### Solution
- Added `elif raw == "": content_lines.append("")` inside the `*** Add File:` line reading loop in `_parse_patch()`.
- Empty lines are now properly retained in the resulting `AddFile.content`.

### Testing
- Added regression tests in `tests/test_tools/test_apply_patch_gates.py`:
  - `test_parse_patch_preserves_blank_lines_in_add_file`: Verifies `_parse_patch` parses an `*** Add File:` block with blank lines without dropping them.
  - `test_apply_patch_add_file_preserves_blank_lines`: Verifies end-to-end `apply_patch` creating a file with blank lines and asserting the written content matches.
- Verification checks:
  - `pytest tests/test_tools/test_apply_patch_gates.py -q` (34 passed)
  - `ruff check src/agentos/tools/builtin/patch.py tests/test_tools/test_apply_patch_gates.py` (Clean)
  - `ruff format --check src/agentos/tools/builtin/patch.py tests/test_tools/test_apply_patch_gates.py` (Clean)
  - `mypy src/agentos/tools/builtin/patch.py --show-error-codes` (Clean)

