### PR TITLE
fix(channels/discord): approval sessionKey check uses entry name, not…

### DIFF
--- a/src/agentos/channels/discord.py
+++ b/src/agentos/channels/discord.py
@@ -92,6 +92,7 @@ FATAL_ERROR_CLASSES: tuple[str, ...] = (
 class DiscordChannelConfig(BaseModel):
     """Pydantic config for Discord channel adapter."""
 
+    name: str = "discord"
     token: str
     application_id: str = ""
     default_channel_id: str = ""
@@ -731,7 +732,7 @@ class DiscordChannel:
                 session_mode = parts[3]
                 session_peer = parts[4]
                 expected_peer = channel_id if session_mode in ("group", "channel") else user_id
-                if session_channel != "discord" or session_peer != expected_peer:
+                if session_channel != self.config.name or session_peer != expected_peer:
                     log.warning(
                         "discord.component_mismatch",
                         session_key=session_key,

--- a/tests/test_channels/test_channel_approvals.py
+++ b/tests/test_channels/test_channel_approvals.py
@@ -405,6 +405,97 @@ async def test_discord_component_interaction_handling() -> None:
     assert msg.sender_id == "usr123"
 
 
+@pytest.mark.asyncio
+async def test_discord_component_interaction_resolves_for_non_default_entry_name() -> None:
+    """Regression for #1600: the sessionKey channel segment carries the entry's
+    configured name (e.g. "discord-support" for a multi-account setup), but the
+    handler used to compare it against the hardcoded literal "discord" -- which
+    never matches for any entry that isn't the default-named one, so the
+    approval could never resolve."""
+    queue = get_approval_queue()
+    approval_id = queue.request(
+        "exec",
+        {
+            "argv": ["rm", "-rf"],
+            "action_kind": "exec",
+            "sessionKey": "agent:main:discord-support:direct:usr123",
+        },
+    )
+
+    channel = DiscordChannel(DiscordChannelConfig(token="test-token", name="discord-support"))
+
+    async def fake_post(path, json=None, headers=None, **kwargs):
+        class FakeResp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"id": "999"}
+
+        return FakeResp()
+
+    channel._get_client = lambda: AsyncMock(post=fake_post)
+
+    data = {
+        "type": 3,
+        "id": "int123",
+        "token": "token123",
+        "channel_id": "chan123",
+        "user": {"id": "usr123"},
+        "message": {"content": "Approval requested"},
+        "data": {"custom_id": f"approve:{approval_id}"},
+    }
+
+    await channel._handle_discord_component_interaction(data)
+
+    entry = queue.get(approval_id)
+    assert entry.resolved is True
+    assert entry.approved is True
+
+
+@pytest.mark.asyncio
+async def test_discord_component_interaction_rejects_mismatched_entry_name() -> None:
+    """A sessionKey minted for a different Discord entry must still be rejected."""
+    queue = get_approval_queue()
+    approval_id = queue.request(
+        "exec",
+        {
+            "argv": ["rm", "-rf"],
+            "action_kind": "exec",
+            "sessionKey": "agent:main:discord-other:direct:usr123",
+        },
+    )
+
+    channel = DiscordChannel(DiscordChannelConfig(token="test-token", name="discord-support"))
+
+    async def fake_post(path, json=None, headers=None, **kwargs):
+        class FakeResp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"id": "999"}
+
+        return FakeResp()
+
+    channel._get_client = lambda: AsyncMock(post=fake_post)
+
+    data = {
+        "type": 3,
+        "id": "int123",
+        "token": "token123",
+        "channel_id": "chan123",
+        "user": {"id": "usr123"},
+        "message": {"content": "Approval requested"},
+        "data": {"custom_id": f"approve:{approval_id}"},
+    }
+
+    await channel._handle_discord_component_interaction(data)
+
+    entry = queue.get(approval_id)
+    assert entry.resolved is False
+
+
 _PENDING_APPROVAL: dict[str, Any] = {
     "approval_id": "app-123",
     "command": "ls -l",


### PR DESCRIPTION
Summary
_handle_discord_component_interaction compared the sessionKey's channel segment against the hardcoded literal "discord" instead of the entry's configured name. Since entry names must be unique, any multi-account Discord setup has at least one entry whose name isn't "discord", and for that entry the channel half of the check could never match — every component interaction logged discord.component_mismatch and returned without resolving the approval.
telegram.py's equivalent check already compares against self.config.name; DiscordChannelConfig had no name field for the generic channel builder (_build_generic_channel) to populate, so it's added here to match TelegramChannelConfig.name.
Test plan
Added test_discord_component_interaction_resolves_for_non_default_entry_name, reproducing the exact bug: a Discord entry named "discord-support" with a sessionKey correctly encoding that name, verifying the approval now resolves.
Added test_discord_component_interaction_rejects_mismatched_entry_name, a guard confirming a sessionKey minted for a different entry is still rejected.
Verified both new tests fail against the pre-fix code (via git stash on discord.py) and pass with the fix.
uv run ruff check and uv run mypy src/agentos — clean.
Full channels suite (tests/test_channels/, tests/test_gateway/test_channel_dispatch_realtime.py) — 587 passed.
Fixes #1600 

