### PR TITLE
fix(channels): parse session keys systematically during approval callbacks

### DIFF
--- a/src/agentos/channels/discord.py
+++ b/src/agentos/channels/discord.py
@@ -505,7 +505,6 @@ class DiscordChannel:
             elif op == 11:  # Heartbeat ACK
                 self._state.last_heartbeat_ack = True
 
-
     async def _handle_dispatch(self, event_type: str | None, data: dict[str, Any]) -> None:
         if event_type == "READY":
             self._state.session_id = data["session_id"]
@@ -723,20 +722,22 @@ class DiscordChannel:
 
         session_key = entry.params.get("sessionKey")
         if isinstance(session_key, str) and session_key:
-            parts = session_key.split(":")
-            if parts and parts[0] == "subagent":
-                parts = parts[1:]
-            if len(parts) >= 5:
-                session_channel = parts[2]
-                session_mode = parts[3]
-                session_peer = parts[4]
-                expected_peer = channel_id if session_mode in ("group", "channel") else user_id
-                if session_channel != "discord" or session_peer != expected_peer:
+            from agentos.session.keys import parse_session_key
+
+            parsed = parse_session_key(session_key)
+            if parsed.channel and parsed.peer_id:
+                expected_peer = channel_id if parsed.chat_type in ("group", "channel") else user_id
+                peer_matches = (
+                    parsed.peer_id == expected_peer
+                    or parsed.peer_id == f"channel-{expected_peer}"
+                    or f"channel-{parsed.peer_id}" == expected_peer
+                )
+                if parsed.channel != "discord" or not peer_matches:
                     log.warning(
                         "discord.component_mismatch",
                         session_key=session_key,
                         expected_peer=expected_peer,
-                        session_peer=session_peer,
+                        session_peer=parsed.peer_id,
                     )
                     return
 
@@ -925,9 +926,7 @@ class DiscordChannel:
 
     def is_connected(self) -> bool:
         return (
-            self._connected
-            and self._dispatch_task is not None
-            and not self._dispatch_task.done()
+            self._connected and self._dispatch_task is not None and not self._dispatch_task.done()
         )
 
     async def health_check(self) -> ChannelHealth:
@@ -940,7 +939,6 @@ class DiscordChannel:
                 "sequence": self._state.sequence,
             },
         )
-
 
     # ------------------------------------------------------------------
     # Inbound

--- a/src/agentos/channels/slack.py
+++ b/src/agentos/channels/slack.py
@@ -908,20 +908,17 @@ class SlackChannel:
 
         session_key = entry.params.get("sessionKey")
         if isinstance(session_key, str) and session_key:
-            parts = session_key.split(":")
-            if parts and parts[0] == "subagent":
-                parts = parts[1:]
-            if len(parts) >= 5:
-                session_channel = parts[2]
-                session_mode = parts[3]
-                session_peer = parts[4]
-                expected_peer = channel_id if session_mode in ("group", "channel") else user_id
-                if session_channel != self.channel_id or session_peer != expected_peer:
+            from agentos.session.keys import parse_session_key
+
+            parsed = parse_session_key(session_key)
+            if parsed.channel and parsed.peer_id:
+                expected_peer = channel_id if parsed.chat_type in ("group", "channel") else user_id
+                if parsed.channel != self.channel_id or parsed.peer_id != expected_peer:
                     log.warning(
                         "slack.interactive_mismatch",
                         session_key=session_key,
                         expected_peer=expected_peer,
-                        session_peer=session_peer,
+                        session_peer=parsed.peer_id,
                     )
                     return
 

--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -959,15 +959,12 @@ class TelegramChannel:
 
         session_key = entry.params.get("sessionKey")
         if isinstance(session_key, str) and session_key:
