### PR TITLE
fix(tools): preserve CJK punctuation and symbols in create_pdf_report (Closes #1739)

### DIFF
--- a/src/agentos/tools/builtin/file_authoring.py
+++ b/src/agentos/tools/builtin/file_authoring.py
@@ -141,15 +141,27 @@ def _register_pdf_fonts() -> tuple[str, str, str | None]:
 def _is_cjk(char: str) -> bool:
     codepoint = ord(char)
     return (
-        0x3400 <= codepoint <= 0x4DBF
-        or 0x4E00 <= codepoint <= 0x9FFF
-        or 0xF900 <= codepoint <= 0xFAFF
-        or 0x20000 <= codepoint <= 0x2A6DF
-        or 0x2A700 <= codepoint <= 0x2B73F
-        or 0x2B740 <= codepoint <= 0x2B81F
-        or 0x2B820 <= codepoint <= 0x2CEAF
-        or 0x2CEB0 <= codepoint <= 0x2EBEF
-        or 0x30000 <= codepoint <= 0x3134F
+        0x2000 <= codepoint <= 0x206F  # General Punctuation (curly quotes, dashes, ellipses)
+        or 0x3000 <= codepoint <= 0x303F  # CJK Symbols and Punctuation (、。〈〉《》【】)
+        or 0x3040 <= codepoint <= 0x309F  # Hiragana
+        or 0x30A0 <= codepoint <= 0x30FF  # Katakana
+        or 0x3100 <= codepoint <= 0x312F  # Bopomofo
+        or 0x31A0 <= codepoint <= 0x31BF  # Bopomofo Extended
+        or 0x3200 <= codepoint <= 0x32FF  # Enclosed CJK Letters and Months
+        or 0x3300 <= codepoint <= 0x33FF  # CJK Compatibility
+        or 0x3400 <= codepoint <= 0x4DBF  # CJK Unified Ideographs Extension A
+        or 0x4E00 <= codepoint <= 0x9FFF  # CJK Unified Ideographs
+        or 0xF900 <= codepoint <= 0xFAFF  # CJK Compatibility Ideographs
+        or 0xFE10 <= codepoint <= 0xFE1F  # Vertical Forms
+        or 0xFE30 <= codepoint <= 0xFE4F  # CJK Compatibility Forms
+        or 0xFE50 <= codepoint <= 0xFE6F  # Small Form Variants
+        or 0xFF00 <= codepoint <= 0xFFEF  # Halfwidth and Fullwidth Forms
+        or 0x20000 <= codepoint <= 0x2A6DF  # Extension B
+        or 0x2A700 <= codepoint <= 0x2B73F  # Extension C
+        or 0x2B740 <= codepoint <= 0x2B81F  # Extension D
+        or 0x2B820 <= codepoint <= 0x2CEAF  # Extension E
+        or 0x2CEB0 <= codepoint <= 0x2EBEF  # Extension F
+        or 0x30000 <= codepoint <= 0x3134F  # Extension I
     )
 
 

--- a/tests/test_tools/test_file_authoring_tools.py
+++ b/tests/test_tools/test_file_authoring_tools.py
@@ -23,7 +23,7 @@ def _channel_artifact_context(tmp_path: Path) -> ToolContext:
     workspace = tmp_path / "workspace"
     workspace.mkdir(exist_ok=True)
     return ToolContext(
-                caller_kind=CallerKind.CHANNEL,
+        caller_kind=CallerKind.CHANNEL,
         workspace_dir=str(workspace),
         artifact_media_root=str(tmp_path / "media"),
         artifact_session_id="session-1",
@@ -227,3 +227,37 @@ async def test_create_pdf_report_uses_unicode_fonts_for_channel_artifact(tmp_pat
 
     assert not any("ZapfDingbats" in font_name for font_name in base_fonts)
     assert any("STSong-Light" in font_name for font_name in base_fonts)
+
+
+@pytest.mark.asyncio
+async def test_create_pdf_report_preserves_cjk_punctuation_and_symbols(tmp_path: Path) -> None:
+    ctx = _channel_artifact_context(tmp_path)
+    token = current_tool_context.set(ctx)
+    try:
+        result = await create_pdf_report(
+            name="cjk-punctuation.pdf",
+            title="中文标点测试：标题！",
+            sections=[
+                {
+                    "heading": "第一节：测试《书名》与【括号】",
+                    "body": "你好，世界！这是“引号”——破折号……省略号。",
+                }
+            ],
+        )
+    finally:
+        current_tool_context.reset(token)
+
+    _, material = _published_material(ctx, result)
+    reader = PdfReader(BytesIO(material))
+    text = "\n".join(page.extract_text() or "" for page in reader.pages)
+
+    # Fullwidth and CJK punctuation marks must not be stripped
+    assert "：" in text
+    assert "！" in text
+    assert "《" in text and "》" in text
+    assert "【" in text and "】" in text
+    assert "，" in text
+    assert "。" in text
+    assert "“" in text and "”" in text
+    assert "—" in text
+    assert "…" in text


### PR DESCRIPTION
Closes #1739

### Summary of Changes
- Expanded `_is_cjk(char: str) -> bool` in `src/agentos/tools/builtin/file_authoring.py` to recognize:
  - CJK Symbols and Punctuation (`0x3000..0x303F`: `。`, `、`, `《`, `》`, `「`, `」`, `『`, `』`, `【`, `】`, `〔`, `〕`)
  - Halfwidth and Fullwidth Forms (`0xFF00..0xFFEF`: `，`, `！`, `？`, `：`, `；`, `（`, `）`)
  - General Punctuation commonly used in CJK typography (`0x2000..0x206F`: curly quotes `“`, `”`, `‘`, `’`, em-dash `—`, ellipsis `…`)
  - Kana (`0x3040..0x30FF`), Bopomofo (`0x3100..0x31BF`), and Compatibility forms (`0xFE10..0xFE6F`, `0x3200..0x33FF`)
- Added public regression test `test_create_pdf_report_preserves_cjk_punctuation_and_symbols` in `tests/test_tools/test_file_authoring_tools.py` verifying that fullwidth and CJK punctuation marks are preserved in generated PDF text rather than dropped.

### Quality Gate
- `uv run pytest tests/test_tools/test_file_authoring_tools.py -v`: 7 passed
- `uv run ruff check src/agentos/tools/builtin/file_authoring.py tests/test_tools/test_file_authoring_tools.py`: All checks passed
- `uv run mypy src/agentos/tools/builtin/file_authoring.py --show-error-codes`: Success
- Deterministic, offline, credential-free.
