### PR TITLE
fix(filesystem): record workspace file write in edit_file (Closes #1689)

### DIFF
--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -316,8 +316,7 @@ def _workspace_strict_read_block(
             "workspace": str(roots[0]),
             "allowed_roots": [str(root) for root in roots],
             "message": (
-                f"{tool_name} blocked: {candidate} is outside active read roots "
-                f"({root_labels})."
+                f"{tool_name} blocked: {candidate} is outside active read roots ({root_labels})."
             ),
             "retryable": False,
         }
@@ -795,8 +794,7 @@ def _format_spreadsheet(
             parts.append(f"{idx}\t" + "\t".join(rows.get(idx, [])))
         if end < total_rows:
             parts.append(
-                f"(Showing rows {offset}-{end} of {total_rows}. "
-                f"Use offset={end + 1} to continue.)"
+                f"(Showing rows {offset}-{end} of {total_rows}. Use offset={end + 1} to continue.)"
             )
     return "\n".join(parts)
 
@@ -886,9 +884,7 @@ def _locate_edit(original: str, old_text: str, new_text: str, *, path: str) -> F
     argv_factory=lambda a: ("fs.edit", str(a.get("path", ""))),
     record_payload=False,
 )
-async def edit_file(
-    path: str, old_text: str, new_text: str, approval_id: str | None = None
-) -> str:
+async def edit_file(path: str, old_text: str, new_text: str, approval_id: str | None = None) -> str:
     p = _resolve_path(path)
     approval = await _gate_out_of_workspace_write("edit_file", p, path, approval_id)
     if approval is not None:
@@ -912,6 +908,7 @@ async def edit_file(
         p.write_text(updated, encoding="utf-8")
 
     await loop.run_in_executor(None, _write)
+    record_workspace_file_write(p)
     _notify_memory_source_write(p)
     _notify_bootstrap_source_write(p)
     summary = f"replaced {len(old_text)} chars with {len(new_text)} chars"

--- a/tests/test_tools/test_filesystem_read_workspace.py
+++ b/tests/test_tools/test_filesystem_read_workspace.py
@@ -435,3 +435,24 @@ async def test_write_file_records_workspace_write_on_both_create_and_overwrite(
         current_tool_context.reset(token)
 
 
+@pytest.mark.asyncio
+async def test_edit_file_records_workspace_file_write(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    ctx = ToolContext(workspace_dir=str(workspace))
+    token = current_tool_context.set(ctx)
+    raw_write_file = fs.write_file.__wrapped__.__wrapped__
+    raw_edit_file = fs.edit_file.__wrapped__.__wrapped__
+    target = workspace / "report.md"
+    try:
+        await raw_write_file(str(target), "initial report draft")
+        assert len(ctx.workspace_file_writes) == 1
+
+        result = await raw_edit_file(str(target), "draft", "final")
+        assert "replaced 5 chars with 5 chars" in result
+        assert len(ctx.workspace_file_writes) == 2
+        assert ctx.workspace_file_writes[1]["name"] == "report.md"
+        assert ctx.workspace_file_writes[1]["relative_path"] == "report.md"
+        assert target.read_text(encoding="utf-8") == "initial report final"
+    finally:
+        current_tool_context.reset(token)


### PR DESCRIPTION
Closes #1689

### Problem

When tools create or modify files inside a workspace, they record the write to `ctx.workspace_file_writes` using `record_workspace_file_write(p)`. Downstream subsystems such as `agentos.engine.artifact_delivery.auto_publish_omitted_workspace_artifacts` rely on `ctx.workspace_file_writes` to automatically publish deliverables, reports, and generated assets to the user.

While `write_file` and `apply_patch` call `record_workspace_file_write(p)`, `edit_file` in `src/agentos/tools/builtin/filesystem.py` only invoked `_notify_memory_source_write(p)` and `_notify_bootstrap_source_write(p)`, omitting `record_workspace_file_write(p)`. As a result, workspace files edited in place with `edit_file` were never recorded in `ctx.workspace_file_writes`, silently dropping artifact auto-publication for edited documents and deliverables.

### Solution
- Added `record_workspace_file_write(p)` in `edit_file()` immediately after writing updated content to disk, matching the behavior of `write_file`.

### Testing
- Added regression test `test_edit_file_records_workspace_file_write` in `tests/test_tools/test_filesystem_read_workspace.py`:
  - Verified that editing an existing file via `edit_file` records a new entry in `ctx.workspace_file_writes` with correct `name`, `relative_path`, and updated contents.
- Verification checks:
  - `pytest tests/test_tools/test_filesystem_read_workspace.py -q` (16 passed, 4 skipped)
  - `ruff check src/agentos/tools/builtin/filesystem.py tests/test_tools/test_filesystem_read_workspace.py` (Clean)
  - `ruff format --check src/agentos/tools/builtin/filesystem.py tests/test_tools/test_filesystem_read_workspace.py` (Clean)
  - `mypy src/agentos/tools/builtin/filesystem.py --show-error-codes` (Clean)

