### PR TITLE
fix(tools): capture quoted shell write targets containing spaces

### DIFF
--- a/src/agentos/tools/builtin/shell.py
+++ b/src/agentos/tools/builtin/shell.py
@@ -341,7 +341,18 @@ _FD_DUP_PATTERN = re.compile(r"\d*>&\s*(?:\d+-?|-)(?=$|[\s|&;<>)])")
 # ``n>>``, ``&>``, ``&>>``, ``>&file`` and the noclobber override ``>|``. The
 # operator is deliberately *not* anchored to a word boundary — ``echo x>file`` is
 # valid shell and must be caught just like ``echo x > file``.
-_REDIRECTION_PATTERN = re.compile(r"(?:&>{1,2}|\d*>{1,2}&?)\|?\s*(['\"]?)([^'\"\s|&;<>()]+)\1")
+#
+# The target is a three-way alternation because a quoted target and a bare one
+# need different bodies. Inside quotes only the *matching* quote ends the path,
+# so ``"/tmp/John's Notes/out.txt"`` is captured whole; outside them a space is a
+# real argument boundary and the original restrictive class still applies. The
+# previous single class excluded whitespace even inside the quotes, so a quoted
+# path containing a space matched nothing at all — the lockdown checks below then
+# iterated an empty target list and returned ``None``, allowing a write outside
+# the workspace (#1230).
+_REDIRECTION_PATTERN = re.compile(
+    r"""(?:&>{1,2}|\d*>{1,2}&?)\|?\s*(?:"([^"]+)"|'([^']+)'|([^'"\s|&;<>()]+))"""
+)
 
 # ``tee`` is the other write primitive this parser covers, and it needs the same
 # treatment as the redirection operators: ``echo x|tee /etc/passwd`` is valid
