### PR TITLE
fix(senior-unilp-manager): reject bare value-taking flags instead of silently coercing to 1/True

### DIFF
--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/lp_read.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/lp_read.py
@@ -47,6 +47,7 @@ from unilp.fmt import (  # noqa: E402
     fmt_usd,
     heading,
     json_safe,
+    opt_str,
     parse_args,
     render_kv,
     render_table,
@@ -1034,10 +1035,10 @@ def resolve_owner(args: dict) -> str:
     the address, and the key never enters a variable here — see
     ``chains.resolve_signer_address`` for why that stays incapable of signing.
     """
-    given = args.get("owner")
+    given = opt_str(args, "owner")
     if given:
-        return str(given)
-    signer_env = args.get("signer-env") or ENV_SIGNER
+        return given
+    signer_env = opt_str(args, "signer-env") or ENV_SIGNER
     try:
         return resolve_signer_address(signer_env)
     except RuntimeError as exc:

--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/lp_write.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/lp_write.py
@@ -49,6 +49,9 @@ from unilp.fmt import (  # noqa: E402
     die,
     fmt_units,
     heading,
+    opt_float,
+    opt_int,
+    opt_str,
     parse_amount,
     parse_args,
     render_kv,
@@ -230,10 +233,11 @@ class MandateAuthorization:
 
 def resolve_signer(args: dict) -> dict:
     """Either a real key (from the environment) or a plan-only address."""
-    if args.get("from"):
-        return {"address": checksum_address(args["from"]), "privateKey": None,
+    from_addr = opt_str(args, "from")
+    if from_addr:
+        return {"address": checksum_address(from_addr), "privateKey": None,
                 "simulateOnly": True}
-    signer_env = args.get("signer-env") or ENV_SIGNER
+    signer_env = opt_str(args, "signer-env") or ENV_SIGNER
     private_key = resolve_private_key(signer_env)
     account = account_from_private_key(private_key)
     # Only the derived address is ever surfaced; the key itself is never logged.
@@ -525,11 +529,11 @@ def _send(client, chain: dict, args: dict, signer: dict, to: str, data: str,
     ``on_sent`` is passed straight through to :func:`send_transaction` so an unattended
     caller can persist the hash and nonce before the broadcast leaves the process.
     """
-    max_fee_cap = args.get("max-fee-per-gas")
+    max_fee_cap = opt_str(args, "max-fee-per-gas")
     tx = prepare_transaction(
         client, chain, signer["address"], to, data, value,
-        gas_multiplier=float(args.get("gas-multiplier") or DEFAULT_GAS_MULTIPLIER),
-        max_fee_cap=int(str(max_fee_cap).replace("_", "")) if max_fee_cap else None,
+        gas_multiplier=opt_float(args, "gas-multiplier", DEFAULT_GAS_MULTIPLIER, minimum=1.0),
+        max_fee_cap=int(max_fee_cap.replace("_", "")) if max_fee_cap else None,
     )
     prefix = f"  {label} " if label else "\n  "
     tx_hash = send_transaction(client, chain, tx, signer["privateKey"],
@@ -554,7 +558,7 @@ def encode_call(plan: dict, deadline: int) -> str:
 
 def deadline_offset(args: dict) -> int:
     """Seconds from now, not the absolute deadline. PLAN_HASH binds this; see plan_hash."""
-    return int(args.get("deadline-secs") or DEFAULT_DEADLINE_SECS)
+    return opt_int(args, "deadline-secs", DEFAULT_DEADLINE_SECS, minimum=60)
 
 
 def with_slippage_up(amount: int, bps: int) -> int:
@@ -595,7 +599,7 @@ def cmd_approve(client, chain: dict, args: dict, signer: dict) -> None:
     raw_amount = args.get("amount")
     amount = (parse_amount(str(raw_amount), info["decimals"])
               if raw_amount and raw_amount != "max" else MAX_UINT160)
-    expiration_days = int(args.get("expiration-days") or 30)
+    expiration_days = opt_int(args, "expiration-days", 30, minimum=1)
     now_secs = int(client.get_block()["timestamp"], 16)
     expiration = now_secs + expiration_days * 86400
 
@@ -869,7 +873,7 @@ def cmd_mint(client, chain: dict, args: dict, signer: dict, *,
     # slippage. Doing it the other way round produces MaximumAmountExceeded reverts.
     required = get_amounts_for_liquidity(pool["sqrtPriceX96"], sqrt_lower, sqrt_upper,
                                          liquidity, True)
-    bps = int(args.get("slippage-bps") or DEFAULT_SLIPPAGE_BPS)
+    bps = opt_int(args, "slippage-bps", DEFAULT_SLIPPAGE_BPS, minimum=0, maximum=9_999)
     amount0_max = 0 if required["amount0"] == 0 else with_slippage_up(required["amount0"], bps)
     amount1_max = 0 if required["amount1"] == 0 else with_slippage_up(required["amount1"], bps)
 
@@ -877,7 +881,7 @@ def cmd_mint(client, chain: dict, args: dict, signer: dict, *,
     plan = build_mint_plan(pool_key, tick_lower, tick_upper, liquidity,
                            amount0_max, amount1_max, recipient)
 
-    max_drift = int(args.get("max-tick-drift") or pool_key["tickSpacing"])
+    max_drift = opt_int(args, "max-tick-drift", pool_key["tickSpacing"], minimum=1)
     now_secs = int(client.get_block()["timestamp"], 16)
     allowances = check_allowances(client, chain, signer["address"],
                                   [pool_key["currency0"], pool_key["currency1"]])
@@ -977,7 +981,7 @@ def cmd_increase(client, chain: dict, args: dict, signer: dict) -> None:
 
     required = get_amounts_for_liquidity(pool["sqrtPriceX96"], sqrt_lower, sqrt_upper,
                                          liquidity, True)
-    bps = int(args.get("slippage-bps") or DEFAULT_SLIPPAGE_BPS)
+    bps = opt_int(args, "slippage-bps", DEFAULT_SLIPPAGE_BPS, minimum=0, maximum=9_999)
     amount0_max = 0 if required["amount0"] == 0 else with_slippage_up(required["amount0"], bps)
     amount1_max = 0 if required["amount1"] == 0 else with_slippage_up(required["amount1"], bps)
 
@@ -1054,7 +1058,7 @@ def cmd_decrease(client, chain: dict, args: dict, signer: dict) -> None:
         pool["sqrtPriceX96"], get_sqrt_ratio_at_tick(pos["tickLower"]),
         get_sqrt_ratio_at_tick(pos["tickUpper"]), liquidity,
     )
-    bps = int(args.get("slippage-bps") or DEFAULT_SLIPPAGE_BPS)
+    bps = opt_int(args, "slippage-bps", DEFAULT_SLIPPAGE_BPS, minimum=0, maximum=9_999)
     amount0_min = with_slippage_down(expected["amount0"], bps)
     amount1_min = with_slippage_down(expected["amount1"], bps)
 
@@ -1148,7 +1152,7 @@ def cmd_burn(client, chain: dict, args: dict, signer: dict, *,
         pool["sqrtPriceX96"], get_sqrt_ratio_at_tick(pos["tickLower"]),
         get_sqrt_ratio_at_tick(pos["tickUpper"]), pos["liquidity"],
     )
-    bps = int(args.get("slippage-bps") or DEFAULT_SLIPPAGE_BPS)
+    bps = opt_int(args, "slippage-bps", DEFAULT_SLIPPAGE_BPS, minimum=0, maximum=9_999)
     amount0_min = with_slippage_down(expected["amount0"], bps)
     amount1_min = with_slippage_down(expected["amount1"], bps)
 
@@ -1195,7 +1199,7 @@ def cmd_address(args: dict) -> None:
     want the address itself — to check which wallet is configured, or to hand to another
     tool. The key is never printed.
     """
-    signer_env = args.get("signer-env") or ENV_SIGNER
+    signer_env = opt_str(args, "signer-env") or ENV_SIGNER
     address = resolve_signer_address(signer_env)
     if args.get("json"):
         print(json.dumps({"address": address, "signerEnv": signer_env}, indent=2))
@@ -1240,7 +1244,7 @@ def main() -> None:
         raise RuntimeError(f'unknown command "{command}"\n{USAGE}')
 
     chain = resolve_chain(args.get("chain"))
-    client = RpcClient(chain, args.get("rpc"))
+    client = RpcClient(chain, opt_str(args, "rpc"))
     handler(client, chain, args, resolve_signer(args))
 
 

--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/ratchet.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/ratchet.py
@@ -39,6 +39,8 @@ from unilp.fmt import (  # noqa: E402
     die,
     fmt_units,
     heading,
+    opt_int,
+    opt_str,
     parse_args,
     render_kv,
     require_arg,
@@ -209,7 +211,7 @@ def tick_summary_line(outcome: dict) -> str:
 
 
 def _client(chain: dict, args: dict) -> RpcClient:
-    return RpcClient(chain, args.get("rpc"))
+    return RpcClient(chain, opt_str(args, "rpc"))
 
 
 def _now() -> int:
@@ -335,11 +337,12 @@ def build_mandate(client, chain: dict, args: dict, signer: dict) -> dict:
     return {
         "immutable": immutable,
         "bounds": {
-            "maxSlippageBps": int(args.get("slippage-bps") or lp_write.DEFAULT_SLIPPAGE_BPS),
+            "maxSlippageBps": opt_int(args, "slippage-bps", lp_write.DEFAULT_SLIPPAGE_BPS,
+                                      minimum=0, maximum=9_999),
             "maxDeadlineSecs": lp_write.deadline_offset(args),
-            "maxTickDrift": int(args.get("max-tick-drift") or pool_key["tickSpacing"]),
+            "maxTickDrift": opt_int(args, "max-tick-drift", pool_key["tickSpacing"], minimum=1),
             "allowHooked": bool(args.get("allow-hooked")),
-            "maxAttempts": int(args.get("max-attempts") or DEFAULT_MAX_ATTEMPTS),
+            "maxAttempts": opt_int(args, "max-attempts", DEFAULT_MAX_ATTEMPTS, minimum=1),
             "maxPrincipalRawPerFire": (
                 str(lp_write.parse_amount(max_per_fire, principal_info["decimals"]))
                 if max_per_fire else None

--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/selftest.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/selftest.py
@@ -154,6 +154,24 @@ class Results:
         print(f"  --   skipped ({reason})")
 
 
+def _raises(r: Results, label: str, fn, *, contains: str = "") -> None:
+    """Assert ``fn()`` raises, and (optionally) that the message names the field.
+
+    Mirrors ``poolsfun/selftest.py``'s ``raises()`` helper. Checking the message,
+    not just that *something* raised, is what catches a regression that swaps in
+    a different, opaque exception which happens to also be a ``ValueError`` —
+    ``int(str(True))``'s ``invalid literal for int() with base 10: 'True'`` is
+    exactly that: a raise with no field name in it, the failure mode this guards.
+    """
+    try:
+        fn()
+    except Exception as exc:  # noqa: BLE001 — asserting the failure itself
+        ok = not contains or contains.lower() in str(exc).lower()
+        r.check(label, ok, True)
+        return
+    r.check(label, "no exception", "raise")
+
+
 # ---------------------------------------------------------------------------
 # Tier 0 — primitives
 # ---------------------------------------------------------------------------
@@ -690,6 +708,9 @@ def tier4(g: dict, r: Results) -> None:
         fmt_band,
         fmt_units,
         fmt_usd,
+        opt_float,
+        opt_int,
+        opt_str,
         parse_args,
         render_kv,
         render_table,
@@ -730,10 +751,45 @@ def tier4(g: dict, r: Results) -> None:
     r.check("parseArgs --k=v", args["mode"], "ticks")
     r.check("parseArgs trailing value", args["ranges"], "10")
 
+    # A bare, value-taking ``--flag`` (no value, or immediately followed by
+    # another ``--flag``) parses to the boolean True — correct for a switch like
+    # --json above, and exactly the sentinel that must never reach int()/float()
+    # unguarded: ``int(True) == 1`` silently replaces the caller's real default
+    # (e.g. a 100bps slippage floor) with 1, and nothing about that looks like a
+    # crash. opt_str/opt_int/opt_float are the one place this is caught.
+    r.check("optInt: absent falls back to default", opt_int({}, "x", 42), 42)
+    r.check("optInt: parses a numeric string", opt_int({"x": "7"}, "x", 42), 7)
+    r.check("optFloat: absent falls back to default", opt_float({}, "x", 1.3), 1.3)
+    r.check("optStr: absent is None", opt_str({}, "x"), None)
+    r.check("optStr: trims whitespace", opt_str({"x": "  v  "}, "x"), "v")
+    for flag in ("slippage-bps", "deadline-secs", "max-tick-drift", "max-attempts",
+                 "expiration-days"):
+        _raises(r, f"optInt: bare --{flag} is rejected, not coerced to 1",
+                lambda f=flag: opt_int({f: True}, f, 100), contains="needs a value")
+    _raises(r, "optFloat: bare --gas-multiplier is rejected, not coerced to 1.0",
+            lambda: opt_float({"gas-multiplier": True}, "gas-multiplier", 1.3),
+            contains="needs a value")
+    _raises(r, "optStr: bare --signer-env is rejected, not coerced to True",
+            lambda: opt_str({"signer-env": True}, "signer-env"), contains="needs a value")
+    _raises(r, "optInt: non-numeric value is rejected",
+            lambda: opt_int({"slippage-bps": "lots"}, "slippage-bps", 100),
+            contains="whole number")
+    # Bounds mirror the call sites in lp_write.py/ratchet.py exactly, so a bound
+    # tightened or loosened at the call site shows up here as a broken test
+    # rather than only at broadcast time.
+    _raises(r, "optInt: slippage-bps >= 100% is rejected",
+            lambda: opt_int({"slippage-bps": "20000"}, "slippage-bps", 100,
+                             minimum=0, maximum=9_999), contains="at most 9999")
+    _raises(r, "optInt: negative slippage-bps is rejected",
+            lambda: opt_int({"slippage-bps": "-1"}, "slippage-bps", 100,
+                             minimum=0, maximum=9_999), contains="at least 0")
+    _raises(r, "optInt: deadline-secs below the 60s floor is rejected",
+            lambda: opt_int({"deadline-secs": "10"}, "deadline-secs", 1200,
+                             minimum=60), contains="at least 60")
+
 
 # ---------------------------------------------------------------------------
 # Tier 5 — planning ergonomics
-# ---------------------------------------------------------------------------
 
 def tier5(g: dict, r: Results) -> None:
     """The parts that decide whether a caller reaches a mint or goes in circles.
@@ -860,6 +916,12 @@ def tier5(g: dict, r: Results) -> None:
         os.environ.pop("UNIV4_LP_PRIVATE_KEY")
         r.check("an explicit --owner never touches the key",
                 lp_read.resolve_owner({"owner": "0x" + "cd" * 20}), "0x" + "cd" * 20)
+        # A bare `--owner` (no value) used to silently resolve to the *string*
+        # "True" — a 20-char literal that fails 30+ lines downstream inside
+        # checksum_address with "not a 20-byte address: 'True'", not here where
+        # the actual mistake was made.
+        _raises(r, "a bare --owner is rejected here, not miles downstream",
+                lambda: lp_read.resolve_owner({"owner": True}), contains="needs a value")
     finally:
         os.environ.clear()
         os.environ.update(was_env)

--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/fmt.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/fmt.py
@@ -50,6 +50,59 @@ def require_arg(args: dict, name: str, hint: str = "") -> Any:
     return value
 
 
+# ``parse_args`` turns a bare ``--flag`` into the boolean ``True``. That sentinel
+# is right for switches and wrong for everything else: passed on unnoticed it
+# becomes ``int(True) == 1``, or crashes with a bare ``AttributeError`` deep in a
+# helper. These three coercers are the single place that distinction is made, so
+# a value-taking flag can never silently mean "1".
+
+
+def opt_str(args: dict, name: str) -> str | None:
+    """A flag's string value, or None when absent. Bare ``--flag`` is an error."""
+    value = args.get(name)
+    if value is None:
+        return None
+    if value is True:
+        raise ValueError(f"--{name} needs a value")
+    text = str(value).strip()
+    return text or None
+
+
+def opt_int(args: dict, name: str, default: int, *,
+            minimum: int | None = None, maximum: int | None = None) -> int:
+    """A flag's integer value with range checking, or ``default`` when absent."""
+    value = args.get(name)
+    if value is None:
+        return default
+    if value is True:
+        raise ValueError(f"--{name} needs a value")
+    try:
+        number = int(str(value).strip())
+    except ValueError:
+        raise ValueError(f"--{name} must be a whole number, got {value!r}") from None
+    if minimum is not None and number < minimum:
+        raise ValueError(f"--{name} must be at least {minimum}, got {number}")
+    if maximum is not None and number > maximum:
+        raise ValueError(f"--{name} must be at most {maximum}, got {number}")
+    return number
+
+
+def opt_float(args: dict, name: str, default: float, *,
+              minimum: float | None = None) -> float:
+    value = args.get(name)
+    if value is None:
+        return default
+    if value is True:
+        raise ValueError(f"--{name} needs a value")
+    try:
+        number = float(str(value).strip())
+    except ValueError:
+        raise ValueError(f"--{name} must be a number, got {value!r}") from None
+    if minimum is not None and number < minimum:
+        raise ValueError(f"--{name} must be at least {minimum}, got {number}")
+    return number
+
+
 # ---------------------------------------------------------------------------
 # Formatting
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Linked issue
Fixes #1705

## Summary
`unilp/fmt.py`'s `parse_args()` turns a bare `--flag` (no value, or
immediately followed by another `--flag`) into the boolean `True` — correct
for a real switch, wrong for anything else. Every optional value-taking flag
in `lp_write.py`, `lp_read.py`, and `ratchet.py` read its value with either
`args.get(name) or DEFAULT` or a bare `args.get(name)` passed straight into a
helper, with no guard against that sentinel. `True or DEFAULT` evaluates to
`True` (Python `or` returns the first truthy operand), so `int(True)`
silently becomes `1` — never the real default, never an error.

Traced and empirically reproduced 20 affected call sites across the three
scripts, not just the original 11 I found (`slippage-bps` ×5, `max-tick-drift`
×2, `deadline-secs`, `expiration-days`, `gas-multiplier`, `max-attempts`):

- 11 sites silently substitute `1` for the real default (`--slippage-bps`,
  `--max-tick-drift`, `--deadline-secs`, `--expiration-days`,
  `--gas-multiplier`, `--max-attempts`).
- 8 sites crash with a low-level error naming no field (`--from`,
  `--signer-env` ×3, `--max-fee-per-gas`, `--rpc` ×3) — e.g.
  `TypeError: str expected, not bool` inside `os.environ.get`, or
  `AttributeError: 'bool' object has no attribute 'strip'` inside URL
  validation. Confirmed empirically for each, not assumed from reading.
- 1 site silently resolves to the literal string `"True"` (`--owner` in
  `lp_read.py`), deferring the failure ~30 lines downstream into
  `checksum_address`'s "not a 20-byte address" error.

I traced every `slippage-bps`/`max-tick-drift` use to confirm direction: both
compute protective bounds (max-in for mint/increase, min-out for
decrease/burn), so this bug always tightens the bound rather than loosening
it — it fails toward reverts and confusing errors, not toward fund loss.
Still a real, previously-undetected correctness bug affecting a script that
broadcasts real transactions.

This is not hypothetical or newly-invented: the sibling skill
`poolsdotfun-token-launcher` — which vendors this exact `fmt.py` convention
verbatim (its own PR #299 description: "vendors the stdlib crypto/RPC layer
from senior-unilp-manager... Copied verbatim where possible to stay
diffable") — was already patched for precisely this bug class. Its
`poolsfun/fmt.py` adds `opt_str`/`opt_int`/`opt_float` with a comment stating
the exact hazard this PR fixes. `senior-unilp-manager`'s own `fmt.py` never
received the same fix. `lp_read.py`'s `main()` even hand-rolls a narrower,
one-off guard for its own `--rpc` case
(`args.get("rpc") if isinstance(args.get("rpc"), str) else None`) — proof
the codebase already knows about this hazard but never applied a fix
consistently across the three scripts.

No competing PR exists for this issue.

## Fix
Backported `opt_str`/`opt_int`/`opt_float` from `poolsfun/fmt.py` into
`unilp/fmt.py`, byte-for-byte identical to the already-accepted
implementation — no new design surface. Rewired all 20 call sites across
`lp_read.py`, `lp_write.py`, and `ratchet.py`. Range bounds on the new
`opt_int`/`opt_float` calls (`slippage-bps`: 0–9999; `deadline-secs`: ≥60;
`gas-multiplier`: ≥1.0) match `poolsfun/pools_write.py`'s own precedent for
the identical parameters exactly, rather than inventing new limits.
`max-tick-drift`/`max-attempts`/`expiration-days` get a `minimum=1`, matching
poolsfun's `max-salt-attempts` convention.

`lp_read.py`'s pre-existing, already-safe `--rpc` guard is left untouched —
it fails safe today and changing it would be an unrequested behavior change
outside this bug's scope.

## Tests
`scripts/selftest.py` (offline, no RPC, no network):
- Added a `_raises()` helper mirroring `poolsfun/selftest.py`'s own `raises()`
  — checks the exception message names the field, not just that something
  raised, since a regression could swap in a different opaque exception that
  happens to also be a `ValueError`.
- 16 new assertions on `opt_str`/`opt_int`/`opt_float` directly: absent falls
  back to default, values parse correctly, whitespace trims, every bare-flag
  case is rejected with a "needs a value" message (not coerced), non-numeric
  values are rejected, and every bound (`slippage-bps` 0/9999,
  `deadline-secs` 60) is enforced.
- 1 new assertion at a real call site (`lp_read.resolve_owner({"owner": True})`)
  proving the fix is correctly wired in, not just correct in isolation.
- Baseline was 733 assertions; now 750 — confirmed the new checks execute
  (not skipped) by running against `upstream/main` before and after.

Commands run:
  uv run ruff check <5 touched files>
  → All checks passed!
  uv run mypy src/agentos --show-error-codes
  → Success: no issues found in 625 source files
  python3 scripts/selftest.py
  → 750 assertions pass
  uv run pytest tests/test_skill_bundled_url_scheme.py tests/test_skill_rpc_error_non_dict_payload.py tests/test_skills_default_prompt_contract.py tests/test_skills_script_paths.py tests/test_skills_third_party_notices.py tests/test_tools/test_skill_view_budget.py -q
  → 67 passed

No `ruff format --check` — every touched file is under `skills/bundled/`,
exempt from the formatter per repo convention.

Third-party origin: none — `opt_str`/`opt_int`/`opt_float` are backported
from this same repository's own `poolsfun/fmt.py` (PR #299, already merged).

Fixes the underlying issue for good, per the acceptance criteria named above:
every one of the 20 confirmed call sites now raises a clear,
field-naming error on a bare flag instead of silently substituting a wrong
value or crashing opaquely — matching the standard the sibling skill already
set.