### PR TITLE
fix(gateway): validate key and keys parameters in sessions.delete

### DIFF
--- a/src/agentos/gateway/rpc_sessions.py
+++ b/src/agentos/gateway/rpc_sessions.py
@@ -1964,9 +1964,17 @@ async def _handle_sessions_delete(params: dict | None, ctx: RpcContext) -> dict:
     keys: list[str] = []
     if isinstance(params, dict):
         if "keys" in params:
-            keys = params["keys"]
+            raw_keys = params["keys"]
+            if not isinstance(raw_keys, list):
+                raise ValueError("params.keys must be a list")
+            keys = [str(k).strip() for k in raw_keys if isinstance(k, str) and str(k).strip()]
         elif "key" in params:
-            keys = [params["key"]]
+            raw_key = params["key"]
+            if not isinstance(raw_key, str):
+                raise ValueError("params.key must be a string")
+            key_val = raw_key.strip()
+            if key_val:
+                keys = [key_val]
 
     if not keys:
         raise ValueError("params.key or params.keys is required")

--- a/tests/test_gateway/test_rpc_sessions.py
+++ b/tests/test_gateway/test_rpc_sessions.py
@@ -2148,10 +2148,47 @@ class TestSessionsDelete:
 
         ctx = make_ctx(session_manager=FakeSessionManager([session]), task_runtime=_BrokenRuntime())
 
-        res = await dispatcher.dispatch(
-            "r1", "sessions.delete", {"key": session.session_key}, ctx
-        )
+        res = await dispatcher.dispatch("r1", "sessions.delete", {"key": session.session_key}, ctx)
 
+        assert res.ok is True
+        assert res.payload["deleted"] == [session.session_key]
+        assert res.payload["errors"] == []
+
+    @pytest.mark.asyncio
+    async def test_delete_rejects_non_list_keys(self, dispatcher, ctx_with_sessions):
+        res = await dispatcher.dispatch(
+            "r1", "sessions.delete", {"keys": "some-key"}, ctx_with_sessions
+        )
+        assert res.ok is False
+        assert "params.keys must be a list" in (res.error.message if res.error else "")
+
+    @pytest.mark.asyncio
+    async def test_delete_rejects_non_string_key(self, dispatcher, ctx_with_sessions):
+        res = await dispatcher.dispatch("r1", "sessions.delete", {"key": 123}, ctx_with_sessions)
+        assert res.ok is False
+        assert "params.key must be a string" in (res.error.message if res.error else "")
+
+    @pytest.mark.asyncio
+    async def test_delete_rejects_empty_key_and_blank_keys(self, dispatcher, ctx_with_sessions):
+        res1 = await dispatcher.dispatch("r1", "sessions.delete", {"key": ""}, ctx_with_sessions)
+        assert res1.ok is False
+        assert "params.key or params.keys is required" in (res1.error.message if res1.error else "")
+
+        res2 = await dispatcher.dispatch("r1", "sessions.delete", {"keys": []}, ctx_with_sessions)
+        assert res2.ok is False
+        assert "params.key or params.keys is required" in (res2.error.message if res2.error else "")
+
+        res3 = await dispatcher.dispatch(
+            "r1", "sessions.delete", {"keys": ["", "   "]}, ctx_with_sessions
+        )
+        assert res3.ok is False
+        assert "params.key or params.keys is required" in (res3.error.message if res3.error else "")
+
+    @pytest.mark.asyncio
+    async def test_delete_bulk_valid_list(self, dispatcher, ctx_with_sessions, session):
+        res = await dispatcher.dispatch(
+            "r1", "sessions.delete", {"keys": [session.session_key]}, ctx_with_sessions
+        )
         assert res.ok is True
         assert res.payload["deleted"] == [session.session_key]
         assert res.payload["errors"] == []


### PR DESCRIPTION
Fixes #1712

### Summary of Changes
In `sessions.delete` (`src/agentos/gateway/rpc_sessions.py`), passing a string to `params["keys"]` caused Python to iterate over each character of the string as a session key. Additionally, passing non-string values or empty strings to `params["key"]` bypassed the `if not keys:` validation check.

This PR adds strict input validation:
- Validates that `params["keys"]`, if provided, is a list of non-empty strings (raising `ValueError("params.keys must be a list")` otherwise).
- Validates that `params["key"]`, if provided, is a string (raising `ValueError("params.key must be a string")` otherwise).
- Ensures that if neither valid `key` nor `keys` is provided, `ValueError("params.key or params.keys is required")` is raised.

### Testing
- Added unit tests in `TestSessionsDelete` (`tests/test_gateway/test_rpc_sessions.py`):
  - `test_delete_rejects_non_list_keys`
  - `test_delete_rejects_non_string_key`
  - `test_delete_rejects_empty_key_and_blank_keys`
  - `test_delete_bulk_valid_list`
- Ran quality gates: `ruff check`, `ruff format`, `mypy`, and `pytest tests/test_gateway/test_rpc_sessions.py` (105/105 passed).