### PR TITLE
fix(session): canonicalize spawned_by and parent_session_key across storage and tools

### DIFF
--- a/src/agentos/session/manager.py
+++ b/src/agentos/session/manager.py
@@ -258,6 +258,12 @@ class SessionManager:
             raise ValueError(f"Session already exists: {session_key}")
         if kwargs.get("project_id"):
             await self._require_project(str(kwargs["project_id"]))
+        if kwargs.get("spawned_by"):
+            kwargs["spawned_by"] = canonicalize_session_key(str(kwargs["spawned_by"]))
+        if kwargs.get("parent_session_key"):
+            kwargs["parent_session_key"] = canonicalize_session_key(
+                str(kwargs["parent_session_key"])
+            )
 
         now = _now_ms()
         node = SessionNode(

--- a/src/agentos/session/storage.py
+++ b/src/agentos/session/storage.py
@@ -662,6 +662,10 @@ class SessionStorage:
     async def upsert_session(self, node: SessionNode) -> None:
         node.session_key = canonicalize_session_key(node.session_key)
         node.agent_id = normalize_agent_id(node.agent_id)
+        if node.parent_session_key:
+            node.parent_session_key = canonicalize_session_key(node.parent_session_key)
+        if node.spawned_by:
+            node.spawned_by = canonicalize_session_key(node.spawned_by)
         data = node.model_dump()
         cols = list(data.keys())
         placeholders = ", ".join("?" for _ in cols)

--- a/src/agentos/tools/builtin/agents.py
+++ b/src/agentos/tools/builtin/agents.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import structlog
 
+from agentos.session.keys import canonicalize_session_key
 from agentos.tools.builtin.sessions import _get_session_manager, _get_task_runtime
 from agentos.tools.registry import tool
 from agentos.tools.types import ToolError, current_tool_context
@@ -56,7 +57,10 @@ def _spawned_by(session_or_dict: object) -> object:
 def _check_spawned_by_or_raise(session_or_dict: object, current_key: str | None) -> None:
     if current_key is None:
         raise ToolError("session context required")
-    if _spawned_by(session_or_dict) != current_key:
+    spawned_by = _spawned_by(session_or_dict)
+    if not spawned_by or canonicalize_session_key(str(spawned_by)) != canonicalize_session_key(
+        current_key
+    ):
         raise ToolError("Session was not spawned by this session")
 
 
@@ -126,11 +130,15 @@ async def subagents(
             if current_key is None:
                 log.warning("subagents.list_no_session_context")
                 return json.dumps({"action": "list", "subagents": []})
-            all_sessions = await mgr.list_sessions()
+            canonical_current = canonicalize_session_key(current_key)
+            try:
+                all_sessions = await mgr.list_sessions(spawned_by=canonical_current)
+            except TypeError:
+                all_sessions = await mgr.list_sessions()
             subs = [
                 s
                 for s in all_sessions
-                if isinstance(s, dict) and s.get("spawned_by") == current_key
+                if canonicalize_session_key(str(_spawned_by(s))) == canonical_current
             ]
             return json.dumps({"action": "list", "subagents": subs})
         except (ImportError, AttributeError, NotImplementedError) as exc:

--- a/src/agentos/tools/builtin/sessions.py
+++ b/src/agentos/tools/builtin/sessions.py
@@ -10,7 +10,11 @@ import structlog
 
 from agentos.agents.limits import MAX_SPAWN_DEPTH
 from agentos.gateway.routing import build_subagent_route_envelope
-from agentos.session.keys import build_subagent_session_key, parse_agent_id
+from agentos.session.keys import (
+    build_subagent_session_key,
+    canonicalize_session_key,
+    parse_agent_id,
+)
 from agentos.session.naming import normalize_session_name
 from agentos.tools.registry import tool
 from agentos.tools.types import SafeToolError, ToolError, current_tool_context
@@ -388,6 +392,7 @@ async def sessions_spawn(
 
         if not parent_session_key:
             raise ToolError("Cannot spawn subagent without a parent session")
+        parent_session_key = canonicalize_session_key(parent_session_key)
         if current_depth >= _MAX_SPAWN_DEPTH:
             raise ToolError(f"Max spawn depth ({_MAX_SPAWN_DEPTH}) exceeded")
 
@@ -658,7 +663,11 @@ async def sessions_yield(
         current = await mgr.get_current_session()
         if current is not None:
             current_key = getattr(current, "session_key", None)
-            if current_key == session_key:
+            if (
+                current_key
+                and session_key
+                and canonicalize_session_key(current_key) == canonicalize_session_key(session_key)
+            ):
                 raise ToolError("Cannot yield to own session")
     except ToolError:
         raise

--- a/tests/test_tools/test_subagents_canonical_keys.py
+++ b/tests/test_tools/test_subagents_canonical_keys.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agentos.session.keys import canonicalize_session_key
+from agentos.session.manager import SessionManager
+from agentos.session.models import SessionNode, SessionStatus
+from agentos.session.storage import SessionStorage
+from agentos.tools.builtin import agents as agents_tool
+from agentos.tools.builtin import sessions as sessions_tool
+from agentos.tools.types import CallerKind, ToolContext, ToolError, current_tool_context
+
+
+class _StubSessionManager:
+    def __init__(self) -> None:
+        self.killed: list[str] = []
+        self.injected: list[tuple[str, str]] = []
+        self.get_session_calls: list[str] = []
+        self.sessions = [
+            {
+                "session_key": "subagent:agent:main:c1",
+                "spawned_by": "agent:main:webchat:default",
+                "status": "running",
+            },
+        ]
+
+    async def get_current_session(self):
+        return None
+
+    async def list_sessions(self, spawned_by: str | None = None, **kwargs):
+        if spawned_by is not None:
+            return [
+                s
+                for s in self.sessions
+                if canonicalize_session_key(s.get("spawned_by"))
+                == canonicalize_session_key(spawned_by)
+            ]
+        return list(self.sessions)
+
+    async def get_session(self, session_key: str):
+        self.get_session_calls.append(session_key)
+        for s in self.sessions:
+            if s["session_key"] == session_key:
+                return dict(s)
+        return None
+
+    async def kill_session(self, session_key: str) -> None:
+        self.killed.append(session_key)
+
+    async def inject_message(self, session_key: str, message: str, provenance: str) -> None:
+        self.injected.append((session_key, message))
+
+
+def _ctx(session_key: str | None) -> ToolContext:
+    return ToolContext(
+        caller_kind=CallerKind.AGENT,
+        session_key=session_key,
+        agent_id="main",
+    )
+
+
+@pytest.fixture
+def stub_manager():
+    mgr = _StubSessionManager()
+    sessions_tool.set_session_manager(mgr)
+    sessions_tool.set_task_runtime(None)
+    yield mgr
+    sessions_tool.set_session_manager(None)
+    sessions_tool.set_task_runtime(None)
+
+
+@pytest.mark.asyncio
+async def test_subagents_list_matches_aliased_session_key(
+    stub_manager: _StubSessionManager,
+) -> None:
+    token = current_tool_context.set(_ctx("webchat:default"))
+    try:
+        raw = await agents_tool.subagents("list")
+        payload = json.loads(raw)
+    finally:
+        current_tool_context.reset(token)
+
+    assert payload["action"] == "list"
+    assert len(payload["subagents"]) == 1
+    assert payload["subagents"][0]["session_key"] == "subagent:agent:main:c1"
+
+
+@pytest.mark.asyncio
+async def test_subagents_kill_and_steer_accepts_aliased_session_key(
+    stub_manager: _StubSessionManager,
+) -> None:
+    token = current_tool_context.set(_ctx("webchat:default"))
+    try:
+        # kill
+        kill_raw = await agents_tool.subagents("kill", session_key="subagent:agent:main:c1")
+        kill_payload = json.loads(kill_raw)
+        assert kill_payload["status"] == "killed"
+        assert stub_manager.killed == ["subagent:agent:main:c1"]
+
+        # steer
+        steer_raw = await agents_tool.subagents(
+            "steer", session_key="subagent:agent:main:c1", message="continue"
+        )
+        steer_payload = json.loads(steer_raw)
+        assert steer_payload["status"] == "delivered"
+        assert stub_manager.injected == [("subagent:agent:main:c1", "continue")]
+    finally:
+        current_tool_context.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_storage_upsert_canonicalizes_spawned_by_and_parent_session_key(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "sessions.db"
+    storage = SessionStorage(str(db_path))
+    await storage.connect()
+    try:
+        node = SessionNode(
+            session_key="subagent:agent:main:test1",
+            session_id="uuid-1",
+            agent_id="main",
+            parent_session_key="webchat:default",
+            spawned_by="webchat:default",
+            status=SessionStatus.RUNNING,
+        )
+        await storage.upsert_session(node)
+
+        # list_sessions queries using canonicalized spawned_by
+        results = await storage.list_sessions(spawned_by="webchat:default")
+        assert len(results) == 1
+        assert results[0].session_key == "subagent:agent:main:test1"
+        assert results[0].spawned_by == "agent:main:webchat:default"
+        assert results[0].parent_session_key == "agent:main:webchat:default"
+    finally:
+        await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_sessions_yield_detects_self_yield_with_alias() -> None:
+    class _CurrentSessionManager:
+        async def get_current_session(self):
+            return type("Obj", (), {"session_key": "agent:main:webchat:default"})()
+
+    sessions_tool.set_session_manager(_CurrentSessionManager())
+    try:
+        with pytest.raises(ToolError, match="Cannot yield to own session"):
+            await sessions_tool.sessions_yield(session_key="webchat:default")
+    finally:
+        sessions_tool.set_session_manager(None)
+
+
+@pytest.mark.asyncio
+async def test_manager_create_canonicalizes_spawned_by_and_parent(tmp_path: Path) -> None:
+    db_path = tmp_path / "manager_test.db"
+    storage = SessionStorage(str(db_path))
+    await storage.connect()
+    try:
+        mgr = SessionManager(storage)
+        node = await mgr.create(
+            session_key="subagent:agent:main:test2",
+            spawned_by="webchat:default",
+            parent_session_key="webchat:default",
+        )
+        assert node.spawned_by == "agent:main:webchat:default"
+        assert node.parent_session_key == "agent:main:webchat:default"
+
+        # Lookup in storage
+        queried = await storage.list_sessions(spawned_by="webchat:default")
+        assert len(queried) == 1
+        assert queried[0].session_key == "subagent:agent:main:test2"
+    finally:
+        await storage.close()


### PR DESCRIPTION
Closes #1744

### Summary

When sessions are created or subagents are spawned from session aliases such as `webchat:default` (which canonicalizes to `agent:main:webchat:default`), `spawned_by` and `parent_session_key` were stored in raw uncanonicalized form in `SessionNode`. However, `SessionStorage.list_sessions(spawned_by=...)` queries using `canonicalize_session_key(spawned_by)`.

Because the SQLite row stored the raw uncanonicalized key while the SQL query filtered against the canonical form, SQL lookups returned 0 child sessions.

This resulted in:
1. `_count_active_children` returning 0, bypassing `max_children_per_session` for aliased parent sessions.
2. `_cascade_kill_children` in `SessionManager.kill_session` failing to find running children, leaving orphan subagent tasks.
3. `subagents("list")` failing to list subagents spawned by aliased parent sessions.
4. `subagents("kill")` and `subagents("steer")` failing with `ToolError("Session was not spawned by this session")` due to raw key mismatch.
5. `sessions_yield(session_key=...)` failing to detect self-yield when one key is in alias form.

### Changes

- **`src/agentos/session/storage.py`**: Canonicalize `node.parent_session_key` and `node.spawned_by` in `upsert_session`.
- **`src/agentos/session/manager.py`**: Canonicalize `spawned_by` and `parent_session_key` in `create(...)`.
- **`src/agentos/tools/builtin/sessions.py`**:
  - Canonicalize `parent_session_key` in `sessions_spawn`.
  - Canonicalize both keys when checking for self-yield in `sessions_yield`.
- **`src/agentos/tools/builtin/agents.py`**:
  - Compare canonicalized keys in `_check_spawned_by_or_raise`.
  - Query `mgr.list_sessions(spawned_by=canonical_current)` and compare canonicalized keys in `subagents(action="list")`.
- **`tests/test_tools/test_subagents_canonical_keys.py`**:
  - Added regression tests covering `subagents("list")`, `subagents("kill")`, `subagents("steer")`, `SessionStorage.list_sessions(spawned_by=...)`, `SessionManager.create(...)`, and `sessions_yield` self-yield detection with alias keys.

### Quality Gate
- `uv run pytest tests/test_tools/test_subagents_canonical_keys.py tests/test_tools/test_subagents_ownership.py tests/test_session/test_kill_cascade.py` passed (11 passed).
- `uv run ruff check` passed.
- `uv run mypy` passed.
