### PR TITLE
fix(scheduler): handle delivery=None gracefully on job update

### DIFF
--- a/src/agentos/gateway/rpc_cron.py
+++ b/src/agentos/gateway/rpc_cron.py
@@ -997,7 +997,9 @@ async def _handle_cron_update(params: dict | None, ctx: RpcContext) -> dict[str,
         effective_target = patch.get("session_target", current_job.session_target)
         _ensure_delivery_supported(session_target=effective_target, delivery_raw=delivery_raw)
         await _ensure_delivery_targets_valid(ctx, delivery_raw)
-        if isinstance(delivery_raw, dict) and delivery_raw.get("mode") == "none":
+        if delivery_raw is None or (
+            isinstance(delivery_raw, dict) and delivery_raw.get("mode") == "none"
+        ):
             patch["delivery"] = DeliveryConfig()
         elif _is_webhook_delivery(delivery_raw):
             new_delivery = _build_webhook_delivery(delivery_raw)

--- a/src/agentos/scheduler/jobs.py
+++ b/src/agentos/scheduler/jobs.py
@@ -193,6 +193,7 @@ async def execute_with_timeout(job: CronJob, handler: HandlerFn) -> JobExecution
     # site so all failure paths reach the FD uniformly.
     if (
         not execution.success
+        and job.delivery is not None
         and job.delivery.failure_destination is not None
         and _failure_dispatcher is not None
     ):

--- a/src/agentos/scheduler/ops.py
+++ b/src/agentos/scheduler/ops.py
@@ -155,19 +155,20 @@ def _validate_main_agent(payload: dict | None, session_target: SessionTarget) ->
 def _normalize_delivery_for_target(
     *,
     session_target: SessionTarget,
-    delivery: DeliveryConfig,
+    delivery: DeliveryConfig | None,
     explicit_delivery: bool,
 ) -> DeliveryConfig:
-    if delivery is not None and delivery.mode == DeliveryMode.WEBHOOK:
+    delivery = delivery or DeliveryConfig()
+    if delivery.mode == DeliveryMode.WEBHOOK:
         validate_webhook_url(delivery.webhook_url)
-    fd = delivery.failure_destination if delivery is not None else None
+    fd = delivery.failure_destination
     if fd is not None and fd.mode == DeliveryMode.WEBHOOK:
         validate_webhook_url(fd.webhook_url)
     if session_target != SessionTarget.MAIN:
         return delivery
     # Webhook delivery is allowed for any sessionTarget — the heartbeat
     # pipeline ignores it and the webhook POST is independent of session.
-    if delivery is not None and delivery.mode == DeliveryMode.WEBHOOK:
+    if delivery.mode == DeliveryMode.WEBHOOK:
         return delivery
     if _delivery_requested(delivery):
         if explicit_delivery:
@@ -431,7 +432,7 @@ class SchedulerOps:
             else:
                 job.payload = {**job.payload, **payload_patch}
         if "delivery" in patch:
-            job.delivery = patch.pop("delivery")
+            job.delivery = patch.pop("delivery") or DeliveryConfig()
 
         (
             job.handler_key,

--- a/src/agentos/scheduler/persistence.py
+++ b/src/agentos/scheduler/persistence.py
@@ -227,8 +227,10 @@ def _parse_wake_mode(raw: object) -> CronWakeMode:
 
 def _effective_delivery_for_target(
     session_target: SessionTarget,
-    delivery: DeliveryConfig,
+    delivery: DeliveryConfig | None,
 ) -> DeliveryConfig:
+    if delivery is None:
+        return DeliveryConfig()
     if (
         session_target == SessionTarget.MAIN
         and delivery.mode != DeliveryMode.NONE
@@ -266,7 +268,9 @@ def _serialize_failure_destination(fd: FailureDestination | None) -> dict | None
     }
 
 
-def _serialize_delivery(delivery: DeliveryConfig) -> str:
+def _serialize_delivery(delivery: DeliveryConfig | None) -> str:
+    if delivery is None:
+        delivery = DeliveryConfig()
     snapshot = delivery.originating_reply_target
     return json.dumps(
         {

--- a/tests/test_scheduler/test_update_job_delivery_none.py
+++ b/tests/test_scheduler/test_update_job_delivery_none.py
@@ -1,0 +1,175 @@
+"""Regression tests: clearing or passing delivery=None during job updates.
+
+Passing delivery=None when updating a job should safely reset delivery to a default
+DeliveryConfig instance rather than raising AttributeError during serialization or
+execution.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agentos.gateway.rpc import RpcContext
+from agentos.gateway.rpc_cron import _handle_cron_update
+from agentos.scheduler.jobs import execute_with_timeout
+from agentos.scheduler.ops import SchedulerOps, _normalize_delivery_for_target
+from agentos.scheduler.persistence import (
+    JobStore,
+    _effective_delivery_for_target,
+    _serialize_delivery,
+)
+from agentos.scheduler.types import (
+    CronJob,
+    DeliveryConfig,
+    DeliveryMode,
+    ScheduleKind,
+    SessionTarget,
+)
+
+
+@pytest.fixture
+async def scheduler_ops(tmp_path) -> SchedulerOps:
+    store = JobStore(str(tmp_path / "scheduler.db"))
+    await store.open()
+    ops = SchedulerOps(store)
+    yield ops
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_update_job_delivery_none_resets_to_default_delivery(
+    scheduler_ops: SchedulerOps,
+) -> None:
+    """Updating a job with delivery=None clears delivery config and saves cleanly."""
+    job = await scheduler_ops.add(
+        name="test-delivery-reset",
+        schedule_kind=ScheduleKind.CRON,
+        schedule_value="*/5 * * * *",
+        session_target=SessionTarget.ISOLATED,
+        delivery=DeliveryConfig(
+            mode=DeliveryMode.CHANNEL,
+            channel_name="slack",
+            channel_id="C12345",
+        ),
+    )
+    assert job.delivery.mode == DeliveryMode.CHANNEL
+    assert job.delivery.channel_name == "slack"
+
+    # Patch job with delivery=None to reset/clear delivery
+    updated = await scheduler_ops.update(job.id, delivery=None)
+    assert updated is not None
+    assert updated.delivery is not None
+    assert updated.delivery.mode == DeliveryMode.NONE
+    assert updated.delivery.channel_name == ""
+
+    # Verify persisted state can be re-read from the store
+    loaded = await scheduler_ops.get(job.id)
+    assert loaded is not None
+    assert loaded.delivery is not None
+    assert loaded.delivery.mode == DeliveryMode.NONE
+
+
+def test_normalize_delivery_for_target_none_defaults_to_delivery_config() -> None:
+    """_normalize_delivery_for_target safely returns DeliveryConfig for None."""
+    res_isolated = _normalize_delivery_for_target(
+        session_target=SessionTarget.ISOLATED,
+        delivery=None,
+        explicit_delivery=True,
+    )
+    assert isinstance(res_isolated, DeliveryConfig)
+    assert res_isolated.mode == DeliveryMode.NONE
+
+    res_main = _normalize_delivery_for_target(
+        session_target=SessionTarget.MAIN,
+        delivery=None,
+        explicit_delivery=True,
+    )
+    assert isinstance(res_main, DeliveryConfig)
+    assert res_main.mode == DeliveryMode.NONE
+
+
+def test_persistence_serialize_delivery_none_safe() -> None:
+    """_serialize_delivery safely handles delivery=None without AttributeError."""
+    serialized = _serialize_delivery(None)
+    data = json.loads(serialized)
+    assert data["schema_version"] == 4
+    assert data["mode"] == "none"
+
+
+def test_persistence_effective_delivery_for_target_none_safe() -> None:
+    """_effective_delivery_for_target safely handles delivery=None."""
+    res = _effective_delivery_for_target(SessionTarget.MAIN, None)
+    assert isinstance(res, DeliveryConfig)
+    assert res.mode == DeliveryMode.NONE
+
+
+@pytest.mark.asyncio
+async def test_rpc_cron_update_handles_delivery_none() -> None:
+    """cron.update RPC endpoint accepts delivery=None to clear delivery."""
+    current = CronJob(
+        id="job-rpc-reset",
+        name="hook",
+        cron_expr="*/5 * * * *",
+        schedule_raw="*/5 * * * *",
+        handler_key="agent_run",
+        payload={"kind": "agent_turn", "task": "x", "agent_id": "main"},
+        session_target=SessionTarget.ISOLATED,
+        delivery=DeliveryConfig(
+            mode=DeliveryMode.CHANNEL,
+            channel_name="slack",
+            channel_id="C12345",
+        ),
+    )
+
+    class _FakeScheduler:
+        def __init__(self, job: CronJob) -> None:
+            self.job = job
+            self.last_patch: dict | None = None
+
+        async def get_job(self, job_id: str) -> CronJob | None:
+            return self.job if self.job.id == job_id else None
+
+        async def update_job(self, job_id: str, **patch) -> CronJob:
+            self.last_patch = patch
+            for k, v in patch.items():
+                setattr(self.job, k, v)
+            return self.job
+
+    sched = _FakeScheduler(current)
+    ctx = RpcContext(conn_id="test-conn", cron_scheduler=sched)
+
+    await _handle_cron_update(
+        {"id": "job-rpc-reset", "delivery": None},
+        ctx,
+    )
+
+    assert sched.last_patch is not None
+    assert "delivery" in sched.last_patch
+    assert isinstance(sched.last_patch["delivery"], DeliveryConfig)
+    assert sched.last_patch["delivery"].mode == DeliveryMode.NONE
+
+
+@pytest.mark.asyncio
+async def test_execute_with_timeout_failure_handles_delivery_without_failure_destination() -> None:
+    """Failed execution handles default delivery safely."""
+
+    async def _failing_handler(job):
+        raise RuntimeError("boom")
+
+    job = CronJob(
+        id="job-fail-test",
+        name="job-fail-test",
+        cron_expr="* * * * *",
+        handler_key="agent_run",
+        session_target=SessionTarget.ISOLATED,
+        delivery=DeliveryConfig(),
+    )
+
+    execution = await execute_with_timeout(
+        job=job,
+        handler=_failing_handler,
+    )
+    assert not execution.success
+    assert "boom" in (execution.error or "")


### PR DESCRIPTION
## Problem

When updating an existing scheduled job to reset or clear its delivery configuration by passing `delivery=None` (via `SchedulerOps.update(job_id, delivery=None)` or `scheduler.update_job(job_id, delivery=None)`), `ops.py` assigned `job.delivery = patch.pop("delivery")` which left `job.delivery` as `None`.

`_normalize_delivery_for_target` returned `delivery` unmodified when `delivery` was `None`. Immediately following this, when `await self._store.save(job)` was called, `persistence._serialize_delivery(job.delivery)` attempted to read `delivery.originating_reply_target`, raising:
```
AttributeError: 'NoneType' object has no attribute 'originating_reply_target'
```

Additionally:
- If execution failed on any job where `delivery` was `None`, `execute_with_timeout` in `src/agentos/scheduler/jobs.py` crashed on `job.delivery.failure_destination` with `AttributeError: 'NoneType' object has no attribute 'failure_destination'`.
- In `src/agentos/gateway/rpc_cron.py`, passing `delivery: None` in a `cron.update` request was ignored rather than resetting the delivery configuration to default.

## Fix

1. `src/agentos/scheduler/ops.py`:
   - In `_normalize_delivery_for_target`: initialize `delivery = delivery or DeliveryConfig()` so `delivery` is always guaranteed to be a valid `DeliveryConfig` instance and never returns `None`.
   - In `update`: default `job.delivery = patch.pop("delivery") or DeliveryConfig()`.
2. `src/agentos/scheduler/persistence.py`:
   - Guard `_serialize_delivery` and `_effective_delivery_for_target` against `delivery is None`, defaulting safely to `DeliveryConfig()`.
3. `src/agentos/scheduler/jobs.py`:
   - In `execute_with_timeout`: guard `job.delivery is not None` before accessing `job.delivery.failure_destination`.
4. `src/agentos/gateway/rpc_cron.py`:
   - In `_handle_cron_update`: support `delivery_raw is None` alongside `delivery_raw.get("mode") == "none"` to reset `patch["delivery"] = DeliveryConfig()`.

## Tests

Added regression test suite in `tests/test_scheduler/test_update_job_delivery_none.py`:
- `test_update_job_delivery_none_resets_to_default_delivery`: verifies `ops.update(job.id, delivery=None)` clears delivery, saves cleanly, and can be retrieved from persistent storage.
- `test_normalize_delivery_for_target_none_defaults_to_delivery_config`: verifies normalization produces `DeliveryConfig` for both isolated and main session targets.
- `test_persistence_serialize_delivery_none_safe`: ensures serialization handles `None` without `AttributeError`.
- `test_persistence_effective_delivery_for_target_none_safe`: ensures target delivery resolution handles `None`.
- `test_rpc_cron_update_handles_delivery_none`: verifies `cron.update` RPC accepts `delivery: None` and updates the delivery config.
- `test_execute_with_timeout_failure_handles_delivery_without_failure_destination`: verifies failed runs complete without crashing when delivery has no failure destination.

## Verification

- `uv run ruff check src/agentos/scheduler src/agentos/gateway/rpc_cron.py tests/test_scheduler/test_update_job_delivery_none.py` — passed
- `uv run mypy src/agentos --show-error-codes` — passed (625 files checked, 0 errors)
- `uv run pytest tests/test_scheduler/test_update_job_delivery_none.py tests/test_gateway/test_rpc_cron_delivery_target.py tests/test_scheduler/test_rpc_webhook_delivery.py -q` — passed
- `uv build --wheel` — passed

Fixes #1722
