### PR TITLE
fix(channels): Slack entry name never reaches the adapter, breaking a…

### DIFF
--- a/src/agentos/channels/slack.py
+++ b/src/agentos/channels/slack.py
@@ -13,7 +13,7 @@ from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import httpx
 import structlog
@@ -40,6 +40,9 @@ from agentos.channels.contract import (
 from agentos.channels.types import ChannelHealth, IncomingMessage, OutgoingMessage
 from agentos.engine.native_commands import slack_command_manifest
 from agentos.env import trust_env as _trust_env
+
+if TYPE_CHECKING:
+    from agentos.gateway.config import SlackChannelEntry
 
 log = structlog.get_logger(__name__)
 
@@ -1044,3 +1047,31 @@ class SlackChannel:
             bot_user_id=self.bot_user_id,
             last_message_at=self._last_message_at,
         )
+
+
+def build_channel_from_entry(entry: SlackChannelEntry) -> SlackChannel:
+    """Build a ``SlackChannel`` from its gateway entry.
+
+    The registry's generic builder only special-cases a field literally named
+    ``name`` (see ``DiscordChannelConfig.name``, ``TelegramChannelConfig.name``);
+    Slack's adapter identity field is ``channel_id`` instead, so it needs this
+    explicit builder to carry ``entry.name`` across. Without it ``channel_id``
+    keeps its dataclass default of ``"slack"`` regardless of the entry's
+    configured name, and the approval sessionKey mismatch check in
+    ``_handle_slack_interactive`` (which compares against ``self.channel_id``)
+    can never match for a non-default-named entry.
+    """
+    return SlackChannel(
+        token=entry.token,
+        slack_channel_id=entry.slack_channel_id,
+        channel_id=entry.name,
+        signing_secret=entry.signing_secret,
+        webhook_path=entry.webhook_path,
+        reply_in_thread=entry.reply_in_thread,
+        connection_mode=entry.connection_mode,
+        app_token=entry.app_token,
+        app_id=entry.app_id,
+        manifest_token=entry.manifest_token,
+        command_request_url=entry.command_request_url,
+        status_reactions_enabled=entry.status_reactions_enabled,
+    )

--- a/tests/test_channels/test_channel_approvals.py
+++ b/tests/test_channels/test_channel_approvals.py
@@ -10,6 +10,7 @@ from starlette.requests import Request
 
 from agentos.channel_pairing import ChannelAdmission
 from agentos.channels.discord import DiscordChannel, DiscordChannelConfig
+from agentos.channels.registry import build_managed_channel
 from agentos.channels.slack import SlackChannel
 from agentos.channels.telegram import TelegramChannel, TelegramChannelConfig
 from agentos.channels.types import IncomingMessage, OutgoingMessage
@@ -19,6 +20,7 @@ from agentos.gateway.channel_dispatch import (
     _run_turn_batch_path,
     _send_channel_approval_prompt,
 )
+from agentos.gateway.config import SlackChannelEntry
 
 
 @pytest.fixture(autouse=True)
@@ -219,6 +221,81 @@ async def test_slack_interactive_payload_handling() -> None:
     msg = await channel.receive()
     assert msg.content == "Approve"
     assert msg.sender_id == "U12345"
+
+
+def test_slack_channel_built_from_entry_reflects_entry_name() -> None:
+    """Regression for #1606: ``build_managed_channel`` must carry the entry's
+    configured name into ``channel.channel_id``, the field the approval
+    sessionKey mismatch check reads -- the same way DiscordChannelConfig.name
+    and TelegramChannelConfig.name reflect their entry's name."""
+    entry = SlackChannelEntry(name="slack-support", token="xoxb-test", slack_channel_id="C12345")
+
+    channel = build_managed_channel(entry)
+
+    assert channel.channel_id == "slack-support"
+
+
+@pytest.mark.asyncio
+async def test_slack_interactive_payload_resolves_for_non_default_entry_name() -> None:
+    """Regression for #1606: a Slack entry with a name other than "slack" used
+    to have its approvals stuck forever, since channel.channel_id stayed
+    hardcoded to "slack" and never matched the sessionKey's channel segment
+    (which correctly carries the entry name)."""
+    entry = SlackChannelEntry(name="slack-support", token="xoxb-test", slack_channel_id="C12345")
+    channel = build_managed_channel(entry)
+    assert isinstance(channel, SlackChannel)
+
+    queue = get_approval_queue()
+    approval_id = queue.request(
+        "exec",
+        {
+            "argv": ["rm", "-rf"],
+            "action_kind": "exec",
+            "sessionKey": "agent:main:slack-support:channel:C12345",
+        },
+    )
+
+    channel.parse_event = lambda ev: IncomingMessage(
+        sender_id=ev["user"],
+        channel_id=ev["channel"],
+        content=ev["text"],
+    )
+
+    payload = {
+        "type": "block_actions",
+        "user": {"id": "U12345"},
+        "channel": {"id": "C12345"},
+        "response_url": "https://hooks.slack.com/actions/test",
+        "message": {
+            "text": "Approve this execution?",
+            "blocks": [
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": "Approve this execution?"},
+                },
+                {
+                    "type": "actions",
+                    "block_id": "approval_actions",
+                    "elements": [{"type": "button", "value": f"approve:{approval_id}"}],
+                },
+            ],
+        },
+        "actions": [{"value": f"approve:{approval_id}"}],
+    }
+
+    class FakeResponse:
+        def raise_for_status(self):
+            pass
+
+    async def fake_post(url, json=None, **kwargs):
+        return FakeResponse()
+
+    with patch("httpx.AsyncClient.post", side_effect=fake_post):
+        await channel._handle_slack_interactive(payload)
+
+    entry_after = queue.get(approval_id)
+    assert entry_after.resolved is True
+    assert entry_after.approved is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION

Summary
SlackChannel.channel_id — the field _handle_slack_interactive's sessionKey mismatch check compares against — kept its dataclass default of "slack" regardless of the entry's configured name. The registry's generic channel builder only special-cases a field literally named name (as DiscordChannelConfig.name and TelegramChannelConfig.name do); Slack has no such field, so entry.name was silently dropped on construction. Every Approve/Deny click on a non-default-named Slack entry's pending approvals logged slack.interactive_mismatch and never resolved.
Adds an explicit build_channel_from_entry for Slack that carries entry.name into channel_id, the same identity the other adapters expose via config.name.
Test plan
Added test_slack_channel_built_from_entry_reflects_entry_name, asserting build_managed_channel(entry).channel_id == entry.name per the issue's exact reproduction steps.
Added test_slack_interactive_payload_resolves_for_non_default_entry_name, an end-to-end check that a Slack entry named "slack-support" now resolves its approval through the real registry-built adapter.
Verified both new tests fail against the pre-fix code (via git stash on slack.py) and pass with the fix.
uv run ruff check and uv run mypy src/agentos — clean.
Full channels/onboarding suite (tests/test_channels/, tests/test_gateway/test_channel_dispatch_realtime.py, tests/test_onboarding/) — 967 passed.
Fixes #1606 
