### PR TITLE
fix(provider): classify an unavailable model as MODEL_NOT_FOUND

### DIFF
--- a/src/agentos/provider/failures.py
+++ b/src/agentos/provider/failures.py
@@ -150,6 +150,32 @@ def _is_gateway_transient(text: str) -> bool:
     return bool(_GATEWAY_TRANSIENT_RE.search(text))
 
 
+#: Phrases a provider uses to say the thing it was asked for is not there.
+#: Deliberately not a bare ``"not_found"``: that substring turns up in unrelated
+#: error codes, and every one it caught would be routed to a second provider.
+_MISSING_MARKERS: tuple[str, ...] = (
+    # OpenAI error code, and its message:
+    # "The model `gpt-5` does not exist or you do not have access to it."
+    "model_not_found",
+    "does not exist",
+    # Google: "models/gemini-2.5-pro is not found for API version v1beta"
+    "is not found",
+    "was not found",
+)
+
+
+def _names_a_missing_model(text: str) -> bool:
+    """Return whether *text* says a **model** is missing, not some other resource.
+
+    The model word is load-bearing, not decoration. OpenAI answers an ordinary
+    bad request with ``400 invalid_request_error`` and "The file you provided
+    does not exist"; on the marker alone that would classify as
+    ``MODEL_NOT_FOUND`` and earn ``FALLBACK_PROVIDER``, which burns a second
+    provider on a request that is malformed against every one of them.
+    """
+    return "model" in text and any(marker in text for marker in _MISSING_MARKERS)
+
+
 def classify_provider_error(
     provider_name: str,
     status_code: int | None,
@@ -177,7 +203,17 @@ def classify_provider_error(
             return ProviderFailureKind.INSUFFICIENT_CREDITS
         if status_code == 429 or "rate limit" in text or "rate_limit" in text:
             return ProviderFailureKind.RATE_LIMITED
-        if "no endpoints found" in text or "model not found" in text:
+        # A 404 from a chat-completions endpoint is a model or base-url problem,
+        # and falling through to the next configured model is the right recovery
+        # for both. Google answers an unavailable model with 404 and a body that
+        # matches neither literal above, so the whole turn surfaced as UNKNOWN
+        # and the fallback chain never ran (#1359).
+        if (
+            status_code == 404
+            or "no endpoints found" in text
+            or "model not found" in text
+            or _names_a_missing_model(text)
+        ):
             return ProviderFailureKind.MODEL_NOT_FOUND
         if "does not support" in text or "unsupported" in text:
             return ProviderFailureKind.UNSUPPORTED_FEATURE

--- a/tests/test_provider_failures.py
+++ b/tests/test_provider_failures.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from agentos.provider.failures import ProviderFailureKind, classify_provider_error
+from agentos.provider.failures import (
+    ProviderFailureKind,
+    ProviderRecoveryAction,
+    classify_provider_error,
+    decide_recovery_action,
+)
 
 
 def test_provider_request_budget_exhausted_is_context_overflow() -> None:
@@ -183,3 +188,116 @@ def test_deepseek_insufficient_quota_is_credits() -> None:
         is ProviderFailureKind.INSUFFICIENT_CREDITS
     )
 
+
+# --- #1359: an unavailable model has to reach the fallback chain -------------
+
+#: The body Google returns when the configured model is not on the key's
+#: allowlist. Reproduced verbatim from the issue.
+_GEMINI_404_BODY = (
+    "models/gemini-2.5-pro is not found for API version v1beta, "
+    "or is not supported for generateContent."
+)
+
+
+def test_gemini_404_unavailable_model_is_model_not_found() -> None:
+    """The classification, not just the recovery action.
+
+    ``gemini`` is in the ``openai_compat`` family, whose branch matched only
+    ``"no endpoints found"`` and ``"model not found"``. Google's wording matches
+    neither and 404 was not a transient status, so the turn fell through to
+    ``UNKNOWN``.
+    """
+    assert (
+        classify_provider_error(
+            provider_name="gemini",
+            status_code=404,
+            raw_code="NOT_FOUND",
+            message=_GEMINI_404_BODY,
+        )
+        is ProviderFailureKind.MODEL_NOT_FOUND
+    )
+
+
+def test_gemini_404_unavailable_model_falls_back_instead_of_surfacing() -> None:
+    """The consequence the operator actually sees: the next model is tried."""
+    kind = classify_provider_error(
+        provider_name="gemini",
+        status_code=404,
+        raw_code="NOT_FOUND",
+        message=_GEMINI_404_BODY,
+    )
+
+    assert decide_recovery_action(kind) is ProviderRecoveryAction.FALLBACK_PROVIDER
+
+
+def test_gemini_unavailable_model_is_model_not_found_without_a_status_code() -> None:
+    """Some transports hand the body up with no status attached.
+
+    The status code carries the match on its own, so this pins the *text*
+    marker: without it the same failure classifies differently depending on how
+    far the status survived the transport.
+    """
+    assert (
+        classify_provider_error(
+            provider_name="gemini",
+            status_code=None,
+            message=_GEMINI_404_BODY,
+        )
+        is ProviderFailureKind.MODEL_NOT_FOUND
+    )
+
+
+def test_openai_model_does_not_exist_is_model_not_found() -> None:
+    """OpenAI's own phrasing for the same failure, which also fell through."""
+    assert (
+        classify_provider_error(
+            provider_name="openai",
+            status_code=404,
+            raw_code="model_not_found",
+            message="The model `gpt-5` does not exist or you do not have access to it.",
+        )
+        is ProviderFailureKind.MODEL_NOT_FOUND
+    )
+
+
+def test_a_missing_file_is_still_a_bad_request() -> None:
+    """Guard: the missing-resource marker must not widen past models.
+
+    ``FALLBACK_PROVIDER`` on a malformed request burns a second provider on a
+    call that is malformed against every one of them, so "does not exist" only
+    counts when the message is about a model.
+    """
+    assert (
+        classify_provider_error(
+            provider_name="openai",
+            status_code=400,
+            raw_code="invalid_request_error",
+            message="The file you provided does not exist",
+        )
+        is ProviderFailureKind.BAD_REQUEST
+    )
+
+
+def test_an_unrelated_model_mention_is_not_a_missing_model() -> None:
+    """Guard: naming a model is not the same as reporting one missing."""
+    assert (
+        classify_provider_error(
+            provider_name="openrouter",
+            status_code=None,
+            message="openrouter model id 520",
+        )
+        is ProviderFailureKind.UNKNOWN
+    )
+
+
+def test_404_outside_the_openai_compatible_family_is_unchanged() -> None:
+    """Guard: the change is scoped to the family the issue reports."""
+    assert (
+        classify_provider_error(
+            provider_name="anthropic",
+            status_code=404,
+            raw_code="not_found_error",
+            message="a resource was not found",
+        )
+        is ProviderFailureKind.UNKNOWN
+    )


### PR DESCRIPTION
Fixes #1359

Scoped to what the issue triage put in scope — the classification — and nothing else. Items 2 and 3 (model names in error copy, onboarding field descriptions) are left out, as ruled.

## The bug

`gemini` is in the `openai_compat` family, and that branch recognises a missing model by two literals (`failures.py:180` on `4ca69ff`):

```python
if "no endpoints found" in text or "model not found" in text:
    return ProviderFailureKind.MODEL_NOT_FOUND
```

Google's body is `models/gemini-2.5-pro is not found for API version v1beta, or is not supported for generateContent.` — neither substring is present, `"is not supported"` is not `"does not support"` or `"unsupported"` either, and 404 is not in `_GATEWAY_TRANSIENT_STATUS_CODES`. So the turn falls off the end of the function:

```
$ uv run python -c "..."   # on 4ca69ff
kind   = unknown
action = surface
```

`SURFACE` is the one action that does not try the next model. An operator whose key simply lacks `gemini-2.5-pro` gets the raw upstream 404 and a dead turn, with a perfectly good fallback chain configured and never consulted.

It is not only Google. OpenAI answers the same condition with HTTP 404, `code: "model_not_found"`, and `The model \`gpt-5\` does not exist or you do not have access to it.` — `"model_not_found"` has an underscore, so `"model not found"` misses it too, and that path is `UNKNOWN` on `main` as well.

| `classify_provider_error(...)` | `main` | this PR |
|---|---|---|
| `gemini`, 404, `models/gemini-2.5-pro is not found…` | `unknown` → **surface** | `model_not_found` → **fallback_provider** |
| `gemini`, no status, same body | `unknown` → surface | `model_not_found` → fallback_provider |
| `openai`, 404, `model_not_found`, `The model … does not exist` | `unknown` → surface | `model_not_found` → fallback_provider |
| `openai`, 400, `invalid_request_error`, `The file you provided does not exist` | `bad_request` | `bad_request` (unchanged) |
| `openrouter`, no status, `openrouter model id 520` | `unknown` | `unknown` (unchanged) |
| `anthropic`, 404, `a resource was not found` | `unknown` | `unknown` (unchanged) |

## The fix

Two things in the `openai_compat` branch, and nothing outside it:

```python
if (
    status_code == 404
    or "no endpoints found" in text
    or "model not found" in text
    or _names_a_missing_model(text)
):
    return ProviderFailureKind.MODEL_NOT_FOUND
```

**`status_code == 404`** — per the triage note, a 404 from a chat-completions endpoint is a model or base-url problem and `FALLBACK_PROVIDER` is the right recovery for both.

**`_names_a_missing_model(text)`** — for the cases where the status did not survive the transport, so the same upstream failure does not classify differently depending on how it was carried:

```python
_MISSING_MARKERS: tuple[str, ...] = (
    "model_not_found",   # OpenAI error code and message
    "does not exist",
    "is not found",      # Google
    "was not found",
)

def _names_a_missing_model(text: str) -> bool:
    return "model" in text and any(marker in text for marker in _MISSING_MARKERS)
```

The `"model" in text` conjunct is the load-bearing part, not decoration. On the marker alone, `400 invalid_request_error / "The file you provided does not exist"` would classify as `MODEL_NOT_FOUND`, earn `FALLBACK_PROVIDER`, and burn a second provider on a request that is malformed against every one of them. There is a test pinning exactly that message to `BAD_REQUEST`.

A bare `"not_found"` substring is deliberately **not** a marker — it appears in unrelated error codes (`not_found_error`, `NotFoundError`), and each one it caught would be routed to a second provider for no reason.

Ordering is unchanged relative to the neighbouring branches: `MODEL_NOT_FOUND` already sat above `UNSUPPORTED_FEATURE` and above `400 / invalid_request`, and both it and `UNSUPPORTED_FEATURE` map to `FALLBACK_PROVIDER`, so a message that trips both resolves to the same action either way.

## Tests

`tests/test_provider_failures.py`, +7 cases, offline, deterministic, no credentials, no network, no `skipif`.

Fail without the fix (4):
- `test_gemini_404_unavailable_model_is_model_not_found` — the **classification** for the exact 404 body from the issue, as requested in triage.
- `test_gemini_404_unavailable_model_falls_back_instead_of_surfacing` — the recovery action that follows from it.
- `test_gemini_unavailable_model_is_model_not_found_without_a_status_code` — pins the text marker rather than the status code.
- `test_openai_model_does_not_exist_is_model_not_found` — OpenAI's own phrasing for the same failure.

Pass either way by design (3) — guards, so a later widening of the marker fails loudly instead of silently sending malformed requests to a second provider:
- `test_a_missing_file_is_still_a_bad_request` — the non-model `"does not exist"` case.
- `test_an_unrelated_model_mention_is_not_a_missing_model` — naming a model is not reporting one missing.
- `test_404_outside_the_openai_compatible_family_is_unchanged` — pins the scope boundary; `anthropic` + 404 stays `UNKNOWN`.

## Verification

```
$ git show upstream/main:src/agentos/provider/failures.py > src/agentos/provider/failures.py
$ uv run pytest tests/test_provider_failures.py -q -p no:randomly
4 failed, 16 passed in 0.32s

$ # fix restored
$ uv run pytest tests/test_provider_failures.py -q -p no:randomly
20 passed in 0.30s

$ uv run pytest -q
6 failed, 10443 passed, 34 skipped, 4 warnings, 3 errors in 252.42s (0:04:12)

$ uv run ruff check src tests
All checks passed!

$ uv run ruff format --check src/agentos/provider/failures.py
1 file already formatted

$ uv run mypy --show-error-codes src
Success: no issues found in 625 source files
```

The 6 failures + 3 errors in the full run are pre-existing on `upstream/main` on this machine and untouched here — unhydrated MiniLM ONNX assets (`test_pilot_encoder`, `test_build_wheelhouse_zip`, `test_pilot_benchmark`) and `test_tracked_public_files_do_not_carry_this_machines_timezone`. Every provider test passes, including `test_provider_openai_compat_family_parity.py` and `test_provider_failure_classification.py`.

`ruff format --check` is not run across the tree: `tests/test_provider_failures.py` already fails it on `upstream/main` (blank lines inside two existing call expressions), and reformatting a file this PR only appends to would bury the diff. The appended block is format-clean on its own.

## One adjacent case, deliberately left alone

The generic tail that runs for providers in no family still has no 404 handling, so a 404 there is `UNKNOWN`. The issue reports the `openai_compat` path and the triage scoped the fix to it, and widening the tail would change the classification for every provider registered without a `failure_family` — a bigger blast radius than this warrants. Happy to follow up if you want that tail to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011s5hBwvxsQK2oPZkMb5KRK
