### PR TITLE
fix(scheduler): clamp JobStore.list_executions limit so unvalidated values never reach SQL LIMIT

### DIFF
--- a/src/agentos/scheduler/persistence.py
+++ b/src/agentos/scheduler/persistence.py
@@ -35,6 +35,14 @@ from .types import (
 __all__ = ["DeliveryReport", "JobStore"]
 log = structlog.get_logger(__name__)
 
+#: Ceiling for ``list_executions``' ``limit`` param, which reaches a raw SQL
+#: ``LIMIT ?`` unclamped. SQLite treats a negative ``LIMIT`` as "no limit" and
+#: ``LIMIT 0`` as zero rows, so a caller passing an unvalidated value would
+#: return a job's entire run history (or an empty one). Both current callers
+#: clamp at their own edge (``rpc_cron`` and the control tool); this guard
+#: lives on the shared store method so the next caller cannot forget it.
+_MAX_LIST_EXECUTIONS_LIMIT = 1000
+
 _CREATE_RUNS_TABLE = """
 CREATE TABLE IF NOT EXISTS scheduler_runs (
     id TEXT PRIMARY KEY,
@@ -959,6 +967,7 @@ class JobStore:
                 await self._db().commit()
 
     async def list_executions(self, job_id: str, limit: int = 20) -> list[JobExecution]:
+        limit = min(max(1, limit), _MAX_LIST_EXECUTIONS_LIMIT)
         async with self._db().execute(
             "SELECT * FROM scheduler_runs WHERE job_id = ? ORDER BY started_at DESC LIMIT ?",
             (job_id, limit),

--- a/tests/test_scheduler/test_list_executions_limit_clamp.py
+++ b/tests/test_scheduler/test_list_executions_limit_clamp.py
@@ -1,0 +1,82 @@
+"""``JobStore.list_executions``' ``limit`` param must never reach SQLite unclamped.
+
+``list_executions`` passes ``limit`` straight into a raw SQL ``LIMIT ?``.
+SQLite reads a negative ``LIMIT`` as "no limit at all" and ``LIMIT 0`` as zero
+rows, so an unvalidated value either leaks a job's entire run history or
+swallows it. Both current callers (``rpc_cron`` and the control tool) clamp at
+their own edge; the shared store method must defend itself too, so the next
+caller cannot forget. The ceiling mirrors ``rpc_cron``'s run-history cap.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from agentos.scheduler.persistence import JobStore
+from agentos.scheduler.types import JobExecution
+
+_CEILING = 1000  # mirrors rpc_cron's cron.runs limit cap
+
+
+async def _seed_runs(store: JobStore, job_id: str, count: int) -> None:
+    for _ in range(count):
+        await store.save_execution(
+            JobExecution(job_id=job_id, success=True, started_at=datetime.now(UTC))
+        )
+
+
+@pytest.mark.asyncio
+async def test_negative_limit_clamps_to_one(tmp_path: Path) -> None:
+    """SQLite reads a negative LIMIT as unbounded; the store must clamp to 1."""
+    store = JobStore(str(tmp_path / "test.db"))
+    await store.open()
+    try:
+        await _seed_runs(store, "job-1", 5)
+        rows = await store.list_executions("job-1", limit=-1)
+        assert len(rows) == 1
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_zero_limit_clamps_to_one(tmp_path: Path) -> None:
+    """SQLite reads LIMIT 0 as zero rows; the store must clamp to 1."""
+    store = JobStore(str(tmp_path / "test.db"))
+    await store.open()
+    try:
+        await _seed_runs(store, "job-1", 5)
+        rows = await store.list_executions("job-1", limit=0)
+        assert len(rows) == 1
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_ceiling_caps_huge_requests() -> None:
+    """A huge limit must cap at the ceiling, not return everything."""
+    store = JobStore(":memory:")
+    await store.open()
+    try:
+        await _seed_runs(store, "job-1", _CEILING + 1)
+        rows = await store.list_executions("job-1", limit=_CEILING + 500)
+        assert len(rows) == _CEILING
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_bounded_limits_keep_exact_semantics(tmp_path: Path) -> None:
+    """In-range limits keep their exact semantics."""
+    store = JobStore(str(tmp_path / "test.db"))
+    await store.open()
+    try:
+        await _seed_runs(store, "job-1", 5)
+        rows = await store.list_executions("job-1", limit=3)
+        assert len(rows) == 3
+        rows = await store.list_executions("job-1", limit=10)
+        assert len(rows) == 5
+    finally:
+        await store.close()


### PR DESCRIPTION
Fixes #1734

## Problem

`JobStore.list_executions` passes `limit` straight into a raw SQL `LIMIT ?`. SQLite reads a **negative** `LIMIT` as "no limit at all" and `LIMIT 0` as zero rows, so an unvalidated value either leaks a job's entire run history in one response or swallows it entirely.

Both current callers happen to clamp at their own edge (`rpc_cron.py`'s `cron.runs`, the control tool's cron action), but `ops.get_runs()` and `engine.get_runs()` are pure passthroughs — the next caller has no way to know it must clamp first. The guard belongs on the shared method itself.

## Fix

```python
_MAX_LIST_EXECUTIONS_LIMIT = 1000  # module-level; mirrors rpc_cron's run-history cap

async def list_executions(self, job_id: str, limit: int = 20) -> list[JobExecution]:
    limit = min(max(1, limit), _MAX_LIST_EXECUTIONS_LIMIT)
```

- negative / zero `limit` → clamps to `1` (was: all rows / zero rows)
- huge `limit` → capped at `1000`
- in-range `limit` → semantics unchanged (verified explicitly)

## Test plan

- New `tests/test_scheduler/test_list_executions_limit_clamp.py` — 4 cases (negative, zero, ceiling, in-range) asserted **through the store**, not a helper.
- **RED → GREEN proven**: with the patch stashed, 3 cases fail exactly per the bug (`limit=-1` returns all 5 seeded rows, `limit=0` returns 0, an over-ceiling request returns 1001 rows); with the patch, 4/4 pass.
- `uv run ruff check src tests` — clean; `ruff format --check` on changed files — clean.
- `uv run mypy src/agentos --show-error-codes` — Success: no issues found in 625 source files.
- `uv run pytest tests/test_scheduler -q` — 524 passed.
- Full suite: 25 failed / 10425 passed on the patch tree vs the same 25 pre-existing failures on the unchanged tree (per AGENTS.md these fail independently; the one differing test in each direction passes standalone — run-to-run flake, not a regression).
