### PR TITLE
fix(tools): support CRLF line endings in inline artifact marker regex

### DIFF
--- a/src/agentos/tools/builtin/artifacts.py
+++ b/src/agentos/tools/builtin/artifacts.py
@@ -316,7 +316,7 @@ async def publish_artifact(
 
 #: The marker a skill script prints, alone on its own line.
 INLINE_ARTIFACT_MARKER_RE = re.compile(
-    r"^publish_artifact[ \t]+path=(?P<path>\S+)[ \t]+mime=(?P<mime>\S+)[ \t]*$",
+    r"^publish_artifact[ \t]+path=(?P<path>\S+)[ \t]+mime=(?P<mime>\S+)[ \t]*(?=\r?$)",
     re.MULTILINE,
 )
 

--- a/tests/test_tools/test_inline_artifacts.py
+++ b/tests/test_tools/test_inline_artifacts.py
@@ -90,6 +90,28 @@ async def test_several_markers_each_publish(ctx: Any, published: list[dict[str, 
     assert "publish_artifact path=" not in out
 
 
+@pytest.mark.asyncio
+async def test_marker_with_crlf_line_endings_publishes_and_preserves_crlf(
+    ctx: Any, published: list[dict[str, str]]
+) -> None:
+    """Windows processes and Python scripts on Windows emit CRLF line endings."""
+    out = await publish_inline_artifacts(f"looked up 683 tokens\r\n{marker()}\r\ndone\r\n")
+    assert published == [{"path": "apple.cards.json", "mime": CARDS_MIME}]
+    assert out.startswith("looked up 683 tokens\r\n")
+    assert out.endswith("\r\ndone\r\n")
+    assert "publish_artifact path=" not in out
+    assert "already rendered for the user" in out
+
+
+@pytest.mark.asyncio
+async def test_markers_with_crlf_and_trailing_whitespace(
+    ctx: Any, published: list[dict[str, str]]
+) -> None:
+    out = await publish_inline_artifacts(f"{marker('a.json')}  \r\n{marker('b.json')}\t\r\n")
+    assert [c["path"] for c in published] == ["a.json", "b.json"]
+    assert "publish_artifact path=" not in out
+
+
 # ── Guards ──────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Fixes #1732

### Motivation

In `src/agentos/tools/builtin/artifacts.py`, `INLINE_ARTIFACT_MARKER_RE` was compiled as:
```python
INLINE_ARTIFACT_MARKER_RE = re.compile(
    r"^publish_artifact[ \t]+path=(?P<path>\S+)[ \t]+mime=(?P<mime>\S+)[ \t]*$",
    re.MULTILINE,
)
```
In `re.MULTILINE` mode, `$` anchors immediately before `\n` or at string end. On Windows, command and skill output lines (e.g. from `robinhood-chain-stocks`, `gmgn-token`, `gmgn-market`, `robinhood-rwa-addresses`) end in CRLF (`\r\n`), leaving `\r` between `[ \t]*` and `\n`. Because `[ \t]` only matches spaces and tabs, `$` fails to match the line. As a result, inline artifacts silently failed to auto-publish on Windows and remained stranded in the workspace.

### Solution

- Updated `INLINE_ARTIFACT_MARKER_RE` to use positive lookahead `(?=\r?$)`:
  ```python
  INLINE_ARTIFACT_MARKER_RE = re.compile(
      r"^publish_artifact[ \t]+path=(?P<path>\S+)[ \t]+mime=(?P<mime>\S+)[ \t]*(?=\r?$)",
      re.MULTILINE,
  )
  ```
  This cleanly matches markers ending in either CRLF (`\r\n`) or LF (`\n`), absorbs optional trailing horizontal whitespace, and avoids consuming `\r` in `match.group(0)` so that `output.replace(marker, note)` preserves surrounding CRLF line endings.
- Added regression tests in `tests/test_tools/test_inline_artifacts.py` covering CRLF line endings, line ending preservation, and optional trailing whitespace.