-            parts = session_key.split(":")
-            if parts and parts[0] == "subagent":
-                parts = parts[1:]
-            if len(parts) >= 5:
-                session_channel = parts[2]
-                session_mode = parts[3]
-                session_peer = parts[4]
-                expected_peer = chat_id if session_mode in ("group", "channel") else sender_id
-                if session_channel != self.config.name or session_peer != expected_peer:
+            from agentos.session.keys import parse_session_key
+
+            parsed = parse_session_key(session_key)
+            if parsed.channel and parsed.peer_id:
+                expected_peer = chat_id if parsed.chat_type in ("group", "channel") else sender_id
+                if parsed.channel != self.config.name or parsed.peer_id != expected_peer:
                     try:
                         await self._api(
                             "answerCallbackQuery",

--- a/src/agentos/session/__init__.py
+++ b/src/agentos/session/__init__.py
@@ -12,6 +12,7 @@ from agentos.session.compaction import (
 from agentos.session.keys import (
     DmScope,
     PeerKind,
+    SessionKeyComponents,
     build_channel_key,
     build_cron_key,
     build_direct_key,
@@ -24,6 +25,7 @@ from agentos.session.keys import (
     derive_chat_type,
     normalize_account_id,
     normalize_agent_id,
+    parse_session_key,
     parse_thread_suffix,
 )
 from agentos.session.manager import SessionManager
@@ -73,6 +75,8 @@ __all__ = [
     "build_cron_key",
     "canonicalize_session_key",
     "parse_thread_suffix",
+    "parse_session_key",
+    "SessionKeyComponents",
     "derive_chat_type",
     "normalize_agent_id",
     "normalize_account_id",

--- a/src/agentos/session/keys.py
+++ b/src/agentos/session/keys.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from enum import StrEnum
 from functools import lru_cache
 
@@ -177,6 +178,180 @@ def build_cron_key(name: str, run_id: str) -> str:
     return f"cron:{name}:run:{run_id}"
 
 
+@dataclass(frozen=True, slots=True)
+class SessionKeyComponents:
+    """Structured representation of a parsed session key."""
+
+    agent_id: str = "main"
+    channel: str | None = None
+    account_id: str | None = None
+    chat_type: str = "unknown"
+    peer_id: str | None = None
+    thread_id: str | None = None
+    is_subagent: bool = False
+
+
+def parse_session_key(session_key: str | None) -> SessionKeyComponents:
+    """Parse a canonical or legacy session key into structured components.
+
+    Handles:
+    - Standard keys: ``agent:<aid>:<channel>:<kind>:<peer_id>``
+    - Account-scoped keys: ``agent:<aid>:<channel>:<account_id>:<kind>:<peer_id>``
+    - Direct per-peer keys: ``agent:<aid>:direct:<peer_id>``
+    - Main/WebChat keys: ``agent:<aid>:main``, ``agent:<aid>:webchat:<peer_id>``
+    - Subagent keys: ``subagent:...`` or ``agent:<aid>:subagent:<run_id>``
+    - Threaded/topic keys: ``...:thread:<id>``, ``...:topic:<id>``
+    - Cron keys: ``cron:<name>:run:<run_id>``
+    - Discord guild keys: ``agent:<aid>:discord:(<acc>:)?guild-<gid>:channel-<cid>``
+    """
+    raw = str(session_key or "").strip()
+    if not raw:
+        return SessionKeyComponents()
+
+    is_sub = is_subagent_key(raw)
+    key = raw
+    if key.lower().startswith("subagent:"):
+        key = key[len("subagent:") :]
+
+    base_key, thread_id = parse_thread_suffix(key)
+
+    if base_key.lower().startswith("cron:"):
+        parts = base_key.split(":")
+        peer = parts[1] if len(parts) >= 2 else None
+        return SessionKeyComponents(
+            agent_id="main",
+            channel="cron",
+            chat_type="cron",
+            peer_id=peer,
+            thread_id=thread_id,
+            is_subagent=is_sub,
+        )
+
+    if not base_key.lower().startswith("agent:"):
+        if ":" in base_key:
+            parts = base_key.split(":")
+            return SessionKeyComponents(
+                agent_id="main",
+                channel=parts[0],
+                peer_id=parts[-1],
+                thread_id=thread_id,
+                is_subagent=is_sub,
+            )
+        return SessionKeyComponents(
+            agent_id="main",
+            peer_id=base_key,
+            thread_id=thread_id,
+            is_subagent=is_sub,
+        )
+
+    parts = base_key.split(":")
+    agent_id = normalize_agent_id(parts[1]) if len(parts) >= 2 else "main"
+    rem = parts[2:] if len(parts) >= 3 else []
+
+    if not rem:
+        return SessionKeyComponents(agent_id=agent_id, is_subagent=is_sub, thread_id=thread_id)
+
+    if rem == ["main"]:
+        return SessionKeyComponents(
+            agent_id=agent_id,
+            chat_type="main",
+            peer_id="main",
+            thread_id=thread_id,
+            is_subagent=is_sub,
+        )
+
+    if rem[0] == "webchat":
+        peer = rem[1] if len(rem) >= 2 else "default"
+        return SessionKeyComponents(
+            agent_id=agent_id,
+            channel="webchat",
+            chat_type="direct",
+            peer_id=peer,
+            thread_id=thread_id,
+            is_subagent=is_sub,
+        )
+
+    if rem[0] == "direct":
+        peer = ":".join(rem[1:]) if len(rem) >= 2 else None
+        return SessionKeyComponents(
+            agent_id=agent_id,
+            channel=None,
+            chat_type="direct",
+            peer_id=peer,
+            thread_id=thread_id,
+            is_subagent=is_sub,
+        )
+
+    if rem[0] == "subagent":
+        peer = ":".join(rem[1:]) if len(rem) >= 2 else None
+        return SessionKeyComponents(
+            agent_id=agent_id,
+            chat_type="subagent",
+            peer_id=peer,
+            thread_id=thread_id,
+            is_subagent=True,
+        )
+
+    channel = rem[0]
+    sub_rem = rem[1:]
+    if not sub_rem:
+        return SessionKeyComponents(
+            agent_id=agent_id,
+            channel=channel,
+            thread_id=thread_id,
+            is_subagent=is_sub,
+        )
+
+    if sub_rem[0] in ("direct", "group", "channel", "dm"):
+        kind = "direct" if sub_rem[0] == "dm" else sub_rem[0]
+        peer = ":".join(sub_rem[1:]) if len(sub_rem) >= 2 else None
+        return SessionKeyComponents(
+            agent_id=agent_id,
+            channel=channel,
+            chat_type=kind,
+            peer_id=peer,
+            thread_id=thread_id,
+            is_subagent=is_sub,
+        )
+
+    if len(sub_rem) >= 2 and sub_rem[1] in ("direct", "group", "channel", "dm"):
+        acc = sub_rem[0]
+        kind = "direct" if sub_rem[1] == "dm" else sub_rem[1]
+        peer = ":".join(sub_rem[2:]) if len(sub_rem) >= 3 else None
+        return SessionKeyComponents(
+            agent_id=agent_id,
+            channel=channel,
+            account_id=acc,
+            chat_type=kind,
+            peer_id=peer,
+            thread_id=thread_id,
+            is_subagent=is_sub,
+        )
+
+    if channel == "discord" and any(
+        seg.startswith("guild-") or seg.startswith("channel-") for seg in sub_rem
+    ):
+        chan_seg = next((s for s in sub_rem if s.startswith("channel-")), "")
+        guild_seg = next((s for s in sub_rem if s.startswith("guild-")), "")
+        peer = chan_seg.removeprefix("channel-") if chan_seg else guild_seg.removeprefix("guild-")
+        return SessionKeyComponents(
+            agent_id=agent_id,
+            channel="discord",
+            chat_type="channel",
+            peer_id=peer or ":".join(sub_rem),
+            thread_id=thread_id,
+            is_subagent=is_sub,
+        )
+
+    return SessionKeyComponents(
+        agent_id=agent_id,
+        channel=channel,
+        peer_id=":".join(sub_rem),
+        thread_id=thread_id,
+        is_subagent=is_sub,
+    )
+
+
 def parse_agent_id(session_key: str) -> str:
     """Extract agent_id from a session key string. Fallback 'main'.
 
@@ -184,28 +359,20 @@ def parse_agent_id(session_key: str) -> str:
     'subagent:agent:ops:...'            -> 'ops'
     'cron:foo:run:abc'                  -> 'main'
     """
-    key = session_key.strip()
-    # subagent:agent:ops:... -> strip prefix, then parse as agent key
-    if key.startswith("subagent:agent:"):
-        key = key[len("subagent:") :]
-    if key.startswith("agent:"):
-        parts = key.split(":")
-        candidate = parts[1] if len(parts) >= 2 else ""
-        return normalize_agent_id(candidate) if candidate else "main"
-    return "main"
+    return parse_session_key(session_key).agent_id
 
 
 def derive_chat_type(session_key: str) -> str:
     """Derive chat type from session key tokens."""
     from agentos.session.models import ChatType
 
-    key = session_key.lower()
-    # Discord legacy pattern
-    if re.match(r"^agent:[^:]+:discord:(?:[^:]+:)?guild-[^:]+:channel-[^:]+", key):
-        return ChatType.CHANNEL
+    parsed = parse_session_key(session_key)
+    if parsed.chat_type in ("direct", "group", "channel"):
+        return parsed.chat_type
+    key = (session_key or "").lower()
     for token in ("group", "channel", "direct", "dm"):
         if f":{token}:" in key or key.endswith(f":{token}"):
             if token in ("direct", "dm"):
                 return ChatType.DIRECT
-            return token  # "group" or "channel"
+            return token
     return ChatType.UNKNOWN

--- a/tests/test_channels/test_channel_approvals.py
+++ b/tests/test_channels/test_channel_approvals.py
@@ -136,6 +136,89 @@ async def test_telegram_callback_query_session_mismatch() -> None:
 
 
 @pytest.mark.asyncio
+async def test_telegram_callback_query_account_and_topic_scoped_session_keys() -> None:
+    queue = get_approval_queue()
+
+    # 1. 6-part account-scoped session key (DmScope.PER_ACCOUNT_CHANNEL_PEER)
+    approval_id = queue.request(
+        "exec",
+        {
+            "argv": ["ls"],
+            "action_kind": "exec",
+            "sessionKey": "agent:main:telegram:bot-account-1:direct:12345",
+        },
+    )
+
+    channel = TelegramChannel(TelegramChannelConfig(token="test-token"))
+    calls = []
+
+    async def fake_api(method: str, payload: dict | None = None) -> Any:
+        calls.append((method, payload or {}))
+        return True
+
+    channel._api = fake_api
+
+    callback_query = {
+        "id": "cb123",
+        "from": {"id": 12345, "username": "bob"},
+        "message": {
+            "message_id": 999,
+            "chat": {"id": 12345, "type": "private"},
+            "text": "Do you want to run this command?",
+        },
+        "data": f"approve:{approval_id}",
+    }
+
+    admission_mock = ChannelAdmission("telegram", "12345", "grant1", 1)
+    with patch.object(channel.pairing_store, "admission", return_value=admission_mock):
+        await channel._handle_telegram_callback(callback_query)
+
+    entry = queue.get(approval_id)
+    assert entry.resolved is True
+    assert entry.approved is True
+    assert len(calls) == 2
+    assert calls[0][0] == "answerCallbackQuery"
+    assert calls[1][0] == "editMessageText"
+    calls.clear()
+
+    # 2. Topic-scoped group session key
+    group_channel = TelegramChannel(
+        TelegramChannelConfig(
+            token="test-token",
+            groups_enabled=True,
+            group_chat_ids=["-10012345"],
+        )
+    )
+    group_channel._api = fake_api
+    group_approval_id = queue.request(
+        "exec",
+        {
+            "argv": ["ls"],
+            "action_kind": "exec",
+            "sessionKey": "agent:main:telegram:group:-10012345:topic:99",
+        },
+    )
+    group_callback_query = {
+        "id": "cb456",
+        "from": {"id": 12345, "username": "bob"},
+        "message": {
+            "message_id": 1000,
+            "chat": {"id": -10012345, "type": "supergroup"},
+            "text": "Do you want to run this command?",
+        },
+        "data": f"approve:{group_approval_id}",
+    }
+    with patch.object(group_channel.pairing_store, "admission", return_value=admission_mock):
+        await group_channel._handle_telegram_callback(group_callback_query)
+
+    group_entry = queue.get(group_approval_id)
+    assert group_entry.resolved is True
+    assert group_entry.approved is True
+    assert calls[0][0] == "answerCallbackQuery"
+    assert calls[1][0] == "editMessageText"
+
+
+@pytest.mark.asyncio
 async def test_slack_interactive_payload_handling() -> None:
     queue = get_approval_queue()
     approval_id = queue.request("exec", {"argv": ["rm", "-rf"], "action_kind": "exec"})
@@ -403,6 +486,82 @@ async def test_discord_component_interaction_handling() -> None:
     msg = await channel.receive()
     assert msg.content == "Deny"
     assert msg.sender_id == "usr123"
+
+
+@pytest.mark.asyncio
+async def test_slack_interactive_account_and_thread_scoped_session_keys() -> None:
+    queue = get_approval_queue()
+    approval_id = queue.request(
+        "exec",
+        {
+            "argv": ["ls"],
+            "action_kind": "exec",
+            "sessionKey": "agent:ops:slack:acc1:direct:U12345",
+        },
+    )
+
+    channel = SlackChannel(token="xoxb-test", slack_channel_id="C12345")
+    channel.parse_event = lambda ev: IncomingMessage(
+        sender_id=ev["user"],
+        channel_id=ev["channel"],
+        content=ev["text"],
+    )
+
+    payload = {
+        "type": "block_actions",
+        "user": {"id": "U12345"},
+        "channel": {"id": "C12345"},
+        "response_url": "https://hooks.slack.com/actions/test",
+        "message": {"text": "Approve this execution?", "blocks": []},
+        "actions": [{"value": f"approve:{approval_id}"}],
+    }
+
+    class FakeResponse:
+        def raise_for_status(self):
+            pass
+
+    with patch("httpx.AsyncClient.post", return_value=FakeResponse()):
+        await channel._handle_slack_interactive(payload)
+
+    entry = queue.get(approval_id)
+    assert entry.resolved is True
+    assert entry.approved is True
+
+
+@pytest.mark.asyncio
+async def test_discord_component_account_and_guild_session_keys() -> None:
+    queue = get_approval_queue()
+    approval_id = queue.request(
+        "exec",
+        {
+            "argv": ["ls"],
+            "action_kind": "exec",
+            "sessionKey": "agent:ops:discord:acc1:direct:usr123",
+        },
+    )
+
+    channel = DiscordChannel(DiscordChannelConfig(token="test-token"))
+
+    class FakeResp:
+        def raise_for_status(self):
+            pass
+
+    channel._get_client = lambda: AsyncMock(post=AsyncMock(return_value=FakeResp()))
+
+    data = {
+        "type": 3,
+        "id": "int123",
+        "token": "token123",
+        "channel_id": "chan123",
+        "user": {"id": "usr123"},
+        "message": {"content": "Approval requested"},
+        "data": {"custom_id": f"approve:{approval_id}"},
+    }
+
+    await channel._handle_discord_component_interaction(data)
+    entry = queue.get(approval_id)
+    assert entry.resolved is True
+    assert entry.approved is True
 
 
 _PENDING_APPROVAL: dict[str, Any] = {

--- a/tests/test_session/test_parse_session_key.py
+++ b/tests/test_session/test_parse_session_key.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from agentos.session.keys import (
+    DmScope,
+    SessionKeyComponents,
+    build_channel_key,
+    build_cron_key,
+    build_direct_key,
+    build_group_key,
+    build_main_key,
+    build_subagent_key,
+    build_subagent_session_key,
+    build_thread_key,
+    build_webchat_key,
+    derive_chat_type,
+    parse_agent_id,
+    parse_session_key,
+)
+from agentos.session.models import ChatType
+
+
+def test_parse_empty_or_none() -> None:
+    assert parse_session_key(None) == SessionKeyComponents()
+    assert parse_session_key("") == SessionKeyComponents()
+    assert parse_session_key("   ") == SessionKeyComponents()
+
+
+def test_parse_main_key() -> None:
+    key = build_main_key("ops")
+    assert key == "agent:ops:main"
+    parsed = parse_session_key(key)
+    assert parsed.agent_id == "ops"
+    assert parsed.channel is None
+    assert parsed.chat_type == "main"
+    assert parsed.peer_id == "main"
+    assert not parsed.is_subagent
+
+
+def test_parse_webchat_key() -> None:
+    key = build_webchat_key("ops")
+    assert key == "agent:ops:webchat:default"
+    parsed = parse_session_key(key)
+    assert parsed.agent_id == "ops"
+    assert parsed.channel == "webchat"
+    assert parsed.chat_type == "direct"
+    assert parsed.peer_id == "default"
+
+
+def test_parse_direct_keys() -> None:
+    # PER_PEER
+    k1 = build_direct_key("ops", "user-1", dm_scope=DmScope.PER_PEER)
+    assert k1 == "agent:ops:direct:user-1"
+    p1 = parse_session_key(k1)
+    assert p1.agent_id == "ops"
+    assert p1.channel is None
+    assert p1.chat_type == "direct"
+    assert p1.peer_id == "user-1"
+
+    # PER_CHANNEL_PEER
+    k2 = build_direct_key("ops", "user-1", channel="slack", dm_scope=DmScope.PER_CHANNEL_PEER)
+    assert k2 == "agent:ops:slack:direct:user-1"
+    p2 = parse_session_key(k2)
+    assert p2.agent_id == "ops"
+    assert p2.channel == "slack"
+    assert p2.chat_type == "direct"
+    assert p2.peer_id == "user-1"
+
+    # PER_ACCOUNT_CHANNEL_PEER
+    k3 = build_direct_key(
+        "ops",
+        "user-1",
+        channel="telegram",
+        account_id="bot-account-1",
+        dm_scope=DmScope.PER_ACCOUNT_CHANNEL_PEER,
+    )
+    assert k3 == "agent:ops:telegram:bot-account-1:direct:user-1"
+    p3 = parse_session_key(k3)
+    assert p3.agent_id == "ops"
+    assert p3.channel == "telegram"
+    assert p3.account_id == "bot-account-1"
+    assert p3.chat_type == "direct"
+    assert p3.peer_id == "user-1"
+
+
+def test_parse_group_and_channel_keys() -> None:
+    gk = build_group_key("ops", "slack", "C12345")
+    assert gk == "agent:ops:slack:group:C12345"
+    pg = parse_session_key(gk)
+    assert pg.agent_id == "ops"
+    assert pg.channel == "slack"
+    assert pg.chat_type == "group"
+    assert pg.peer_id == "C12345"
+
+    ck = build_channel_key("ops", "discord", "chan-999")
+    assert ck == "agent:ops:discord:channel:chan-999"
+    pc = parse_session_key(ck)
+    assert pc.agent_id == "ops"
+    assert pc.channel == "discord"
+    assert pc.chat_type == "channel"
+    assert pc.peer_id == "chan-999"
+
+
+def test_parse_threaded_keys() -> None:
+    base = "agent:ops:telegram:acc1:direct:user-1"
+    topic_key = build_thread_key(base, "42", channel_hint="telegram")
+    assert topic_key == "agent:ops:telegram:acc1:direct:user-1:topic:42"
+    pt = parse_session_key(topic_key)
+    assert pt.agent_id == "ops"
+    assert pt.channel == "telegram"
+    assert pt.account_id == "acc1"
+    assert pt.chat_type == "direct"
+    assert pt.peer_id == "user-1"
+    assert pt.thread_id == "42"
+
+    slack_base = "agent:ops:slack:group:C12345"
+    thread_key = build_thread_key(slack_base, "171234.567", channel_hint="slack")
+    assert thread_key == "agent:ops:slack:group:C12345:thread:171234.567"
+    ps = parse_session_key(thread_key)
+    assert ps.agent_id == "ops"
+    assert ps.channel == "slack"
+    assert ps.chat_type == "group"
+    assert ps.peer_id == "C12345"
+    assert ps.thread_id == "171234.567"
+
+
+def test_parse_subagent_keys() -> None:
+    # subagent:agent:ops:telegram:direct:user-1
+    base = "agent:ops:telegram:direct:user-1"
+    sub_key = build_subagent_key(base)
+    ps = parse_session_key(sub_key)
+    assert ps.agent_id == "ops"
+    assert ps.channel == "telegram"
+    assert ps.chat_type == "direct"
+    assert ps.peer_id == "user-1"
+    assert ps.is_subagent is True
+
+    # agent:ops:subagent:run-123
+    canon_sub = build_subagent_session_key("ops", "run-123")
+    pcs = parse_session_key(canon_sub)
+    assert pcs.agent_id == "ops"
+    assert pcs.chat_type == "subagent"
+    assert pcs.peer_id == "run-123"
+    assert pcs.is_subagent is True
+
+
+def test_parse_cron_keys() -> None:
+    ck = build_cron_key("heartbeat", "run-456")
+    assert ck == "cron:heartbeat:run:run-456"
+    pc = parse_session_key(ck)
+    assert pc.agent_id == "main"
+    assert pc.channel == "cron"
+    assert pc.chat_type == "cron"
+    assert pc.peer_id == "heartbeat"
+
+
+def test_parse_discord_legacy_keys() -> None:
+    key = "agent:ops:discord:guild-12345:channel-67890"
+    pd = parse_session_key(key)
+    assert pd.agent_id == "ops"
+    assert pd.channel == "discord"
+    assert pd.chat_type == "channel"
+    assert pd.peer_id == "67890"
+
+
+def test_parse_agent_id_and_derive_chat_type() -> None:
+    assert parse_agent_id("agent:analytics:telegram:direct:user-1") == "analytics"
+    assert parse_agent_id("subagent:agent:analytics:telegram:direct:user-1") == "analytics"
+    assert parse_agent_id("cron:heartbeat:run:123") == "main"
+
+    assert derive_chat_type("agent:main:slack:group:C123") == ChatType.GROUP
+    assert derive_chat_type("agent:main:slack:channel:C123") == ChatType.CHANNEL
+    assert derive_chat_type("agent:main:telegram:acc1:direct:user1") == ChatType.DIRECT


### PR DESCRIPTION
Fixes #1730

### Problem

When interactive approval callbacks arrive in `TelegramChannel`, `SlackChannel`, and `DiscordChannel`, the adapters verify that the pending approval belongs to the interacting user/chat by inspecting `session_key`.

Previously, all three adapters parsed `session_key` via fixed-index string slicing (`parts = session_key.split(":")`, `session_channel = parts[2]`, `session_mode = parts[3]`, `session_peer = parts[4]`). This resulted in severe bugs for legitimate approval requests:
1. **Account-scoped DMs (`DmScope.PER_ACCOUNT_CHANNEL_PEER`):**
   `agent:<aid>:<channel>:<account_id>:direct:<peer_id>` (6 parts) placed `account_id` into `session_mode` and `"direct"` into `session_peer`, causing the comparison `session_peer != sender_id` to unconditionally fail and reject all approvals in account-scoped setups with `Unauthorized: Approval does not belong to this chat.`
2. **Thread/Topic-scoped sessions:**
   Session keys containing `:topic:<id>` (Telegram) or `:thread:<id>` (Slack/Discord) failed or shifted slicing checks.
3. **Legacy/guild Discord keys:**
   `agent:<aid>:discord:guild-<gid>:channel-<cid>` evaluated `parts[3]` as `guild-<gid>` (not `"group"` or `"channel"`), falling back to matching against `user_id` and dropping approvals in server channels.

### Solution

1. **Centralized `parse_session_key` helper:** Added `SessionKeyComponents` and `parse_session_key` in `agentos.session.keys` (exported in `agentos.session`) to handle subagent prefixes, thread/topic suffixes, account scopes, and kind/peer token normalization (`direct`, `group`, `channel`, `dm`).
2. **Channel verification:** Updated `TelegramChannel._handle_telegram_callback`, `SlackChannel._handle_slack_interactive`, and `DiscordChannel._handle_interaction` to use `parse_session_key` for safe, accurate channel and peer validation.
3. **Tests:**
   - Added unit test suite in `tests/test_session/test_parse_session_key.py` covering all key formats (main, webchat, direct per-peer, account-scoped, group, channel, threaded, subagent, cron, legacy).
   - Added regression test cases in `tests/test_channels/test_channel_approvals.py` verifying approval resolution for account-scoped and threaded session keys across Telegram, Slack, and Discord.
