### PR TITLE
fix(gateway): validate parameter types in skills RPC handlers

### DIFF
--- a/src/agentos/gateway/rpc_skills.py
+++ b/src/agentos/gateway/rpc_skills.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from agentos.gateway.access import CONTROL_AND_CHANNEL, CONTROL_AND_NODE
-from agentos.gateway.rpc import RpcContext, get_dispatcher
+from agentos.gateway.rpc import RpcContext, get_dispatcher, require_params_dict
 from agentos.skills.availability import SkillAvailability
 from agentos.skills.eligibility import (
     EligibilityContext,
@@ -364,17 +364,19 @@ async def _handle_skills_bins(params: dict | None, ctx: RpcContext) -> dict[str,
 @_d.method("skills.get")
 async def _handle_skills_get(params: dict | None, ctx: RpcContext) -> dict[str, Any]:
     """Get a single skill by name, including its full content."""
-    if not isinstance(params, dict) or "name" not in params:
-        raise ValueError("params.name is required")
+    params = require_params_dict(params)
+    name = params.get("name")
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError("params.name must be a non-empty string")
 
     loader = _get_loader(ctx)
     if loader is None:
         raise KeyError("No skill loader available")
 
     all_rows = _inventory(ctx)
-    row = next((item for item in all_rows if item.spec.name == params["name"]), None)
+    row = next((item for item in all_rows if item.spec.name == name), None)
     if row is None:
-        raise KeyError(f"Skill not found: {params['name']}")
+        raise KeyError(f"Skill not found: {name}")
 
     result = _rows_payload([row], index_from=all_rows)[0]
     result["content"] = row.spec.content
@@ -490,8 +492,10 @@ def _synthesized_installed_rows(
 @_d.method("skills.search")
 async def _handle_skills_search(params: dict | None, ctx: RpcContext) -> dict[str, Any]:
     """Search for skills across Community sources."""
-    if not isinstance(params, dict) or "query" not in params:
-        raise ValueError("params.query is required")
+    params = require_params_dict(params)
+    query = params.get("query")
+    if not isinstance(query, str):
+        raise ValueError("params.query must be a string")
 
     router = getattr(ctx, "_skill_router", None)
     if router is None:
@@ -570,8 +574,10 @@ def _invalidate_loader(ctx: RpcContext) -> None:
 @_d.method("skills.install")
 async def _handle_skills_install(params: dict | None, ctx: RpcContext) -> dict[str, Any]:
     """Install a skill from a Community source."""
-    if not isinstance(params, dict) or "identifier" not in params:
-        raise ValueError("params.identifier is required")
+    params = require_params_dict(params)
+    identifier = params.get("identifier")
+    if not isinstance(identifier, str) or not identifier.strip():
+        raise ValueError("params.identifier must be a non-empty string")
     loader = _get_loader(ctx)
     if loader is None:
         return {"success": False, "message": "No skill loader configured"}
@@ -580,7 +586,6 @@ async def _handle_skills_install(params: dict | None, ctx: RpcContext) -> dict[s
     if installer is None:
         return {"success": False, "message": "No skill installer configured"}
 
-    identifier = params["identifier"]
     source_id = params.get("source", "clawhub")
     force = params.get("force", False)
     result = await installer.install(identifier, source_id, force=force)
@@ -602,6 +607,14 @@ async def _handle_skills_install(params: dict | None, ctx: RpcContext) -> dict[s
 @_d.method("skills.update")
 async def _handle_skills_update(params: dict | None, ctx: RpcContext) -> dict[str, Any]:
     """Update installed skills from lockfile."""
+    name: str | None = None
+    if params is not None:
+        if not isinstance(params, dict):
+            raise ValueError("params must be an object")
+        name = params.get("name")
+        if name is not None and (not isinstance(name, str) or not name.strip()):
+            raise ValueError("params.name must be a non-empty string")
+
     loader = _get_loader(ctx)
     if loader is None:
         return {
@@ -613,7 +626,6 @@ async def _handle_skills_update(params: dict | None, ctx: RpcContext) -> dict[st
     if installer is None:
         return {"success": False, "message": "No skill installer configured"}
 
-    name = (params or {}).get("name")
     try:
         results = await installer.update(_lock_key(ctx, name) if name else None)
     except OSError as exc:
@@ -641,14 +653,16 @@ async def _handle_skills_update(params: dict | None, ctx: RpcContext) -> dict[st
 @_d.method("skills.uninstall")
 async def _handle_skills_uninstall(params: dict | None, ctx: RpcContext) -> dict[str, Any]:
     """Uninstall a managed skill."""
-    if not isinstance(params, dict) or "name" not in params:
-        raise ValueError("params.name is required")
+    params = require_params_dict(params)
+    name = params.get("name")
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError("params.name must be a non-empty string")
 
     installer = _get_default_installer(managed_dir=_loader_managed_dir(ctx))
     if installer is None:
         return {"success": False, "message": "No skill installer configured"}
 
-    result = await installer.uninstall(_lock_key(ctx, params["name"]))
+    result = await installer.uninstall(_lock_key(ctx, name))
     if result.success:
         _invalidate_loader(ctx)
     return {"success": result.success, "name": result.name, "message": result.message}
@@ -665,15 +679,13 @@ async def _handle_skills_deps_install(params: dict | None, ctx: RpcContext) -> d
     Note: `kind == "download"` is non-idempotent — re-running re-downloads.
     Callers should consult `missing_still` before retrying.
     """
-    if not isinstance(params, dict):
-        raise ValueError("params must be a dict")
-    if "name" not in params:
-        raise ValueError("params.name is required")
-    if "install_id" not in params:
-        raise ValueError("params.install_id is required")
-
-    name = params["name"]
-    install_id = params["install_id"]
+    params = require_params_dict(params)
+    name = params.get("name")
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError("params.name must be a non-empty string")
+    install_id = params.get("install_id")
+    if not isinstance(install_id, str) or not install_id.strip():
+        raise ValueError("params.install_id must be a non-empty string")
     loader = _get_loader(ctx)
     if loader is None:
         raise KeyError("No skill loader available")

--- a/tests/test_gateway/test_rpc_skills_params.py
+++ b/tests/test_gateway/test_rpc_skills_params.py
@@ -1,0 +1,75 @@
+"""Unit tests for parameter validation in skills RPC handlers."""
+
+from __future__ import annotations
+
+import pytest
+
+import agentos.gateway.rpc_skills  # noqa: F401
+from agentos.gateway.access import ConnectionSurface
+from agentos.gateway.auth import AccessContext
+from agentos.gateway.rpc import RpcContext, get_dispatcher
+
+
+def _ctx() -> RpcContext:
+    return RpcContext(
+        conn_id="conn-test",
+        access=AccessContext(
+            surface=ConnectionSurface.CONTROL,
+            admitted=True,
+            credential_verified=True,
+        ),
+    )
+
+
+class TestSkillsRpcParamValidation:
+    @pytest.mark.parametrize(
+        ("method", "invalid_params"),
+        [
+            ("skills.get", None),
+            ("skills.get", []),
+            ("skills.get", "string"),
+            ("skills.get", {}),
+            ("skills.get", {"name": 123}),
+            ("skills.get", {"name": ""}),
+            ("skills.get", {"name": "   "}),
+            ("skills.get", {"name": None}),
+            ("skills.search", None),
+            ("skills.search", []),
+            ("skills.search", {}),
+            ("skills.search", {"query": 123}),
+            ("skills.search", {"query": None}),
+            ("skills.install", None),
+            ("skills.install", []),
+            ("skills.install", {}),
+            ("skills.install", {"identifier": 123}),
+            ("skills.install", {"identifier": ""}),
+            ("skills.install", {"identifier": "   "}),
+            ("skills.install", {"identifier": None}),
+            ("skills.update", "not-a-dict"),
+            ("skills.update", [123]),
+            ("skills.update", {"name": 123}),
+            ("skills.update", {"name": ""}),
+            ("skills.update", {"name": "   "}),
+            ("skills.uninstall", None),
+            ("skills.uninstall", []),
+            ("skills.uninstall", {}),
+            ("skills.uninstall", {"name": 123}),
+            ("skills.uninstall", {"name": ""}),
+            ("skills.uninstall", {"name": "   "}),
+            ("skills.uninstall", {"name": None}),
+            ("skills.deps.install", None),
+            ("skills.deps.install", []),
+            ("skills.deps.install", {}),
+            ("skills.deps.install", {"name": "foo"}),
+            ("skills.deps.install", {"install_id": "bar"}),
+            ("skills.deps.install", {"name": 123, "install_id": "bar"}),
+            ("skills.deps.install", {"name": "", "install_id": "bar"}),
+            ("skills.deps.install", {"name": "foo", "install_id": 123}),
+            ("skills.deps.install", {"name": "foo", "install_id": ""}),
+            ("skills.deps.install", {"name": "foo", "install_id": "   "}),
+        ],
+    )
+    async def test_invalid_params_rejected(self, method: str, invalid_params: object) -> None:
+        res = await get_dispatcher().dispatch("req-1", method, invalid_params, _ctx())
+        assert res.error is not None, f"Expected error for {method} with {invalid_params!r}"
+        assert res.error.code == "INVALID_REQUEST", res.error


### PR DESCRIPTION
## Summary

Several RPC handlers in `src/agentos/gateway/rpc_skills.py` (`skills.get`, `skills.search`, `skills.install`, `skills.update`, `skills.uninstall`, `skills.deps.install`) did not strictly validate parameter types or reject non-mapping payloads via `require_params_dict`.

This PR:
- Adds `require_params_dict` calls across `skills.get`, `skills.search`, `skills.install`, `skills.uninstall`, and `skills.deps.install` to ensure non-mapping payloads are rejected as `INVALID_REQUEST` under all optimization levels (`-O`).
- Validates that required string parameters (`name`, `identifier`, `query`, `install_id`) are non-empty strings, raising `ValueError` (mapping to JSON-RPC `INVALID_REQUEST`).
- Validates optional `params.name` in `skills.update` before loader checks.
- Adds comprehensive parameter validation unit tests in `tests/test_gateway/test_rpc_skills_params.py`.

Fixes #1714

## Verification

- `uv run ruff check src/agentos/gateway/rpc_skills.py tests/test_gateway/test_rpc_skills_params.py` (passed)
- `uv run ruff format --check src/agentos/gateway/rpc_skills.py tests/test_gateway/test_rpc_skills_params.py` (passed)
- `uv run mypy src/agentos/gateway/rpc_skills.py --show-error-codes` (passed)
- `uv run pytest tests/test_gateway/test_rpc_skills_params.py -v` (42 passed)
- `uv run pytest tests/test_gateway/test_rpc_skills_*.py tests/test_skills_*.py -v` (361 passed)
