### PR TITLE
fix(engine): exempt all subagent session key shapes from router overriding and preflight compaction

### DIFF
--- a/src/agentos/engine/runtime.py
+++ b/src/agentos/engine/runtime.py
@@ -5237,7 +5237,7 @@ class TurnRunner:
         if tier_index(previous) not in {0, 1, 2}:
             return _T3_NOT_APPLICABLE
 
-        if session_key.startswith(("cron:", "subagent:")):
+        if session_key.startswith("cron:") or is_subagent_key(session_key):
             return _T3_NOT_APPLICABLE
 
         if self._session_manager is None:
@@ -5496,7 +5496,7 @@ class TurnRunner:
         if self._session_manager is None:
             return
         # Skip ephemeral sessions
-        if session_key.startswith(("cron:", "subagent:")):
+        if session_key.startswith("cron:") or is_subagent_key(session_key):
             return
         if self.has_compacted_this_turn(session_key):
             log.info(

--- a/src/agentos/engine/steps/agentos_router.py
+++ b/src/agentos/engine/steps/agentos_router.py
@@ -38,6 +38,7 @@ from agentos.router_tiers import (
     TIER_TO_ROUTE_CLASS,
     normalize_text_tier,
 )
+from agentos.session.keys import is_subagent_key
 
 log = structlog.get_logger(__name__)
 
@@ -1359,7 +1360,7 @@ async def apply_agentos_router(ctx: TurnContext) -> TurnContext:
         semantic_message = ctx.message
     if not semantic_message.strip():
         return ctx
-    if ":subagent:" in ctx.session_key:
+    if is_subagent_key(ctx.session_key):
         return ctx
 
     rollout_phase: str = getattr(router_cfg, "rollout_phase", "observe")

--- a/src/agentos/gateway/rpc_sessions.py
+++ b/src/agentos/gateway/rpc_sessions.py
@@ -54,7 +54,12 @@ from agentos.session.compaction_lifecycle import (
     durable_receipt_allows_destructive_compaction,
     new_compaction_id,
 )
-from agentos.session.keys import canonicalize_session_key, normalize_agent_id, parse_agent_id
+from agentos.session.keys import (
+    canonicalize_session_key,
+    is_subagent_key,
+    normalize_agent_id,
+    parse_agent_id,
+)
 from agentos.session.naming import normalize_session_name
 from agentos.session.runtime_state import evict_session_runtime_state
 from agentos.session.terminal_reply import build_terminal_reply, sanitize_agent_error
@@ -704,7 +709,7 @@ def _derive_source_metadata(session: Any) -> dict[str, Any]:
     elif ":cli:" in key or ":standalone:" in key:
         source_kind = source_kind or "cli"
         channel_kind = channel_kind or "cli"
-    elif ":subagent:" in key:
+    elif is_subagent_key(key):
         source_kind = source_kind or "subagent"
         channel_kind = channel_kind or "subagent"
     elif key.startswith("cron:") or ":cron:" in key:

--- a/tests/test_engine/test_subagent_session_key_routing_exemption.py
+++ b/tests/test_engine/test_subagent_session_key_routing_exemption.py
@@ -1,0 +1,73 @@
+"""Test subagent session key routing and metadata exemptions across key shapes."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from agentos.engine.pipeline import TurnContext
+from agentos.engine.steps.agentos_router import apply_agentos_router
+from agentos.gateway.rpc_sessions import _derive_source_metadata
+
+
+@pytest.mark.parametrize(
+    "subagent_key",
+    [
+        "subagent:agent:main:main:coder:1:abcd1234",
+        "subagent:agent:ops:direct:user1",
+        "subagent:worker-1",
+        "agent:main:subagent:run-123",
+        "agent:coder:subagent:task-99",
+    ],
+)
+async def test_apply_agentos_router_skips_all_subagent_key_shapes(subagent_key: str) -> None:
+    """All subagent session key formats must be exempted from router model override."""
+    cfg = SimpleNamespace(
+        agentos_router=SimpleNamespace(
+            enabled=True,
+            tiers={"c0": {"model": "cheap-model"}, "c1": {"model": "expensive-model"}},
+            rollout_phase="enforce",
+        )
+    )
+    ctx = TurnContext(
+        message="Translate this text or write complex code",
+        session_key=subagent_key,
+        config=cfg,
+        provider=None,
+        model="custom-subagent-model",
+        tool_defs=[],
+        system_prompt="You are a helpful assistant.",
+    )
+
+    result_ctx = await apply_agentos_router(ctx)
+
+    assert result_ctx.model == "custom-subagent-model"
+    assert "routed_tier" not in result_ctx.metadata
+    assert "routed_model" not in result_ctx.metadata
+
+
+@pytest.mark.parametrize(
+    "subagent_key",
+    [
+        "subagent:agent:main:main:coder:1:abcd1234",
+        "subagent:worker-1",
+        "agent:main:subagent:run-123",
+    ],
+)
+def test_session_source_metadata_identifies_subagents(subagent_key: str) -> None:
+    """Both prefix and infix subagent keys must report source_kind and channel_kind as subagent."""
+    session = SimpleNamespace(
+        session_key=subagent_key,
+        origin=None,
+        last_channel=None,
+        channel=None,
+        last_to=None,
+    )
+
+    kinds = _derive_source_metadata(session)
+
+    assert kinds["source_kind"] == "subagent"
+    assert kinds["sourceKind"] == "subagent"
+    assert kinds["channel_kind"] == "subagent"
+    assert kinds["channelKind"] == "subagent"


### PR DESCRIPTION
## Summary

In AgentOS, subagent sessions can be formed in two canonical shapes (`agentos.session.keys.is_subagent_key`):
- Prefix shape: `subagent:agent:<agent_id>:...` (created when spawning subagents from parent sessions in `agent.py`)
- Infix shape: `agent:<agent_id>:subagent:<run_id>` (created via `build_subagent_session_key`)

Several core modules previously used crude substring checks (`":subagent:" in key` or `key.startswith("subagent:")`), which caused subagents with `subagent:agent:...` keys to fail the check:

1. **Pilot Router (`src/agentos/engine/steps/agentos_router.py`):** `apply_agentos_router` checked `if ":subagent:" in ctx.session_key:`. Subagents spawned with `subagent:agent:...` failed this check, causing the Pilot Router to forcefully override the subagent's assigned model with a router tier.
2. **Gateway Session Metadata (`src/agentos/gateway/rpc_sessions.py`):** `_derive_source_metadata` checked `elif ":subagent:" in key:`, missing prefix-style subagent sessions and misclassifying their `source_kind` and `channel_kind`.
3. **TurnRunner Compaction (`src/agentos/engine/runtime.py`):** `_maybe_preflight_compact` and `_maybe_upgrade_t3_compaction` checked `if session_key.startswith(("cron:", "subagent:")):`, missing infix-style `agent:*:subagent:*` sessions.

This PR:
- Replaces raw substring checks with `is_subagent_key(session_key)` across `agentos_router.py`, `rpc_sessions.py`, and `runtime.py`.
- Adds unit tests in `tests/test_engine/test_subagent_session_key_routing_exemption.py` covering router model override exemption and session metadata resolution for all subagent key formats.

Fixes #1726

## Verification

- `uv run ruff check src/agentos/engine/steps/agentos_router.py src/agentos/gateway/rpc_sessions.py src/agentos/engine/runtime.py tests/test_engine/test_subagent_session_key_routing_exemption.py` (passed)
- `uv run ruff format --check src/agentos/engine/steps/agentos_router.py src/agentos/gateway/rpc_sessions.py src/agentos/engine/runtime.py tests/test_engine/test_subagent_session_key_routing_exemption.py` (passed)
- `uv run mypy src/agentos/engine/steps/agentos_router.py src/agentos/gateway/rpc_sessions.py --show-error-codes` (passed)
- `uv run pytest tests/test_engine/test_subagent_session_key_routing_exemption.py -v` (8 passed)
- `uv run pytest tests/test_engine/ tests/test_gateway/test_rpc_sessions*.py -k "subagent or router" -q` (139 passed)
