### PR TITLE
fix(tools): treat a newline as a command separator when gating env-dump redaction

### DIFF
--- a/src/agentos/redact.py
+++ b/src/agentos/redact.py
@@ -660,17 +660,30 @@ def _has_known_prefix(text: str) -> bool:
 
 _ENV_DUMP_COMMANDS = frozenset({"env", "printenv", "set", "export", "declare"})
 
+#: The separators that end one command and start the next. A newline is one of
+#: them — in POSIX shell it does the same job as ``;`` — and ``exec_command``
+#: hands the whole string to ``create_subprocess_shell``, so a two-line script
+#: is an ordinary thing for an agent to run. Leaving ``\n`` out classified
+#: ``cd /srv\nprintenv`` as not-a-dump while the identical ``cd /srv &&
+#: printenv`` was masked.
+_SEGMENT_SEPARATOR_RE = re.compile(r"[|;&\n\r]+")
+
+#: ``(printenv)`` and ``(cd /srv; printenv)`` keep the grouping character glued
+#: to the command by the time ``shlex`` is done with them.
+_SHELL_GROUPING_CHARS = "(){}"
+
 
 def is_env_dump_command(command: str | None) -> bool:
     """Return whether *command* prints the environment to stdout.
 
-    Checks the first token of every pipeline or sequence segment. Conservative:
-    anything it cannot parse is reported as not-a-dump, and the caller falls
-    back to the pass that has fewer false positives.
+    Checks the first token of every pipeline or sequence segment, with shell
+    grouping characters stripped off. Conservative: anything it cannot parse is
+    reported as not-a-dump, and the caller falls back to the pass that has
+    fewer false positives.
     """
     if not command or not isinstance(command, str):
         return False
-    for segment in re.split(r"[|;&]+", command):
+    for segment in _SEGMENT_SEPARATOR_RE.split(command):
         segment = segment.strip()
         if not segment:
             continue
@@ -678,6 +691,11 @@ def is_env_dump_command(command: str | None) -> bool:
             tokens = shlex.split(segment)
         except ValueError:
             tokens = segment.split()
+        tokens = [
+            stripped
+            for stripped in (token.strip(_SHELL_GROUPING_CHARS) for token in tokens)
+            if stripped
+        ]
         if tokens and tokens[0] in _ENV_DUMP_COMMANDS:
             return True
     return False

--- a/tests/test_security/test_redact.py
+++ b/tests/test_security/test_redact.py
@@ -211,10 +211,46 @@ class TestTerminalOutput:
             ("cat notes.txt", False),
             ("echo env", False),
             ("", False),
+            # A newline separates commands exactly like ``;`` does, and a
+            # two-line script is what an agent writes when it needs a cwd.
+            pytest.param("cd /srv/app\nprintenv", True, id="newline-separator"),
+            pytest.param("cd /srv\r\nprintenv", True, id="crlf-separator"),
+            pytest.param("cat x\nenv\ncat y", True, id="dump-on-an-inner-line"),
+            # Grouping keeps the command glued to a paren once shlex is done.
+            pytest.param("(printenv)", True, id="parenthesised"),
+            pytest.param("(cd /srv; printenv)", True, id="parenthesised-sequence"),
+            # The same shapes with no dump in them stay out.
+            pytest.param("git log --oneline\ngit status", False, id="multi-line-non-dump"),
+            pytest.param('grep "(env)" notes.txt', False, id="parens-in-a-pattern"),
+            pytest.param("echo 'set'\nls", False, id="quoted-keyword-on-a-line"),
+            pytest.param("node --env-file=.env app.js", False, id="env-inside-a-flag"),
         ],
     )
     def test_env_dump_detection(self, command: str, expected: bool) -> None:
         assert redact.is_env_dump_command(command) is expected
