### PR TITLE
fix(gateway): persist elevatedMode in approval queue SQLite parameters on resolve

### DIFF
--- a/src/agentos/application/approval_queue.py
+++ b/src/agentos/application/approval_queue.py
@@ -236,11 +236,16 @@ class ApprovalQueue:
                 return
             raise ValueError(f"Approval already resolved: {approval_id}")
 
+        params = dict(entry.params)
+        if approved and elevated_mode in VALID_ELEVATED_MODES:
+            params["elevatedMode"] = elevated_mode
+        payload = self._serialize_params(params)
+
         cursor = self._conn.execute(
             "UPDATE approval_queue "
-            "SET resolved = 1, approved = ? "
+            "SET resolved = 1, approved = ?, params = ? "
             "WHERE approval_id = ? AND resolved = 0",
-            (1 if approved else 0, approval_id),
+            (1 if approved else 0, payload, approval_id),
         )
         if cursor.rowcount != 1:
             self._conn.rollback()
@@ -260,7 +265,6 @@ class ApprovalQueue:
         self._pending[approval_id] = entry
 
         if approved and elevated_mode in VALID_ELEVATED_MODES:
-            entry.params["elevatedMode"] = elevated_mode
             session_key = str(entry.params.get("sessionKey") or "").strip()
             if session_key:
                 self.set_elevated_mode(session_key, elevated_mode)

--- a/tests/test_gateway/test_approval_queue_persistence.py
+++ b/tests/test_gateway/test_approval_queue_persistence.py
@@ -176,3 +176,46 @@ def test_approval_queue_consume_is_one_shot_with_stale_unconsumed_read(
         assert queue.get(approval_id).consumed is True
     finally:
         queue.close()
+
+
+def test_approval_queue_resolve_persists_elevated_mode_across_reload_and_get(tmp_path) -> None:
+    db_path = tmp_path / "approval_queue.sqlite"
+    queue = ApprovalQueue(db_path=str(db_path))
+    aid = queue.request(
+        "exec",
+        {"toolName": "exec_command", "command": "rm -rf /tmp/test", "sessionKey": "s1"},
+    )
+
+    queue.resolve(aid, True, elevated_mode="bypass")
+
+    entry = queue.get(aid)
+    assert entry.params.get("elevatedMode") == "bypass"
+    queue.close()
+
+    reloaded = ApprovalQueue(db_path=str(db_path))
+    reloaded_entry = reloaded.get(aid)
+    assert reloaded_entry.params.get("elevatedMode") == "bypass"
+    assert reloaded.get_elevated_mode("s1") is None  # session mode is in-memory, but params persist
+    reloaded.close()
+
+
+def test_approval_queue_resolve_pending_for_session_persists_elevated_mode(tmp_path) -> None:
+    db_path = tmp_path / "approval_queue.sqlite"
+    queue = ApprovalQueue(db_path=str(db_path))
+    aid = queue.request(
+        "exec",
+        {"toolName": "exec_command", "command": "ls", "sessionKey": "session-xyz"},
+    )
+
+    resolved_count = queue.resolve_pending_for_session(
+        "session-xyz",
+        approved=True,
+        elevated_mode="on",
+    )
+    assert resolved_count == 1
+    assert queue.get(aid).params.get("elevatedMode") == "on"
+    queue.close()
+
+    reloaded = ApprovalQueue(db_path=str(db_path))
+    assert reloaded.get(aid).params.get("elevatedMode") == "on"
+    reloaded.close()


### PR DESCRIPTION
Fixes #1687

### Summary of Changes
When `ApprovalQueue.resolve()` resolved an approval with `elevated_mode`, `entry.params["elevatedMode"]` was only updated in-memory and was never persisted to the `approval_queue` SQLite table `params` column. As a result, subsequent calls to `queue.get(approval_id)` or reloads from SQLite overwrote the in-memory entry with stale DB contents, dropping `elevatedMode` and causing `_apply_approval_elevated_mode()` in shell execution to silently fail to apply elevated execution mode.

This PR updates `ApprovalQueue.resolve()` to serialize the updated `params` payload (containing `elevatedMode` when approved) into the SQLite `approval_queue` record during the resolution transaction.

### Testing
- Added regression test `test_approval_queue_resolve_persists_elevated_mode_across_reload_and_get` verifying `elevatedMode` persistence across `get()` and queue restarts.
- Added regression test `test_approval_queue_resolve_pending_for_session_persists_elevated_mode` verifying persistence when resolved via session batching.
- Full suite of approval tests (`tests/test_gateway/test_approval_queue_persistence.py`, `tests/test_application/test_approval_rpc.py`, `tests/test_gateway/test_rpc_approvals.py`, `tests/test_channels/test_channel_approvals.py`) and type checks (`mypy`, `ruff`) passed.