### PR TITLE
fix(gateway): include reasoning capability in models.list wire format (#1707)

### DIFF
--- a/src/agentos/gateway/rpc_models.py
+++ b/src/agentos/gateway/rpc_models.py
@@ -13,10 +13,12 @@ _d = get_dispatcher()
 def _model_info_to_wire(m: dict[str, Any]) -> dict[str, Any]:
     """Convert a ModelInfo.model_dump() dict to the RPC wire format."""
     capabilities: list[str] = ["chat"]
-    if m.get("supports_tools"):
+    if m.get("supports_tools") or "tools" in m.get("capabilities", []):
         capabilities.append("tools")
-    if m.get("supports_vision"):
+    if m.get("supports_vision") or "vision" in m.get("capabilities", []):
         capabilities.append("vision")
+    if m.get("supports_reasoning") or "reasoning" in m.get("capabilities", []):
+        capabilities.append("reasoning")
     return {
         "id": m.get("model_id", ""),
         "name": m.get("display_name") or m.get("model_id", ""),

--- a/tests/test_gateway/test_rpc_models_catalog_scope.py
+++ b/tests/test_gateway/test_rpc_models_catalog_scope.py
@@ -17,6 +17,7 @@ import asyncio
 from types import SimpleNamespace
 
 from agentos.gateway.rpc import RpcContext, get_dispatcher
+from agentos.gateway.rpc_models import _model_info_to_wire
 from agentos.router_control import RouterControlHoldStore
 
 _OPENCAP_ROWS = [
@@ -36,6 +37,7 @@ def _ctx(provider: str = "opencap", rows: list[dict] | None = None) -> RpcContex
                     "model_id": row["id"],
                     "display_name": row["id"],
                     "provider": row["provider"],
+                    **{k: v for k, v in row.items() if k not in {"id", "provider"}},
                 }
             )
             for row in catalog_rows
@@ -118,3 +120,29 @@ def test_a_model_outside_the_catalog_cannot_be_pinned() -> None:
     )
 
     assert result.error is not None
+
+
+def test_model_info_to_wire_includes_reasoning() -> None:
+    wire = _model_info_to_wire({"supports_reasoning": True, "supports_tools": True})
+    assert wire["capabilities"] == ["chat", "tools", "reasoning"]
+
+    wire_no_reasoning = _model_info_to_wire({"supports_tools": True})
+    assert wire_no_reasoning["capabilities"] == ["chat", "tools"]
+
+
+def test_models_list_includes_reasoning_capability_and_filters() -> None:
+    rows = [
+        {"id": "deepseek/deepseek-r1", "provider": "openrouter", "supports_reasoning": True},
+        {"id": "anthropic/claude-3.5-sonnet", "provider": "openrouter", "supports_tools": True},
+    ]
+    ctx = _ctx("openrouter", rows)
+    all_models = _list({}, ctx)
+    assert len(all_models) == 2
+    r1 = next(m for m in all_models if m["id"] == "deepseek/deepseek-r1")
+    assert "reasoning" in r1["capabilities"]
+    assert "chat" in r1["capabilities"]
+
+    filtered = _list({"capabilities": ["reasoning"]}, ctx)
+    assert len(filtered) == 1
+    assert filtered[0]["id"] == "deepseek/deepseek-r1"
+


### PR DESCRIPTION
## Linked issue

Closes #1707

- [x] This pull request fully resolves the linked issue, or the description
      says what remains.

## Summary

In `src/agentos/gateway/rpc_models.py`, `_model_info_to_wire()` converts model metadata into the RPC wire format. While `ModelInfo` has `supports_reasoning: bool`, `_model_info_to_wire` only checked for `supports_tools` and `supports_vision`.

This meant that:
- Models supporting reasoning (such as DeepSeek-R1, OpenAI o1/o3-mini, Gemini 2.5/3, GLM-5) never exposed `"reasoning"` in their `capabilities` list.
- Callers filtering models by reasoning capability (`models.list` with `{"capabilities": ["reasoning"]}` or CLI `agentos models list -c reasoning`) always received an empty list.

This change:
1. Updates `_model_info_to_wire` to append `"reasoning"` to `capabilities` when `supports_reasoning` is true (or when `"reasoning"` is already present in `capabilities`).
2. Adds unit tests verifying that `_model_info_to_wire` includes `"reasoning"` and that `models.list` properly filters by the reasoning capability.

## Tests

- `uv run pytest tests/test_gateway/test_rpc_models_catalog_scope.py -q` (6 passed)
- `uv run ruff check src/agentos/gateway/rpc_models.py tests/test_gateway/test_rpc_models_catalog_scope.py` (All checks passed)
- `uv run mypy src/agentos/gateway/rpc_models.py --show-error-codes` (Success: no issues found)
