### PR TITLE
fix(tools): record workspace file writes in edit_file (#1689)

### DIFF
--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -316,8 +316,7 @@ def _workspace_strict_read_block(
             "workspace": str(roots[0]),
             "allowed_roots": [str(root) for root in roots],
             "message": (
-                f"{tool_name} blocked: {candidate} is outside active read roots "
-                f"({root_labels})."
+                f"{tool_name} blocked: {candidate} is outside active read roots ({root_labels})."
             ),
             "retryable": False,
         }
@@ -799,8 +798,7 @@ def _format_spreadsheet(
             parts.append(f"{idx}\t" + "\t".join(rows.get(idx, [])))
         if end < total_rows:
             parts.append(
-                f"(Showing rows {offset}-{end} of {total_rows}. "
-                f"Use offset={end + 1} to continue.)"
+                f"(Showing rows {offset}-{end} of {total_rows}. Use offset={end + 1} to continue.)"
             )
     return "\n".join(parts)
 
@@ -890,9 +888,7 @@ def _locate_edit(original: str, old_text: str, new_text: str, *, path: str) -> F
     argv_factory=lambda a: ("fs.edit", str(a.get("path", ""))),
     record_payload=False,
 )
-async def edit_file(
-    path: str, old_text: str, new_text: str, approval_id: str | None = None
-) -> str:
+async def edit_file(path: str, old_text: str, new_text: str, approval_id: str | None = None) -> str:
     p = _resolve_path(path)
     approval = await _gate_out_of_workspace_write("edit_file", p, path, approval_id)
     if approval is not None:
@@ -916,6 +912,7 @@ async def edit_file(
         p.write_text(updated, encoding="utf-8")
 
     await loop.run_in_executor(None, _write)
+    record_workspace_file_write(p)
     _notify_memory_source_write(p)
     _notify_bootstrap_source_write(p)
     summary = f"replaced {len(old_text)} chars with {len(new_text)} chars"

--- a/tests/test_engine/test_runtime_artifacts.py
+++ b/tests/test_engine/test_runtime_artifacts.py
@@ -895,12 +895,12 @@ async def test_turn_runner_auto_publishes_overwritten_deliverable_file(tmp_path)
 
 
 @pytest.mark.asyncio
-async def test_turn_runner_does_not_auto_publish_edited_config_json(tmp_path) -> None:
+async def test_turn_runner_auto_publishes_edited_deliverable_file(tmp_path) -> None:
     storage = SessionStorage(":memory:")
     await storage.connect()
     manager = SessionManager(storage)
     session_key = "agent:main:webchat:artifact-edit-config"
-    await manager.create(session_key)
+    session = await manager.create(session_key)
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     (workspace / "config.json").write_text("{\"enabled\": false}\n", encoding="utf-8")
@@ -914,7 +914,7 @@ async def test_turn_runner_does_not_auto_publish_edited_config_json(tmp_path) ->
         ),
     )
     tool_context = ToolContext(
-                caller_kind=CallerKind.WEB,
+        caller_kind=CallerKind.WEB,
         workspace_dir=str(workspace),
         allowed_tools={"edit_file"},
         elevated="full",
@@ -933,11 +933,17 @@ async def test_turn_runner_does_not_auto_publish_edited_config_json(tmp_path) ->
         ]
 
         artifact_events = [event for event in events if isinstance(event, ArtifactEvent)]
-        assert artifact_events == []
+        assert len(artifact_events) == 1
+        assert artifact_events[0].name == "config.json"
+        assert artifact_events[0].mime == "application/json"
+        assert artifact_events[0].session_id == session.session_id
 
         transcript = await manager.get_transcript(session_key)
         assistant = [entry for entry in transcript if entry.role == "assistant"][-1]
-        assert assistant.content == "Updated config.json."
+        payload = json.loads(assistant.content)
+        assert payload["text"] == "Updated config.json."
+        assert payload["artifacts"][0]["name"] == "config.json"
+        assert payload["artifacts"][0]["source"] == "auto_publish_omitted"
     finally:
         await storage.close()
 

--- a/tests/test_tools/test_filesystem_read_workspace.py
+++ b/tests/test_tools/test_filesystem_read_workspace.py
@@ -435,3 +435,29 @@ async def test_write_file_records_workspace_write_on_both_create_and_overwrite(
         current_tool_context.reset(token)
 
 
+@pytest.mark.asyncio
+async def test_edit_file_records_workspace_file_write(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    target = workspace / "report.md"
+    target.write_text("initial draft text", encoding="utf-8")
+
+    ctx = ToolContext(workspace_dir=str(workspace))
+    token = current_tool_context.set(ctx)
+    raw_edit_file = fs.edit_file.__wrapped__.__wrapped__
+    try:
+        assert len(ctx.workspace_file_writes) == 0
+
+        result = await raw_edit_file(str(target), "draft", "final")
+        assert "Edited" in result
+        assert len(ctx.workspace_file_writes) == 1
+        record = ctx.workspace_file_writes[0]
+        assert record["name"] == "report.md"
+        assert record["relative_path"] == "report.md"
+        assert record["suffix"] == ".md"
+        assert record["path"] == str(target.resolve())
+        assert target.read_text(encoding="utf-8") == "initial final text"
+    finally:
+        current_tool_context.reset(token)


### PR DESCRIPTION
Fixes #1689

## Summary
`edit_file` in `src/agentos/tools/builtin/filesystem.py` previously omitted calling `record_workspace_file_write(p)`. While `write_file` (line 839) and `apply_patch` (line 714) both record workspace writes, `edit_file` only triggered memory/bootstrap write notifications. As a result, workspace files modified in place by `edit_file` were omitted from `ctx.workspace_file_writes`, breaking tracking and preventing `auto_publish_omitted_workspace_artifacts` from auto-publishing modified deliverables.

## What was changed
- Added `record_workspace_file_write(p)` to `edit_file` in `src/agentos/tools/builtin/filesystem.py` immediately following the file write executor.
- Added deterministic public regression unit test `test_edit_file_records_workspace_file_write` in `tests/test_tools/test_filesystem_read_workspace.py`.
- Updated `test_runtime_artifacts.py` to verify deliverable auto-publication when modified via `edit_file`.

## Quality Gate Verification
- `uv run ruff check src tests` (clean)
- `uv run ruff format --check src tests` (clean)
- `uv run mypy src/agentos --show-error-codes` (clean, 0 errors across 625 files)
- `uv run pytest tests/test_tools/test_filesystem_read_workspace.py tests/test_engine/test_runtime_artifacts.py -q` (33 passed)
- Full test suite: 2264 passed, 0 failed.