### PR TITLE
fix(skills): clamp skills.search and SourceRouter limit to valid bounds

### DIFF
--- a/src/agentos/gateway/rpc_skills.py
+++ b/src/agentos/gateway/rpc_skills.py
@@ -504,7 +504,7 @@ async def _handle_skills_search(params: dict | None, ctx: RpcContext) -> dict[st
         # The browse gallery requests whole catalogs (Bankr alone is ~100
         # skills), so the cap must comfortably exceed catalog sizes — a cap
         # sized for paged search results silently truncates browse.
-        limit = min(int(params.get("limit", 20)), 500)
+        limit = max(1, min(int(params.get("limit", 20)), 500))
     except (TypeError, ValueError):
         limit = 20
     source_id = params.get("source")

--- a/src/agentos/skills/hub/router.py
+++ b/src/agentos/skills/hub/router.py
@@ -33,6 +33,7 @@ class SourceRouter:
         self, query: str, limit: int = 20, source_id: str | None = None
     ) -> list[SkillMeta]:
         """Search across all sources (or a specific one). Returns merged results."""
+        limit = max(1, limit)
         if source_id:
             src = self._sources.get(source_id)
             if src is None:

--- a/tests/test_gateway/test_rpc_skills_search_limit.py
+++ b/tests/test_gateway/test_rpc_skills_search_limit.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import pytest
+
+from agentos.gateway import rpc_skills
+from agentos.skills.hub.router import SourceRouter
+from agentos.skills.hub.source import SkillMeta, SkillSource
+
+
+class _StubRouter:
+    def __init__(self, results: list[SkillMeta] | None = None) -> None:
+        self._results = results or []
+        self.calls: list[dict] = []
+
+    async def search(self, query: str, limit: int = 20, source_id: str | None = None):
+        self.calls.append({"query": query, "limit": limit, "source_id": source_id})
+        return self._results[:limit]
+
+
+class _Ctx:
+    def __init__(self, router: _StubRouter) -> None:
+        self._skill_router = router
+
+
+class _StubSource(SkillSource):
+    def __init__(self, source_id: str, results: list[SkillMeta]) -> None:
+        self._source_id = source_id
+        self._results = results
+        self.calls: list[dict] = []
+
+    @property
+    def source_id(self) -> str:
+        return self._source_id
+
+    @property
+    def trust_level(self) -> str:
+        return "community"
+
+    async def search(self, query: str, limit: int = 20) -> list[SkillMeta]:
+        self.calls.append({"query": query, "limit": limit})
+        return self._results[:limit]
+
+    async def fetch(self, identifier: str):
+        return None
+
+    async def inspect(self, identifier: str):
+        return None
+
+
+def _no_lockfile(monkeypatch) -> None:
+    monkeypatch.setattr(rpc_skills, "_installed_names", lambda: set())
+    monkeypatch.setattr(rpc_skills, "installed_skill_identifiers", lambda: set())
+    monkeypatch.setattr(rpc_skills, "_installed_lock_entries", dict)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_limit", [-5, -1, 0])
+async def test_skills_search_clamps_non_positive_limit_to_one(monkeypatch, bad_limit: int) -> None:
+    _no_lockfile(monkeypatch)
+    router = _StubRouter()
+    await rpc_skills._handle_skills_search({"query": "test", "limit": bad_limit}, _Ctx(router))
+
+    assert len(router.calls) == 1
+    assert router.calls[0]["limit"] == 1
+
+
+@pytest.mark.asyncio
+async def test_skills_search_clamps_oversized_limit_to_five_hundred(monkeypatch) -> None:
+    _no_lockfile(monkeypatch)
+    router = _StubRouter()
+    await rpc_skills._handle_skills_search({"query": "test", "limit": 1000}, _Ctx(router))
+
+    assert len(router.calls) == 1
+    assert router.calls[0]["limit"] == 500
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("invalid_limit", ["invalid", None, [], {}])
+async def test_skills_search_falls_back_to_default_on_non_integer_limit(
+    monkeypatch, invalid_limit: object
+) -> None:
+    _no_lockfile(monkeypatch)
+    router = _StubRouter()
+    await rpc_skills._handle_skills_search({"query": "test", "limit": invalid_limit}, _Ctx(router))
+
+    assert len(router.calls) == 1
+    assert router.calls[0]["limit"] == 20
+
+
+@pytest.mark.asyncio
+async def test_skills_search_passes_valid_limit_unchanged(monkeypatch) -> None:
+    _no_lockfile(monkeypatch)
+    router = _StubRouter()
+    await rpc_skills._handle_skills_search({"query": "test", "limit": 42}, _Ctx(router))
+
+    assert len(router.calls) == 1
+    assert router.calls[0]["limit"] == 42
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("limit", [-10, -1, 0])
+async def test_source_router_search_clamps_limit_to_one(limit: int) -> None:
+    m1 = SkillMeta(name="s1", source_id="src1", identifier="id1")
+    m2 = SkillMeta(name="s2", source_id="src1", identifier="id2")
+    source = _StubSource("src1", [m1, m2])
+    router = SourceRouter([source])
+
+    results = await router.search("test", limit=limit)
+
+    assert len(source.calls) == 1
+    assert source.calls[0]["limit"] == 1
+    assert len(results) == 1
+    assert results[0].name == "s1"


