### PR TITLE
fix(gateway): persist elevatedMode in SQLite on approval resolve (Closes #1751)

### DIFF
--- a/src/agentos/application/approval_queue.py
+++ b/src/agentos/application/approval_queue.py
@@ -243,11 +243,16 @@ class ApprovalQueue:
                 return
             raise ValueError(f"Approval already resolved: {approval_id}")
 
+        updated_params = dict(entry.params)
+        if approved and elevated_mode in VALID_ELEVATED_MODES:
+            updated_params["elevatedMode"] = elevated_mode
+        payload = self._serialize_params(updated_params)
+
         cursor = self._conn.execute(
             "UPDATE approval_queue "
-            "SET resolved = 1, approved = ? "
+            "SET resolved = 1, approved = ?, params = ? "
             "WHERE approval_id = ? AND resolved = 0",
-            (1 if approved else 0, approval_id),
+            (1 if approved else 0, payload, approval_id),
         )
         if cursor.rowcount != 1:
             self._conn.rollback()
@@ -267,7 +272,6 @@ class ApprovalQueue:
         self._pending[approval_id] = entry
 
         if approved and elevated_mode in VALID_ELEVATED_MODES:
-            entry.params["elevatedMode"] = elevated_mode
             session_key = str(entry.params.get("sessionKey") or "").strip()
             if session_key:
                 self.set_elevated_mode(session_key, elevated_mode)

--- a/tests/test_gateway/test_approval_queue_persistence.py
+++ b/tests/test_gateway/test_approval_queue_persistence.py
@@ -191,3 +191,31 @@ def test_approval_queue_consume_is_one_shot_with_stale_unconsumed_read(
         assert queue.get(approval_id).consumed is True
     finally:
         queue.close()
+
+
+def test_approval_queue_resolve_persists_elevated_mode_across_restarts(tmp_path) -> None:
+    db_path = tmp_path / "approval_queue.sqlite"
+    queue = ApprovalQueue(db_path=str(db_path))
+    approval_id = queue.request(
+        "exec",
+        {
+            "toolName": "exec_command",
+            "command": "id",
+            "sessionKey": "agent:main:demo",
+        },
+    )
+    queue.resolve(approval_id, True, elevated_mode="full")
+
+    # Immediate status check on same instance
+    status = queue.status(approval_id)
+    assert status["params"].get("elevatedMode") == "full"
+    assert queue.get(approval_id).params.get("elevatedMode") == "full"
+    queue.close()
+
+    # Reopened from SQLite persistence
+    reloaded = ApprovalQueue(db_path=str(db_path))
+    reloaded_status = reloaded.status(approval_id)
+    assert reloaded_status["params"].get("elevatedMode") == "full"
+    assert reloaded.get(approval_id).params.get("elevatedMode") == "full"
+    reloaded.close()
+


### PR DESCRIPTION
Closes #1751

### Problem
When `ApprovalQueue.resolve(approval_id, approved, elevated_mode=...)` was called, `elevatedMode` was assigned to the in-memory entry but omitted from the SQLite `UPDATE` statement. Consequently, subsequent calls to `status()` or `get()` reloaded the row from SQLite, wiping out `elevatedMode` from `_pending` and losing elevated mode across queue restarts.

### Solution
- Persist the serialized `params` dictionary containing `elevatedMode` in the SQLite `approval_queue` table during `resolve()`.
- Added a regression test verifying that `elevatedMode` is preserved in `status()`, `get()`, and across queue restarts.