### PR TITLE
fix(skills): escape colons in non-drive paths for subtitle-burner (#1719)

### DIFF
--- a/src/agentos/skills/bundled/subtitle-burner/scripts/burn.py
+++ b/src/agentos/skills/bundled/subtitle-burner/scripts/burn.py
@@ -20,6 +20,7 @@ Exit codes:
     0 — success, output written.
     1 — failure; stderr carries the ffmpeg tail.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -31,30 +32,37 @@ from glob import glob
 from pathlib import Path
 
 _WINGET_FFMPEG_GLOB = (
-    "Microsoft/WinGet/Packages/Gyan.FFmpeg_Microsoft.Winget.Source_*/"
-    "ffmpeg-*-full_build/bin"
+    "Microsoft/WinGet/Packages/Gyan.FFmpeg_Microsoft.Winget.Source_*/ffmpeg-*-full_build/bin"
 )
 
 
 def _probe_resolution(ffmpeg_bin: str, video_path: Path) -> tuple[int, int] | None:
     """Use ffprobe (next to ffmpeg) to read the source video's W x H."""
     ffprobe = ffmpeg_bin.replace("ffmpeg.exe", "ffprobe.exe").replace(
-        "/ffmpeg", "/ffprobe",
+        "/ffmpeg",
+        "/ffprobe",
     )
     if ffprobe == ffmpeg_bin:
         # Fallback for non-Windows / non-suffixed names.
-        ffprobe = str(Path(ffmpeg_bin).with_name(
-            "ffprobe.exe" if os.name == "nt" else "ffprobe",
-        ))
+        ffprobe = str(
+            Path(ffmpeg_bin).with_name(
+                "ffprobe.exe" if os.name == "nt" else "ffprobe",
+            )
+        )
     if not Path(ffprobe).is_file() and shutil.which(ffprobe) is None:
         return None
     try:
         proc = subprocess.run(
             [
-                ffprobe, "-v", "error",
-                "-select_streams", "v:0",
-                "-show_entries", "stream=width,height",
-                "-of", "csv=s=x:p=0",
+                ffprobe,
+                "-v",
+                "error",
+                "-select_streams",
+                "v:0",
+                "-show_entries",
+                "stream=width,height",
+                "-of",
+                "csv=s=x:p=0",
                 str(video_path),
             ],
             capture_output=True,
@@ -109,17 +117,21 @@ def _escape_subtitle_path(path: str) -> str:
     libass on Windows is picky: drive-letter colons must be backslash-
     escaped, and the path uses forward slashes regardless of OS. Inside
     the filter graph, single quotes wrap the path so commas / brackets
-    in the file name don't confuse the parser.
+    in the file name don't confuse the parser, and any other colons must
+    be backslash-escaped so ffmpeg does not treat them as option separators.
     """
     # Always use forward slashes inside the filter graph.
     normalised = path.replace("\\", "/")
-    # Escape drive-letter colon ("C:" -> "C\:") to keep libass happy.
-    if len(normalised) >= 2 and normalised[1] == ":" and normalised[0].isalpha():
-        normalised = normalised[0] + r"\:" + normalised[2:]
-    # Escape any remaining colon (e.g. an unusual file name).
-    rest = normalised[3:] if len(normalised) >= 3 else ""
-    if ":" in rest:
-        normalised = normalised[:3] + rest.replace(":", r"\:")
+    has_drive = len(normalised) >= 2 and normalised[1] == ":" and normalised[0].isalpha()
+    if has_drive:
+        # Escape drive-letter colon ("C:" -> "C\:") to keep libass happy on Windows,
+        # and escape any remaining colons in the rest of the path.
+        drive = normalised[0] + r"\:"
+        rest = normalised[2:].replace(":", r"\:")
+        normalised = drive + rest
+    else:
+        # On non-drive paths, escape all colons so ffmpeg does not mistake them for option separators.
+        normalised = normalised.replace(":", r"\:")
     # Escape single quotes inside the path (rare on Windows but possible).
     normalised = normalised.replace("'", r"\'")
     return normalised
@@ -137,36 +149,56 @@ def main() -> int:
     )
     parser.add_argument("--font-size", type=int, default=42)
     parser.add_argument(
-        "--primary-colour", default="&Hffffff",
+        "--primary-colour",
+        default="&Hffffff",
         help="ASS colour code for fill (&HBBGGRR). Default white &Hffffff.",
     )
     parser.add_argument(
-        "--outline-colour", default="&H000000",
+        "--outline-colour",
+        default="&H000000",
         help="ASS colour code for outline. Default black &H000000.",
     )
     parser.add_argument(
-        "--outline", type=int, default=2, help="Outline thickness in px.",
+        "--outline",
+        type=int,
+        default=2,
+        help="Outline thickness in px.",
     )
     parser.add_argument(
-        "--margin-v", type=int, default=80,
+        "--margin-v",
+        type=int,
+        default=80,
         help="Bottom margin in PX of the source video (we set PlayResX/Y to "
-             "the source resolution so MarginV maps 1:1 to pixels).",
+        "the source resolution so MarginV maps 1:1 to pixels).",
     )
     parser.add_argument(
-        "--play-res", default="auto",
+        "--play-res",
+        default="auto",
         help="libass PlayRes as 'WxH', or 'auto' to probe the input MP4. "
-             "Setting this makes FontSize and MarginV act in source pixels.",
+        "Setting this makes FontSize and MarginV act in source pixels.",
     )
     parser.add_argument(
-        "--alignment", type=int, default=2,
+        "--alignment",
+        type=int,
+        default=2,
         help="libass alignment: 1=bottom-left, 2=bottom-center, 3=bottom-right, "
-             "7=top-left, 8=top-center, 9=top-right. Default 2.",
+        "7=top-left, 8=top-center, 9=top-right. Default 2.",
     )
     parser.add_argument("--crf", type=int, default=20)
     parser.add_argument(
-        "--preset", default="medium",
-        choices=["ultrafast", "superfast", "veryfast", "faster", "fast",
-                 "medium", "slow", "slower", "veryslow"],
+        "--preset",
+        default="medium",
+        choices=[
+            "ultrafast",
+            "superfast",
+            "veryfast",
+            "faster",
+            "fast",
+            "medium",
+            "slow",
+            "slower",
+            "veryslow",
+        ],
     )
     parser.add_argument("--ffmpeg-path", default="ffmpeg")
     args = parser.parse_args()
@@ -216,14 +248,22 @@ def main() -> int:
     cmd = [
         ffmpeg_bin,
         "-y",
-        "-i", str(in_path),
-        "-vf", vf,
-        "-c:v", "libx264",
-        "-pix_fmt", "yuv420p",
-        "-crf", str(args.crf),
-        "-preset", args.preset,
-        "-c:a", "copy",
-        "-movflags", "+faststart",
+        "-i",
+        str(in_path),
+        "-vf",
+        vf,
+        "-c:v",
+        "libx264",
+        "-pix_fmt",
+        "yuv420p",
+        "-crf",
+        str(args.crf),
+        "-preset",
+        args.preset,
+        "-c:a",
+        "copy",
+        "-movflags",
+        "+faststart",
         str(out_path),
     ]
     print("==> burning subtitles", file=sys.stderr)

--- a/tests/test_skill_subtitle_burner.py
+++ b/tests/test_skill_subtitle_burner.py
@@ -1,0 +1,93 @@
+"""subtitle-burner skill — load, eligibility, and path escaping tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from agentos.skills.eligibility import EligibilityContext, check_eligibility
+from agentos.skills.loader import SkillLoader
+
+ROOT = Path(__file__).resolve().parents[1]
+BUNDLED = ROOT / "src" / "agentos" / "skills" / "bundled"
+SCRIPTS = BUNDLED / "subtitle-burner" / "scripts"
+
+
+def _spec() -> object:
+    return SkillLoader(bundled_dir=BUNDLED).get_by_name("subtitle-burner")
+
+
+def _burn_module() -> object:
+    sys.path.insert(0, str(SCRIPTS))
+    try:
+        import burn  # type: ignore[import-not-found]
+    finally:
+        sys.path.pop(0)
+    return burn
+
+
+def test_skill_loads() -> None:
+    spec = _spec()
+    assert spec is not None
+    assert spec.name == "subtitle-burner"
+    assert spec.provenance.origin == "agentos-original"
+    assert spec.provenance.license == "MIT"
+
+
+def test_eligibility_with_bins(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "agentos.skills.eligibility.shutil.which",
+        lambda name: f"/usr/bin/{name}" if name in {"python", "python3", "ffmpeg"} else None,
+    )
+    spec = _spec()
+    assert spec is not None
+    assert check_eligibility(spec, EligibilityContext.auto())
+
+
+@pytest.mark.parametrize(
+    ("raw_path", "expected"),
+    [
+        # Standard POSIX paths without colons
+        ("/home/user/video.srt", "/home/user/video.srt"),
+        # POSIX paths with colons at various positions (including indices 0, 1, 2)
+        ("/a:b/sub.srt", "/a\\:b/sub.srt"),
+        (":leading.srt", "\\:leading.srt"),
+        ("08:30.srt", "08\\:30.srt"),
+        ("10:00:00.srt", "10\\:00\\:00.srt"),
+        ("/tmp/2026-09-11_08:30:00/sub.srt", "/tmp/2026-09-11_08\\:30\\:00/sub.srt"),
+        # Windows drive paths (drive letter colon escaped as C\:, others escaped as \:)
+        (r"C:\Users\test\video.srt", "C\\:/Users/test/video.srt"),
+        (r"C:\Users\test\08:30:00.srt", "C\\:/Users/test/08\\:30\\:00.srt"),
+        (r"C:\a:b:c\sub.srt", "C\\:/a\\:b\\:c/sub.srt"),
+        ("D:/media/clip_01:23.srt", "D\\:/media/clip_01\\:23.srt"),
+        # Single quotes inside path
+        ("/path/with 'quotes'/sub.srt", "/path/with \\'quotes\\'/sub.srt"),
+        (
+            r"C:\path with 'quotes'\08:30.srt",
+            "C\\:/path with \\'quotes\\'/08\\:30.srt",
+        ),
+    ],
+)
+def test_escape_subtitle_path(raw_path: str, expected: str) -> None:
+    burn = _burn_module()
+    assert burn._escape_subtitle_path(raw_path) == expected
+
+
+def test_missing_files_exit_1(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    burn = _burn_module()
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "burn.py",
+            "--input",
+            str(tmp_path / "nonexistent.mp4"),
+            "--subtitles",
+            str(tmp_path / "nonexistent.srt"),
+            "--output",
+            str(tmp_path / "out.mp4"),
+        ],
+    )
+    assert burn.main() == 1


### PR DESCRIPTION
Fixes #1719

## Summary
Fixes a bug in the `subtitle-burner` bundled skill where `_escape_subtitle_path` only sliced at `normalised[3:]` under the assumption that all paths begin with a 3-character Windows drive-letter prefix (`C\:`). When subtitle paths on POSIX systems or relative paths with timestamps (e.g. `08:30.srt`, `10:00:00.srt`, `/a:b/sub.srt`) contain colons in the leading characters, they were left unescaped. This caused ffmpeg's `subtitles='...':force_style='...'` filter parser to misinterpret the unescaped colons as filter option separators and fail.

## What was changed
- Updated `_escape_subtitle_path` in `src/agentos/skills/bundled/subtitle-burner/scripts/burn.py` to explicitly check for a Windows drive letter prefix.
- If a drive letter is present, escape the drive colon as `C\:` and escape all subsequent colons in the path as `\:`.
- If no drive letter is present (POSIX / relative paths), escape all colons as `\:`.
- Added comprehensive unit tests in `tests/test_skill_subtitle_burner.py` validating Windows drive paths, relative timestamped files, POSIX paths with colons, single quote escaping, skill metadata loading, and eligibility.

## Quality Gate Verification
- `uv run ruff check src/agentos/skills/bundled/subtitle-burner tests/test_skill_subtitle_burner.py` (All checks passed)
- `uv run ruff format --check src/agentos/skills/bundled/subtitle-burner tests/test_skill_subtitle_burner.py` (Clean)
- `uv run mypy src/agentos --show-error-codes` (Success: no issues found in 625 source files)
- `uv run pytest tests/test_skill_subtitle_burner.py -v` (15 passed)