### PR DESCRIPTION
## Linked issue

Fixes #1709

- [x] This pull request fully resolves the linked issue.

## Summary

`_handle_skills_search` in `src/agentos/gateway/rpc_skills.py` parsed `limit` with `min(int(params.get("limit", 20)), 500)`, which capped the upper ceiling but failed to clamp the lower bound to 1. Other gateway RPC handlers reading limit (`rpc_chat.py`, `rpc_logs.py`, `rpc_cron.py`, `rpc_sessions.py`) already enforce `max(1, ...)`.

When a non-positive integer (e.g. `limit: -1` or `limit: -5`) was supplied:
- `SourceRouter.search` passed it down to all registered adapters.
- In `src/agentos/skills/hub/github.py`, `per_page=min(limit, 30)` evaluated to a negative integer, causing GitHub API's code search endpoint to reject the request with `HTTP 422 Unprocessable Entity`.
- In `clawhub.py`, `aeon.py`, `capminal.py`, `bankr.py`, and `SourceRouter.search`, in-memory slicing `results[:limit]` (e.g. `results[:-5]`) triggered negative slice semantics, stripping the trailing entries from the results list.
- A value of `0` returned empty results instead of clamping to the minimum valid page size of 1.

Fixed by clamping `limit = max(1, min(int(params.get("limit", 20)), 500))` at the RPC boundary and ensuring `limit = max(1, limit)` in `SourceRouter.search`.

## Tests

Added `tests/test_gateway/test_rpc_skills_search_limit.py`:
- Verifies non-positive limits (`-5`, `-1`, `0`) clamp to 1.
- Verifies oversized limits (`1000`) clamp to 500.
- Verifies non-numeric values (`"invalid"`, `None`, etc.) fall back to the default of 20.
- Verifies valid limits pass through unchanged.
- Verifies `SourceRouter.search` direct invocations with non-positive limits clamp to 1.

Ran quality gate:
```
ruff check src/agentos/gateway/rpc_skills.py src/agentos/skills/hub/router.py tests/test_gateway/test_rpc_skills_search_limit.py   # All checks passed!
ruff format --check src/agentos/gateway/rpc_skills.py src/agentos/skills/hub/router.py tests/test_gateway/test_rpc_skills_search_limit.py   # All checks passed!
mypy src/agentos/gateway/rpc_skills.py src/agentos/skills/hub/router.py --show-error-codes   # Success: no issues found
pytest tests/test_gateway/test_rpc_skills_search_limit.py tests/test_gateway/test_rpc_skills_search_payload.py tests/test_skills/ -q   # 81 passed, 1 skipped
```