+
+    def test_a_multi_line_dump_is_masked_like_its_one_line_twin(self) -> None:
+        """``cd x`` + newline + ``printenv`` runs what ``cd x && printenv`` runs.
+
+        The secret here is deliberately opaque rather than vendor-prefixed:
+        ``_redact_value_shapes`` catches the prefixed shapes with no help from
+        the gate, so only an opaque value proves the assignment pass ran.
+        """
+        output = "DEPLOY_API_KEY=9f2b7c41ae55d0e3bb84\nPATH=/usr/bin\n"
+        chained = redact.redact_terminal_output(output, "cd /srv/app && printenv")
+        multi_line = redact.redact_terminal_output(output, "cd /srv/app\nprintenv")
+        assert "9f2b7c41ae55d0e3bb84" not in multi_line
+        assert multi_line == chained
+        assert "PATH=/usr/bin" in multi_line
+
+    def test_a_grouped_dump_is_masked(self) -> None:
+        out = redact.redact_terminal_output("DB_PASSWORD=hunter2hunter2hunter2\n", "(printenv)")
+        assert "hunter2hunter2hunter2" not in out
+
+    def test_a_multi_line_ordinary_command_keeps_its_assignments(self) -> None:
+        """The widened split must not drag ordinary output into the pass."""
+        out = redact.redact_terminal_output("MAX_TOKENS=4096\n", "cd /srv\ncat config.py")
+        assert out == "MAX_TOKENS=4096\n"
 
 
 def test_the_disable_switch_is_read_once_at_import(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Fixes #1721

## The bug

`redact_terminal_output` decides whether to run the **assignment pass** — the one that masks `NAME=secret` — by asking `is_env_dump_command`. That helper split the command into segments on `[|;&]+` only:

```python
for segment in re.split(r"[|;&]+", command):
```

A newline is missing from that class, and in POSIX shell a newline ends a command exactly the way `;` does. `exec_command` hands the whole string to `create_subprocess_shell` (`tools/builtin/shell.py`), so a two-line script is simply what an agent writes when it needs a working directory first. The result is that two commands which run the *same two programs* get opposite redaction:

| command | classified as dump | `DEPLOY_API_KEY=9f2b7c41ae55d0e3bb84` comes back as |
|---|---|---|
| `printenv` | ✅ | `DEPLOY_API_KEY=9f2b7c***bb84` |
| `cd /srv/app && printenv` | ✅ | `DEPLOY_API_KEY=9f2b7c***bb84` |
| `cd /srv/app\nprintenv` | ❌ | `DEPLOY_API_KEY=9f2b7c41ae55d0e3bb84` |
| `(printenv)` | ❌ | `DEPLOY_API_KEY=9f2b7c41ae55d0e3bb84` |

Measured on `main` @ `4ca69fff`, not inferred — the table above is the actual return value of `redact_terminal_output` for each command.

`_redact_value_shapes` runs unconditionally, so vendor-prefixed keys (`sk-ant-…`, `ghp_…`) and JWTs were still masked. What leaked is precisely the **opaque, non-vendor-prefixed** material the assignment pass exists for: database passwords, internal API keys, custom tokens. Two first-class surfaces are affected — `exec_command` on all three backends, and `background_process` polling at `shell.py:1180`, which redacts with the same stored `session.command`.

The grouping shape is the same root cause one step further along: `shlex.split("(printenv)")` returns `["(printenv)"]`, so the paren is still glued to the command when the membership test runs.

## The fix

Two changes inside `is_env_dump_command`, both in the direction the docstring already promised ("the first token of every pipeline or sequence segment"):

```python
_SEGMENT_SEPARATOR_RE = re.compile(r"[|;&\n\r]+")
_SHELL_GROUPING_CHARS = "(){}"
...
    for segment in _SEGMENT_SEPARATOR_RE.split(command):
        ...
        tokens = [
            stripped
            for stripped in (token.strip(_SHELL_GROUPING_CHARS) for token in tokens)
            if stripped
        ]
```

Only the first surviving token is ever tested, so stripping is a no-op on every ordinary command. `_ENV_DUMP_COMMANDS` is untouched, the `shlex` / `str.split` fallback is untouched, and the helper keeps its documented conservative bias: anything it cannot parse still reads as not-a-dump.

`reads_credential_file` — the other half of the same gate — was checked and needs no change: it runs `shlex.split` over the whole command, which already treats a newline as whitespace.

No CLI surface (command, flag, config key, port, path) changes, so `SKILL.md` and `docs/cli.md` stay as they are.

## Tests

`tests/test_security/test_redact.py`, extending the existing `TestTerminalOutput` class — 9 new rows on the `test_env_dump_detection` table plus 3 behavioural cases, 12 in all, offline and deterministic.

**Fail without the fix (7):**

- `newline-separator` — `cd /srv/app\nprintenv`
- `crlf-separator` — `cd /srv\r\nprintenv`
- `dump-on-an-inner-line` — `cat x\nenv\ncat y`, the dump neither first nor last
- `parenthesised` — `(printenv)`
- `parenthesised-sequence` — `(cd /srv; printenv)`
- `test_a_multi_line_dump_is_masked_like_its_one_line_twin` — asserts the multi-line output is **byte-identical** to the `&&` form's, not merely masked, so the two spellings cannot drift apart again
- `test_a_grouped_dump_is_masked`

**Pass either way by design (5)** — these are the guard rail for the widened split, and the reason they are worth having is that the split is the risky half of the change:

- `multi-line-non-dump` — `git log --oneline\ngit status`
- `parens-in-a-pattern` — `grep "(env)" notes.txt`, where the parens belong to a search pattern, not to grouping
- `quoted-keyword-on-a-line` — `echo 'set'\nls`
- `env-inside-a-flag` — `node --env-file=.env app.js`
- `test_a_multi_line_ordinary_command_keeps_its_assignments` — `cd /srv\ncat config.py` must still return `MAX_TOKENS=4096` untouched

The secret fixtures are deliberately opaque rather than vendor-prefixed. A `ghp_…` value would be masked by `_redact_value_shapes` whatever the gate decided, so it would prove nothing about the gate; an opaque value is the only evidence the assignment pass actually ran.

The existing six rows on that table are all single-line, which is why this shape survived since the helper landed in `590753d2f` (2026-07-31).

## Verification

Self-test — source reverted to `upstream/main` with the new tests in place:

```
$ git show upstream/main:src/agentos/redact.py > src/agentos/redact.py
$ uv run pytest tests/test_security/test_redact.py -q
7 failed, 70 passed
```

With the fix, and the full gate exactly as `.github/workflows/ci.yml` runs it:

```
$ uv run pytest tests/test_security/test_redact.py -q
77 passed in 0.16s

$ uv run ruff check src tests
All checks passed!

$ uv run mypy src/agentos --show-error-codes
Success: no issues found in 625 source files

$ uv run pytest tests -q
6 failed, 10448 passed, 34 skipped, 3 errors in 258.31s
```

The 9 non-passing entries in the full run are pre-existing and environmental, not from this change. I confirmed this by stashing the diff and re-running the same selection on pristine `upstream/main`, which reproduces the identical set:

- `test_pilot_encoder` (2) and `test_pilot_benchmark` (3 errors) — `onnxruntime` cannot load the local MiniLM asset (`INVALID_PROTOBUF`); the model blob is not hydrated in this checkout.
- `test_build_wheelhouse_zip` (3) — the same missing embedding asset, reached through the packaging script.
- `test_tracked_public_files_do_not_carry_this_machines_timezone` (1) — the authoring guard that, as its own comment says, "fires on the machine where the mistake is being made and stays quiet in CI".

## One adjacent case, deliberately left alone

`for f in a b; do env; done` still reads as not-a-dump: the segment's first token is the `do` keyword, not the command. Covering shell keyword prefixes (`do`, `then`, `else`, `elif`) means teaching this helper a slice of shell grammar, which is a different change with its own false-positive surface — `then` and `do` appear as ordinary argument words too. Happy to follow up in a separate issue if that shape is worth closing; this PR stays on the two forms that need no grammar at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qk3sdfjuyj4cX2QdpuAfnV
