### PR TITLE
fix(tools): record workspace file write in http_request (Closes #1747)

### DIFF
--- a/src/agentos/tools/builtin/web.py
+++ b/src/agentos/tools/builtin/web.py
@@ -21,6 +21,7 @@ from agentos.tools.registry import tool
 from agentos.tools.ssrf import assert_not_metadata_endpoint
 from agentos.tools.ssrf_client import ssrf_guarded_client, validate_metadata_only_address
 from agentos.tools.types import ToolError, UnsupportedURLSchemeError, current_tool_context
+from agentos.tools.write_tracking import record_workspace_file_write
 
 
 def _validate_http_url(url: str) -> None:
@@ -179,6 +180,7 @@ def _save_http_response_body(raw_body: bytes, output_path: str | None) -> tuple[
         return path, digest
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(raw_body)
+    record_workspace_file_write(path)
     return path, digest
 
 

--- a/tests/test_tools/test_web_http_request.py
+++ b/tests/test_tools/test_web_http_request.py
@@ -465,3 +465,44 @@ async def test_http_request_env_overrides_download_limit(
 
 
 _STREAM_CHUNK = 65_536
+
+
+@pytest.mark.asyncio
+async def test_http_request_output_path_records_workspace_file_write(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from agentos.tools.types import ToolContext, current_tool_context
+
+    raw = b"%PDF-1.4 sample report content"
+    monkeypatch.chdir(tmp_path)
+    _patch_response(
+        monkeypatch,
+        httpx.Response(
+            200,
+            content=raw,
+            headers={"content-type": "application/pdf"},
+            request=httpx.Request("GET", "https://example.test/report.pdf"),
+        ),
+    )
+
+    ctx = ToolContext(workspace_dir=str(tmp_path))
+    token = current_tool_context.set(ctx)
+    try:
+        payload = json.loads(
+            await _original_http_request()(
+                url="https://example.test/report.pdf",
+                output_path="report.pdf",
+            )
+        )
+        saved_path = tmp_path / ".fetch" / "report.pdf"
+        assert Path(payload["path"]) == saved_path
+        assert saved_path.read_bytes() == raw
+        assert len(ctx.workspace_file_writes) == 1
+        record = ctx.workspace_file_writes[0]
+        assert record["name"] == "report.pdf"
+        assert record["suffix"] == ".pdf"
+        assert record["relative_path"] == ".fetch/report.pdf"
+    finally:
+        current_tool_context.reset(token)
+


### PR DESCRIPTION
Closes #1747


### Summary
When http_request downloads content to an output_path within the workspace, it wrote directly via 	arget_path.write_bytes(body) without calling 
ecord_workspace_file_write(target_path). As a result, files downloaded by http_request were not tracked as modified/created workspace files in turn result metadata, preventing automatic artifact delivery.

### Changes
- In src/agentos/tools/builtin/web.py: call 
ecord_workspace_file_write(target_path) in _save_http_response_body after writing the response bytes to disk.
- Added test 	est_http_request_output_path_records_workspace_file_write in 	ests/test_tools/test_web_http_request.py verifying 
ecord_workspace_file_write is invoked with the target path when output_path is specified.

