### PR TITLE
fix(tools): record workspace file writes in http_request with output_path (#1747)

### DIFF
--- a/src/agentos/tools/builtin/web.py
+++ b/src/agentos/tools/builtin/web.py
@@ -21,6 +21,7 @@ from agentos.tools.registry import tool
 from agentos.tools.ssrf import assert_not_metadata_endpoint
 from agentos.tools.ssrf_client import ssrf_guarded_client, validate_metadata_only_address
 from agentos.tools.types import ToolError, UnsupportedURLSchemeError, current_tool_context
+from agentos.tools.write_tracking import record_workspace_file_write
 
 
 def _validate_http_url(url: str) -> None:
@@ -179,6 +180,7 @@ def _save_http_response_body(raw_body: bytes, output_path: str | None) -> tuple[
         return path, digest
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(raw_body)
+    record_workspace_file_write(path)
     return path, digest
 
 

--- a/tests/test_tools/test_web_http_request.py
+++ b/tests/test_tools/test_web_http_request.py
@@ -11,7 +11,7 @@ import httpx
 import pytest
 
 from agentos.tools.builtin import web
-from agentos.tools.types import ToolError
+from agentos.tools.types import ToolContext, ToolError, current_tool_context
 
 HttpRequestCallable = Callable[..., Awaitable[str]]
 
@@ -465,3 +465,118 @@ async def test_http_request_env_overrides_download_limit(
 
 
 _STREAM_CHUNK = 65_536
+
+
+@pytest.mark.asyncio
+async def test_http_request_with_output_path_records_workspace_file_write(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    ctx = ToolContext(workspace_dir=str(workspace))
+    token = current_tool_context.set(ctx)
+
+    pdf_content = b"%PDF-1.4 sample binary content"
+    _patch_response(
+        monkeypatch,
+        httpx.Response(
+            200,
+            content=pdf_content,
+            headers={"content-type": "application/pdf"},
+            request=httpx.Request("GET", "https://example.test/quarterly_report.pdf"),
+        ),
+    )
+
+    try:
+        raw_result = await _original_http_request()(
+            url="https://example.test/quarterly_report.pdf",
+            output_path="quarterly_report.pdf",
+        )
+        payload = json.loads(raw_result)
+
+        assert payload["body_saved"] is True
+        saved_path = Path(payload["path"])
+        assert saved_path.exists()
+        assert saved_path.read_bytes() == pdf_content
+
+        assert len(ctx.workspace_file_writes) == 1
+        record = ctx.workspace_file_writes[0]
+        assert record["name"] == "quarterly_report.pdf"
+        assert record["relative_path"] == ".fetch/quarterly_report.pdf"
+        assert record["suffix"] == ".pdf"
+        assert record["path"] == str(saved_path.resolve(strict=False))
+    finally:
+        current_tool_context.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_http_request_with_nested_output_path_records_workspace_file_write(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    ctx = ToolContext(workspace_dir=str(workspace))
+    token = current_tool_context.set(ctx)
+
+    json_content = b'{"status": "ok", "items": [1, 2, 3]}'
+    _patch_response(
+        monkeypatch,
+        httpx.Response(
+            200,
+            content=json_content,
+            headers={"content-type": "application/json"},
+            request=httpx.Request("GET", "https://example.test/data.json"),
+        ),
+    )
+
+    try:
+        raw_result = await _original_http_request()(
+            url="https://example.test/data.json",
+            output_path="exports/nested/data.json",
+        )
+        payload = json.loads(raw_result)
+
+        assert payload["body_saved"] is True
+        saved_path = Path(payload["path"])
+        assert saved_path.exists()
+        assert saved_path.read_bytes() == json_content
+
+        assert len(ctx.workspace_file_writes) == 1
+        record = ctx.workspace_file_writes[0]
+        assert record["name"] == "data.json"
+        assert record["relative_path"] == ".fetch/exports/nested/data.json"
+        assert record["suffix"] == ".json"
+        assert record["path"] == str(saved_path.resolve(strict=False))
+    finally:
+        current_tool_context.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_http_request_without_output_path_does_not_record_workspace_write(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    ctx = ToolContext(workspace_dir=str(workspace))
+    token = current_tool_context.set(ctx)
+
+    _patch_response(
+        monkeypatch,
+        httpx.Response(
+            200,
+            content=b'{"key": "value"}',
+            headers={"content-type": "application/json"},
+            request=httpx.Request("GET", "https://example.test/data"),
+        ),
+    )
+
+    try:
+        raw_result = await _original_http_request()(url="https://example.test/data")
+        payload = json.loads(raw_result)
+        assert payload.get("body_saved") is not True
+        assert len(ctx.workspace_file_writes) == 0
+    finally:
+        current_tool_context.reset(token)


### PR DESCRIPTION
Fixes #1747

### Problem
When `http_request` downloaded response bodies into the workspace under `.fetch/<output_path>`, `_save_http_response_body()` in `src/agentos/tools/builtin/web.py` wrote the bytes directly to disk via `path.write_bytes(raw_body)` but omitted calling `record_workspace_file_write(path)`. Consequently, `ctx.workspace_file_writes` remained empty, preventing the turn-completion backstop `auto_publish_omitted_workspace_artifacts` from detecting and auto-delivering deliverables (such as `.pdf`, `.json`, `.csv`).

### Solution
- Imported `record_workspace_file_write` from `agentos.tools.write_tracking` in `src/agentos/tools/builtin/web.py`.
- Called `record_workspace_file_write(path)` inside `_save_http_response_body()` immediately after writing the bytes to disk.
- Added regression tests in `tests/test_tools/test_web_http_request.py` verifying that:
  - Saving with `output_path` records the file in `ctx.workspace_file_writes` with expected `path`, `relative_path`, `name`, and `suffix`.
  - Saving with nested `output_path` correctly tracks relative path within `.fetch`.
  - Requests without `output_path` do not record any workspace writes.

### Quality Gate
- `uv run pytest tests/test_tools/test_web_http_request.py -q` (17 passed)
- `uv run ruff check src tests` (All checks passed)
- `uv run ruff format --check src tests`
- `uv run mypy src/agentos --show-error-codes` (Success: no issues found in 625 source files)
