### PR TITLE
fix(provider): keep override_model fallbacks off the shared SelectorC…

### DIFF
--- a/src/agentos/provider/protocol.py
+++ b/src/agentos/provider/protocol.py
@@ -179,11 +179,17 @@ def resolve_failover_chain(
     primary_failure: Exception,
     config: SelectorConfig,
     plugin: ProviderPlugin | None = None,
+    *,
+    default: list[ProviderConfig] | None = None,
 ) -> list[ProviderConfig]:
     """Return the fallback chain honoring a plugin ``failover_hook`` if set.
 
-    Default (no plugin, or plugin raising) returns the static
-    ``config.fallbacks`` chain declared on ``SelectorConfig``.
+    Default (no plugin, or plugin raising) returns *default* if given, else
+    the static ``config.fallbacks`` chain declared on ``SelectorConfig``.
+    ``default`` exists so a caller holding a per-turn override (e.g.
+    ``ModelSelector.override_model``'s ``fallbacks``) can supply it without
+    writing it into the shared ``SelectorConfig`` first — a config mutation
+    a later ``clone()`` of the same config would otherwise inherit.
     """
     if plugin is not None and hasattr(plugin, "failover_hook"):
         try:
@@ -192,7 +198,7 @@ def resolve_failover_chain(
             chain = None
         if chain is not None:
             return list(chain)
-    return list(config.fallbacks)
+    return list(default) if default is not None else list(config.fallbacks)
 
 
 def resolve_quota_status(

--- a/src/agentos/provider/selector.py
+++ b/src/agentos/provider/selector.py
@@ -149,6 +149,13 @@ class ModelSelector:
         # to the fallback, burning a probe per turn so the primary never
         # recovers.
         self._admitted_index: int | None = None
+        # Per-turn fallback override from override_model(), if any. Kept off
+        # the shared SelectorConfig on purpose: clone() passes that config
+        # by reference, and __init__ rebuilds _chain from config.fallbacks,
+        # so writing the override there would leak this turn's fallbacks
+        # into every clone made afterward instead of staying local to this
+        # selector instance the way the clone() docstring promises.
+        self._fallback_override: list[ProviderConfig] | None = None
 
     @property
     def circuit_breaker(self) -> ProviderCircuitBreaker:
@@ -237,7 +244,9 @@ class ModelSelector:
         replaces the static fallback chain from ``SelectorConfig``. An
         empty chain raises ``IndexError`` exactly like ``next_fallback``.
         """
-        chain = resolve_failover_chain(primary_failure, self._config, self._plugin)
+        chain = resolve_failover_chain(
+            primary_failure, self._config, self._plugin, default=self._fallback_override
+        )
         if not chain:
             raise IndexError("No more provider fallbacks available")
         rebuilt = [self._chain[0], *chain]
@@ -280,7 +289,9 @@ class ModelSelector:
                 provider_routing=self._chain[0].provider_routing,
             )
         if fallbacks is not None:
-            self._config.fallbacks = list(fallbacks)
+            # Local to this selector instance, not written into self._config
+            # -- see the _fallback_override comment in __init__.
+            self._fallback_override = list(fallbacks)
             self._chain = [self._chain[0], *fallbacks]
 
     def sync_primary(self, cfg: ProviderConfig) -> None:

--- a/tests/test_engine/test_selector_fallback_circuit_breaker.py
+++ b/tests/test_engine/test_selector_fallback_circuit_breaker.py
@@ -305,3 +305,59 @@ def test_next_fallback_after_failure_empty_plugin_chain_raises_clear_error(
 
     with pytest.raises(IndexError, match="No more provider fallbacks available"):
         selector.next_fallback_after_failure(RuntimeError("primary down"))
+
+
+def test_override_model_fallbacks_do_not_leak_into_later_clones_of_the_config() -> None:
+    """Regression for #1717: ``override_model``'s ``fallbacks`` used to write
+
+    into the shared ``SelectorConfig``, so a clone made *after* one turn's
+    override would silently inherit that turn's fallback chain instead of
+    the originally configured one -- breaking the ``clone()`` docstring's
+    promise that a turn's mutations don't affect the original.
+    """
+    original_fallback = ProviderConfig("ollama", "llama3")
+    config = SelectorConfig(
+        primary=ProviderConfig("openrouter", "openai/gpt-5.6-luna", api_key="k"),
+        fallbacks=[original_fallback],
+    )
+    original = ModelSelector(config)
+
+    turn_a = original.clone()
+    turn_a.override_model(
+        "openai/gpt-5.6-luna", fallbacks=[ProviderConfig("opencap", "glm-5.3")]
+    )
+
+    assert config.fallbacks == [original_fallback]
+
+    turn_b = original.clone()
+    assert [c.model for c in turn_b._chain[1:]] == ["llama3"]
+
+
+def test_next_fallback_after_failure_uses_override_model_fallbacks_within_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The per-turn override chain must still drive within-turn failover.
+
+    ``override_model``'s docstring promises the supplied ``fallbacks`` (e.g.
+    router-tier candidates) are tried if the primary fails -- moving the
+    override off the shared config must not silently drop that behavior.
+    """
+    from agentos.provider import selector as selector_module
+
+    def _fake_build(cfg: ProviderConfig) -> _StubProvider:
+        return _StubProvider(cfg.provider, [[ProviderDone(stop_reason="stop")]])
+
+    monkeypatch.setattr(selector_module, "_build_provider", _fake_build)
+
+    selector = ModelSelector(
+        SelectorConfig(
+            primary=ProviderConfig("openrouter", "openai/gpt-5.6-luna", api_key="k"),
+            fallbacks=[ProviderConfig("ollama", "llama3")],
+        ),
+    )
+    turn = selector.clone()
+    turn.override_model("openai/gpt-5.6-luna", fallbacks=[ProviderConfig("opencap", "glm-5.3")])
+
+    turn.next_fallback_after_failure(RuntimeError("primary down"))
+
+    assert turn.active_provider_id == "opencap"


### PR DESCRIPTION
Summary
ModelSelector.override_model()'s fallbacks argument used to write into self._config.fallbacks — the same SelectorConfig object clone() passes by reference to new ModelSelector instances. Since __init__ rebuilds _chain from config.fallbacks, any clone created after a turn called override_model(fallbacks=...) silently inherited that turn's fallback chain instead of the originally configured one, contradicting clone()'s own docstring promise that a turn's mutations (override_model, next_fallback) don't affect the original.
The per-turn override now lives on a new self._fallback_override instance attribute instead of the shared config. resolve_failover_chain() gained a keyword-only default parameter so next_fallback_after_failure() still honors the override for in-turn failover (e.g. router-tier candidates), preserving the existing precedence: plugin failover_hook > per-turn override > static config.fallbacks.
Scoped narrowly to the config-mutation issue; does not touch _index/_admitted_index, so it should compose cleanly with the stale-index fix from #1616/#1617 touching the same function.
Test plan
Added test_override_model_fallbacks_do_not_leak_into_later_clones_of_the_config, reproducing the exact leak: override a clone's fallbacks, then clone the original selector again and confirm the new clone starts with the originally configured fallback chain.
Added test_next_fallback_after_failure_uses_override_model_fallbacks_within_turn, confirming the override still drives in-turn failover after the fix.
Verified the leak test fails against the pre-fix code (via git stash on the two source files) and passes with the fix.
uv run ruff check and uv run mypy src/agentos — clean.
Full engine/provider/selector suite (tests/test_engine/, tests/test_gateway/test_boot_local_provider_selector.py, tests/test_provider_circuit_breaker*.py) — 1131 passed.
Fixes #1717 