@@ -349,9 +360,11 @@ _REDIRECTION_PATTERN = re.compile(r"(?:&>{1,2}|\d*>{1,2}&?)\|?\s*(['\"]?)([^'\"\
 # space. The lookbehind keeps ``mytee``/``notee`` out while still matching a
 # fully qualified ``/usr/bin/tee``. Options may be short (``-a``), long
 # (``--append``) or long with a value (``--output-error=warn``); all of them are
-# skipped so the first non-option word is the real target.
+# skipped so the first non-option word is the real target. The target alternation
+# is the same three-way split as ``_REDIRECTION_PATTERN``; see there for why.
 _TEE_PATTERN = re.compile(
-    r"(?<![\w-])tee(?:\s+-{1,2}[A-Za-z][\w-]*(?:=[^\s|&;]+)?)*\s+(['\"]?)([^'\"\s|&;]+)\1"
+    r"(?<![\w-])tee(?:\s+-{1,2}[A-Za-z][\w-]*(?:=[^\s|&;]+)?)*\s+"
+    r"""(?:"([^"]+)"|'([^']+)'|([^'"\s|&;]+))"""
 )
 
 
@@ -363,8 +376,12 @@ def _shell_write_targets(command: str) -> list[str]:
     # covers ``tee /dev/null``, where the sink arrives as an argument rather
     # than as a redirection and so survives the stripper.
     scanned = _FD_DUP_PATTERN.sub(" ", _without_shell_null_redirections(command))
-    targets: list[str] = [match.group(2) for match in _REDIRECTION_PATTERN.finditer(scanned)]
-    targets.extend(match.group(2) for match in _TEE_PATTERN.finditer(scanned))
+    targets: list[str] = []
+    for pattern in (_REDIRECTION_PATTERN, _TEE_PATTERN):
+        for match in pattern.finditer(scanned):
+            # Exactly one of the double-quoted / single-quoted / bare groups
+            # took part in the match; the other two are None.
+            targets.append(next(group for group in match.groups() if group is not None))
     return [target for target in targets if target != _NULL_SINK_PATH]
 
 

--- a/tests/test_tools/test_shell_approval_policy.py
+++ b/tests/test_tools/test_shell_approval_policy.py
@@ -549,6 +549,114 @@ def test_shell_write_targets_ignores_words_ending_in_tee(command: str) -> None:
     assert shell._shell_write_targets(command) == []
 
 
+# --- #1230: quoted write targets containing spaces -------------------------
+#
+# A quoted path with a space matched neither pattern, so ``_shell_write_targets``
+# returned ``[]`` and every lockdown / deny-glob check below iterated an empty
+# list and allowed the write.
+
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        'echo ok > "{target}"',
+        "echo ok > '{target}'",
+        'echo ok>"{target}"',
+        'echo ok >> "{target}"',
+        'echo ok 2> "{target}"',
+        'echo ok &> "{target}"',
+        '>&"{target}"',
+    ],
+)
+def test_shell_write_targets_detects_quoted_redirection_targets_with_spaces(
+    template: str,
+) -> None:
+    target = "/tmp/my custom folder/outside.txt"
+    assert shell._shell_write_targets(template.format(target=target)) == [target]
+
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        'echo ok | tee "{target}"',
+        "echo ok | tee '{target}'",
+        'echo ok|tee "{target}"',
+        'echo ok | tee -a "{target}"',
+        'echo ok | tee --append "{target}"',
+        'echo ok | tee --output-error=warn "{target}"',
+        'echo ok | /usr/bin/tee "{target}"',
+    ],
+)
+def test_shell_write_targets_detects_quoted_tee_targets_with_spaces(template: str) -> None:
+    target = "/tmp/my custom folder/outside.txt"
+    assert shell._shell_write_targets(template.format(target=target)) == [target]
+
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        ("""echo ok > "/tmp/John's Notes/out.txt\"""", "/tmp/John's Notes/out.txt"),
+        ("""echo ok | tee "/tmp/John's Notes/out.txt\"""", "/tmp/John's Notes/out.txt"),
+        ("""echo ok > '/tmp/say "hi"/out.txt'""", '/tmp/say "hi"/out.txt'),
+        ("""echo ok | tee '/tmp/say "hi"/out.txt'""", '/tmp/say "hi"/out.txt'),
+    ],
+)
+def test_shell_write_targets_detects_quoted_targets_holding_the_other_quote(
+    command: str,
+    expected: str,
+) -> None:
+    """Only the *matching* quote ends a quoted target.
+
+    ``~/John's Notes`` is an ordinary directory name on macOS and Windows, and a
+    body that excluded both quote characters would leave exactly the reported
+    fail-open in place for it: the closing ``"`` is never reached, the bare
+    alternative cannot start on a quote, and the parser reports no target at all.
+    """
+    assert shell._shell_write_targets(command) == [expected]
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'echo ok > "AT&T report.txt"',
+        'echo ok | tee "AT&T report.txt"',
+    ],
+)
+def test_shell_write_targets_quoted_target_survives_the_fd_dup_prepass(command: str) -> None:
+    """``_FD_DUP_PATTERN`` runs first; a quoted ``&`` must not be blanked out."""
+    assert shell._shell_write_targets(command) == ["AT&T report.txt"]
+
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        # Bash redirects to the first word and passes the rest to the command:
+        # ``echo ok > /tmp/John Doe/out.txt`` writes ``/tmp/John``. Truncating at
+        # whitespace is correct for a bare target and must stay that way.
+        ("echo ok > /tmp/John Doe/out.txt", ["/tmp/John"]),
+        ("echo ok > /tmp/.env extra", ["/tmp/.env"]),
+        ("echo ok > out.txt # note", ["out.txt"]),
+        ("echo ok > out.txt 2>/dev/null", ["out.txt"]),
+        ("echo ok | tee reports/o.txt;whoami", ["reports/o.txt"]),
+        ("cat > out.txt <<'EOF'", ["out.txt"]),
+        ("echo ok 2>&1", []),
+        ("echo ok >&2", []),
+        ("echo x|mytee foo.txt", []),
+    ],
+)
+def test_shell_write_targets_leaves_unquoted_targets_unchanged(
+    command: str,
+    expected: list[str],
+) -> None:
+    """Pins the bare-target class to the behaviour it has on ``main``.
+
+    The quoted body is the only thing #1230 changes. A bare target that swallowed
+    whitespace would mis-model the shell *and* fail open: ``> reports/out.txt
+    2>/dev/null`` would resolve as one long path that matches no deny glob.
+    """
+    assert shell._shell_write_targets(command) == expected
+
+
 @pytest.mark.parametrize(
     "command",
     [
@@ -641,7 +749,7 @@ async def test_workspace_lockdown_still_blocks_a_real_target_beside_a_null_sink(
 
     result = await shell._check_exec_approval(
         "exec_command",
-        f"echo ok > {outside} 2>/dev/null",
+        f'echo ok > "{outside}" 2>/dev/null',
         str(workspace),
         "command requires approval",
         None,
@@ -658,12 +766,12 @@ async def test_workspace_lockdown_still_blocks_a_real_target_beside_a_null_sink(
 @pytest.mark.parametrize(
     "template",
     [
-        "echo ok>{target}",
-        "echo ok>>{target}",
-        "echo ok 2>{target}",
-        ">&{target}",
-        "echo ok &>{target}",
-        "cat<in>{target}",
+        'echo ok>"{target}"',
+        'echo ok>>"{target}"',
+        'echo ok 2>"{target}"',
+        '>&"{target}"',
+        'echo ok &>"{target}"',
+        'cat<in>"{target}"',
     ],
 )
 async def test_workspace_lockdown_blocks_redirection_without_whitespace(
@@ -699,10 +807,10 @@ async def test_workspace_lockdown_blocks_redirection_without_whitespace(
 @pytest.mark.parametrize(
     "template",
     [
-        "echo ok|tee {target}",
-        "echo ok|tee -a {target}",
-        "echo ok | tee --append {target}",
-        "echo ok | tee --output-error=warn {target}",
+        'echo ok|tee "{target}"',
+        'echo ok|tee -a "{target}"',
+        'echo ok | tee --append "{target}"',
+        'echo ok | tee --output-error=warn "{target}"',
     ],
 )
 async def test_workspace_lockdown_blocks_tee_without_whitespace_or_long_options(
@@ -748,6 +856,134 @@ async def test_workspace_write_deny_globs_block_tee_without_whitespace(tmp_path:
     result = await shell._check_exec_approval(
         "exec_command",
         "echo ok|tee --append reports/out.txt",
+        str(workspace),
+        "command requires approval",
+        None,
+        False,
+    )
+
+    assert result is not None
+    assert result["status"] == "blocked"
+    assert result["reason"] == "workspace_write_deny"
+    assert result["matched_pattern"] == "reports/*.txt"
+
+
+# --- #1230: the block decision, one layer past the parser -------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "template",
+    [
+        'echo ok > "{target}"',
+        "echo ok > '{target}'",
+        'echo ok >> "{target}"',
+        'echo ok | tee "{target}"',
+        "echo ok | tee -a '{target}'",
+    ],
+)
+async def test_workspace_lockdown_blocks_quoted_targets_with_spaces(
+    tmp_path: Path,
+    template: str,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside_dir = tmp_path / "my custom folder"
+    outside_dir.mkdir()
+    outside = outside_dir / "outside.txt"
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.interaction_mode = InteractionMode.UNATTENDED
+    ctx.elevated = "bypass"
+    ctx.workspace_dir = str(workspace)
+    ctx.workspace_lockdown = True  # type: ignore[attr-defined]
+
+    result = await shell._check_exec_approval(
+        "exec_command",
+        template.format(target=outside),
+        str(workspace),
+        "command requires approval",
+        None,
+        False,
+    )
+
+    assert result is not None
+    assert result["status"] == "blocked"
+    assert result["reason"] == "workspace_lockdown"
+    assert result["target"] == str(outside)
+    assert result["resolved_path"] == str(outside)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "command",
+    [
+        'echo ok > "reports/my report.txt"',
+        "echo ok > 'reports/my report.txt'",
+        'echo ok | tee --append "reports/my report.txt"',
+    ],
+)
+async def test_workspace_write_deny_globs_block_quoted_targets_with_spaces(
+    tmp_path: Path,
+    command: str,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.interaction_mode = InteractionMode.UNATTENDED
+    ctx.elevated = "bypass"
+    ctx.workspace_dir = str(workspace)
+    ctx.workspace_write_deny_globs = ["reports/*.txt"]  # type: ignore[attr-defined]
+
+    result = await shell._check_exec_approval(
+        "exec_command",
+        command,
+        str(workspace),
+        "command requires approval",
+        None,
+        False,
+    )
+
+    assert result is not None
+    assert result["status"] == "blocked"
+    assert result["reason"] == "workspace_write_deny"
+    assert result["matched_pattern"] == "reports/*.txt"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "command",
+    [
+        "echo ok > reports/out.txt 2>/dev/null",
+        "echo ok > reports/out.txt extra",
+        "echo ok > reports/out.txt # note",
+        "echo ok|tee --append reports/out.txt;whoami",
+    ],
+)
+async def test_workspace_write_deny_globs_block_bare_target_with_a_trailing_token(
+    tmp_path: Path,
+    command: str,
+) -> None:
+    """A bare target followed by another token must stay blocked.
+
+    This is the regression the quoted fix has to avoid re-opening: if the bare
+    body swallowed whitespace, the target would resolve to
+    ``reports/out.txt 2>/dev/null`` — one path that matches no deny glob — and
+    ordinary, non-adversarial shell would slip past the check.
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.interaction_mode = InteractionMode.UNATTENDED
+    ctx.elevated = "bypass"
+    ctx.workspace_dir = str(workspace)
+    ctx.workspace_write_deny_globs = ["reports/*.txt"]  # type: ignore[attr-defined]
+
+    result = await shell._check_exec_approval(
+        "exec_command",
+        command,
         str(workspace),
         "command requires approval",
         None,


### PR DESCRIPTION
Fixes #1230

Picking up the review on #1242, which has been idle since the `CHANGES_REQUESTED`. This implements the three-way alternation from that review verbatim, keeps the bare-target class byte-identical to `main`, and adds the deny-glob regression test that review asked for.

## The bug

Both write-target patterns folded the quoted and bare cases into one body, and that body excluded whitespace unconditionally (`shell.py:342,351` on `main`):

```python
_REDIRECTION_PATTERN = re.compile(r"(?:&>{1,2}|\d*>{1,2}&?)\|?\s*(['\"]?)([^'\"\s|&;<>()]+)\1")
_TEE_PATTERN = re.compile(
    r"(?<![\w-])tee(?:\s+-{1,2}[A-Za-z][\w-]*(?:=[^\s|&;]+)?)*\s+(['\"]?)([^'\"\s|&;]+)\1"
)
```

Group 1 captures the opening quote, but group 2 still refuses a space, so `> "…/my dir/x.txt"` matches at **no** position at all — not partially, not at the wrong offset. `_shell_write_targets` returns `[]`, and both callers are written as "iterate the targets, return a block for the first bad one":

```python
for target in _shell_write_targets(command):
    ...
return None
```

An empty list means `None`, which means allowed. Quoting a path that happens to contain a space is enough to write outside the workspace with lockdown on, and enough to write to a `workspace_write_deny` glob. Measured on `4ca69ff`:

| command | `main` | this PR |
|---|---|---|
| `echo p > "/tmp/my custom folder/outside.txt"` | `[]` **(allowed)** | `['/tmp/my custom folder/outside.txt']` |
| `echo p > '/tmp/my custom folder/outside.txt'` | `[]` **(allowed)** | `['/tmp/my custom folder/outside.txt']` |
| `echo p \| tee "/tmp/my dir/x.txt"` | `[]` **(allowed)** | `['/tmp/my dir/x.txt']` |
| `echo p > "/tmp/John's Notes/out.txt"` | `[]` **(allowed)** | `["/tmp/John's Notes/out.txt"]` |
| `echo p > '/tmp/say "hi"/out.txt'` | `[]` **(allowed)** | `['/tmp/say "hi"/out.txt']` |
| `echo ok > "AT&T report.txt"` | `[]` **(allowed)** | `['AT&T report.txt']` |

The last three rows are why the body has to be **per-quote**, not just "not a quote". A single body of `[^'"]+` behind a `(['"])…\1` backreference — the obvious shape, and the one #1578 uses — still fails open on every one of them: inside `"…"` the body stops at the apostrophe, the closing `"` is never reached, and the bare alternative cannot start on a quote either, so the parser reports nothing. `~/John's Notes` and `Documents/Client's brief` are ordinary directory names on macOS and Windows, so that is the same p1 fail-open wearing a different path.

## The fix

Three-way alternation, exactly as specified in the #1242 review — the quoted bodies end at their own quote, the bare body is unchanged from `main`:

```python
_REDIRECTION_PATTERN = re.compile(
    r"""(?:&>{1,2}|\d*>{1,2}&?)\|?\s*(?:"([^"]+)"|'([^']+)'|([^'"\s|&;<>()]+))"""
)
_TEE_PATTERN = re.compile(
    r"(?<![\w-])tee(?:\s+-{1,2}[A-Za-z][\w-]*(?:=[^\s|&;]+)?)*\s+"
    r"""(?:"([^"]+)"|'([^']+)'|([^'"\s|&;]+))"""
)
```

and `_shell_write_targets` takes whichever group participated:

```python
targets.append(next(group for group in match.groups() if group is not None))
```

Deliberately left alone:

- **The bare-target class.** `echo ok > /tmp/John Doe/out.txt` redirects to `/tmp/John` and passes `Doe/out.txt` to `echo`; `main`'s truncation at whitespace is what the shell does. Widening it would trade the reported fail-open for a `workspace_write_deny` bypass on entirely ordinary commands (`> reports/out.txt 2>/dev/null`), which is the regression the #1242 review found. Item 3 of the issue ("unquoted paths should not be truncated") is therefore **declined as specified** and fixed as a test-side bug instead — see below.
- **The null-sink handling and `_FD_DUP_PATTERN`.** Untouched; `> "/dev/null"` now parses and is dropped by the existing `_NULL_SINK_PATH` filter, and a quoted `&` survives the FD-dup pre-pass (there is a test for each).
- **No filesystem access in the parser.** A verdict that depends on `Path.exists()` is machine-dependent; this stays pure string work.

**The 10 failing tests are a test-side bug, and this fixes that side.** `test_workspace_lockdown_blocks_redirection_without_whitespace` (6 cases) and `..._blocks_tee_without_whitespace_or_long_options` (4) interpolated `{target}` **unquoted**, so they only passed where pytest's tmp path had no space. They now quote the interpolation. The operator matrix they exist to cover (`>`, `>>`, `2>`, `>&`, `&>`, `cat<in>`, `tee -a/--append/--output-error=`) is unaffected, because the operator prefix is shared by both branches, and unquoted end-to-end lockdown coverage is unchanged in `test_workspace_lockdown_blocks_obvious_outside_shell_redirection`. Reproduced and fixed:

```
# on 4ca69ff, with a basetemp containing a space
$ uv run pytest tests/test_tools/test_shell_approval_policy.py -q --basetemp="…/base temp/bt"
11 failed, 79 passed in 2.32s
   test_workspace_lockdown_blocks_redirection_without_whitespace          (6)
   test_workspace_lockdown_blocks_tee_without_whitespace_or_long_options  (4)
   test_workspace_lockdown_still_blocks_a_real_target_beside_a_null_sink  (1)

# on this branch, same basetemp
131 passed in 2.17s
```

(The 11th, `…_beside_a_null_sink`, has the same unquoted f-string and is fixed the same way — the issue's count of 10 missed it.)

## Tests

`tests/test_tools/test_shell_approval_policy.py`, +41 cases, all offline, no network, no credentials, no `skipif`.

Parser level:
- `…_detects_quoted_redirection_targets_with_spaces` — 7 cases: `> "…"`, `> '…'`, `>"…"`, `>> "…"`, `2> "…"`, `&> "…"`, `>&"…"`.
- `…_detects_quoted_tee_targets_with_spaces` — 7 cases incl. `|tee`, `-a`, `--append`, `--output-error=warn`, `/usr/bin/tee`, single quotes.
- `…_detects_quoted_targets_holding_the_other_quote` — 4 cases: apostrophe inside `"…"`, double quote inside `'…'`, for both redirection and `tee`. **This is the set a backreference body cannot pass.**
- `…_quoted_target_survives_the_fd_dup_prepass` — 2 cases, `"AT&T report.txt"` (the review note on `_FD_DUP_PATTERN`).
- `…_leaves_unquoted_targets_unchanged` — 9 cases pinning the bare class to `main`'s exact output: `/tmp/John Doe/out.txt → ['/tmp/John']`, `/tmp/.env extra`, `out.txt # note`, `out.txt 2>/dev/null`, `tee reports/o.txt;whoami`, heredoc, `2>&1`, `>&2`, `mytee`.

Block-envelope level (the layer the bypass actually lives in):
- `…_lockdown_blocks_quoted_targets_with_spaces` — 5 cases through `_check_exec_approval`, asserting `status: blocked`, `reason: workspace_lockdown`, and both `target` and `resolved_path` equal to the full spaced path.
- `…_write_deny_globs_block_quoted_targets_with_spaces` — 3 cases, asserting `matched_pattern`.
- `…_write_deny_globs_block_bare_target_with_a_trailing_token` — 4 cases (`> reports/out.txt 2>/dev/null`, `… extra`, `… # note`, `tee --append reports/out.txt;whoami`). **The regression guard requested in review item 4.**

Which fail without the fix: reverting only `src/agentos/tools/builtin/shell.py` to `upstream/main` leaves **28 of the new cases failing** — every quoted case, at both the parser and the block-envelope layer.

Pass either way by design: `…_leaves_unquoted_targets_unchanged` (9) and `…_write_deny_globs_block_bare_target_with_a_trailing_token` (4). They are guards, not proofs — they exist so a later widening of the bare body fails loudly instead of silently reopening the deny-glob bypass.

## Verification

```
$ git show upstream/main:src/agentos/tools/builtin/shell.py > src/agentos/tools/builtin/shell.py
$ uv run pytest tests/test_tools/test_shell_approval_policy.py -q -p no:randomly
28 failed, 103 passed in 2.87s

$ # fix restored
$ uv run pytest tests/test_tools/test_shell_approval_policy.py -q -p no:randomly
131 passed in 2.26s

$ uv run pytest -q
6 failed, 10477 passed, 34 skipped, 4 warnings, 3 errors in 261.05s (0:04:21)

$ uv run ruff check src tests
All checks passed!

$ uv run ruff format --check src/agentos/tools/builtin/shell.py
1 file already formatted

$ uv run mypy --show-error-codes src
Success: no issues found in 625 source files
```

The 6 failures + 3 errors in the full run are pre-existing on `upstream/main` on this machine and untouched by this change — unhydrated MiniLM ONNX assets (`test_pilot_encoder`, `test_build_wheelhouse_zip`, `test_pilot_benchmark`) and `test_tracked_public_files_do_not_carry_this_machines_timezone`. `tests/test_tools/` is green end to end. `ruff format --check` is not run over the whole tree here: `tests/test_tools/test_shell_approval_policy.py` already fails it on `upstream/main` (one trailing blank line at EOF), and reformatting a file this PR only appends to would bury the diff.

## One adjacent case, deliberately left alone

The parser still does not understand **escaped** quotes or backslash-escaped spaces: `> /tmp/my\ dir/out.txt` and `> "a\"b.txt"` are outside both branches. Closing those means a real tokenizer rather than a regex, which is a larger change than a p1 hotfix should carry, and neither is a regression from `main` — they fail open there too. Happy to open a follow-up if you want the tokenizer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011s5hBwvxsQK2oPZkMb5KRK
