### PR TITLE
fix(session): synchronize schema initialization with reentrant write lock (Closes #1777)

### DIFF
--- a/src/agentos/session/storage.py
+++ b/src/agentos/session/storage.py
@@ -26,6 +26,43 @@ from agentos.session.models import (
 log = logging.getLogger(__name__)
 
 
+class _AsyncReentrantLock:
+    """Async reentrant lock bound to asyncio.current_task()."""
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._owner: asyncio.Task[Any] | None = None
+        self._depth = 0
+
+    async def acquire(self) -> None:
+        current_task = asyncio.current_task()
+        if self._owner is not None and self._owner is current_task:
+            self._depth += 1
+            return
+        await self._lock.acquire()
+        self._owner = current_task
+        self._depth = 1
+
+    def release(self) -> None:
+        current_task = asyncio.current_task()
+        if self._owner is not current_task:
+            raise RuntimeError("Cannot release un-owned lock")
+        self._depth -= 1
+        if self._depth == 0:
+            self._owner = None
+            self._lock.release()
+
+    def locked(self) -> bool:
+        return self._lock.locked()
+
+    async def __aenter__(self) -> _AsyncReentrantLock:
+        await self.acquire()
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self.release()
+
+
 def _serialized_write[**P, R](
     method: Callable[Concatenate[SessionStorage, P], Awaitable[R]],
 ) -> Callable[Concatenate[SessionStorage, P], Awaitable[R]]:
@@ -439,7 +476,7 @@ class SessionStorage:
     ) -> None:
         self._db_path = db_path
         self._conn: Any | None = None
-        self._write_lock = asyncio.Lock()
+        self._write_lock = _AsyncReentrantLock()
 
     async def connect(self) -> None:
         self._conn = await aiosqlite.connect(self._db_path)
@@ -459,6 +496,7 @@ class SessionStorage:
             await self._conn.close()
             self._conn = None
 
+    @_serialized_write
     async def _initialize_schema(self) -> None:
         assert self._conn is not None
         await self._conn.execute(_CREATE_SESSIONS)

--- a/tests/test_session/test_storage_transaction_serialization.py
+++ b/tests/test_session/test_storage_transaction_serialization.py
@@ -147,3 +147,50 @@ async def test_failed_write_rolls_back_before_releasing_serialization_lock() -> 
         assert await storage.count_sessions() == 1
     finally:
         await storage.close()
+
+
+async def test_initialize_schema_holds_write_lock() -> None:
+    storage = SessionStorage(":memory:")
+    lock_was_held = False
+    original_migrate = storage._migrate_epoch_column
+
+    async def checked_migrate() -> None:
+        nonlocal lock_was_held
+        lock_was_held = storage._write_lock.locked()
+        await original_migrate()
+
+    storage._migrate_epoch_column = checked_migrate  # type: ignore[method-assign]
+    try:
+        await storage.connect()
+        assert lock_was_held is True
+    finally:
+        await storage.close()
+
+
+async def test_reentrant_serialized_write_does_not_deadlock() -> None:
+    storage = SessionStorage(":memory:")
+    try:
+        await storage.connect()
+        async with storage._write_lock:
+            abandoned = await storage.mark_abandoned_agent_tasks()
+            assert isinstance(abandoned, int)
+    finally:
+        await storage.close()
+
+
+async def test_concurrent_initialize_schema_serialized() -> None:
+    storage = SessionStorage(":memory:")
+    try:
+        await storage.connect()
+        results = await asyncio.gather(
+            storage._initialize_schema(),
+            storage._initialize_schema(),
+            storage._initialize_schema(),
+            return_exceptions=True,
+        )
+        for res in results:
+            assert not isinstance(res, Exception), f"Unexpected exception: {res}"
+
+        assert await storage.count_sessions() == 0
+    finally:
+        await storage.close()


### PR DESCRIPTION
Closes #1777

### Summary of Changes

- **Synchronized `_initialize_schema`**: Decorated `SessionStorage._initialize_schema` with `@_serialized_write` so that all DDL creation statements (`CREATE TABLE`, `CREATE INDEX`), schema migrations, and startup maintenance execute under the protection of `_write_lock`, preventing race conditions during concurrent initialization.
- **Added `_AsyncReentrantLock`**: Replaced non-reentrant `asyncio.Lock()` in `SessionStorage.__init__` with a task-reentrant asynchronous lock (`_AsyncReentrantLock`) bound to `asyncio.current_task()` and tracking recursion depth (matching the existing precedent in `src/agentos/scheduler/persistence.py`). This allows `_initialize_schema` to safely execute nested `@_serialized_write` calls—specifically `await self.mark_abandoned_agent_tasks()`—without deadlocking.
- **Added Regression Tests**: Added 3 new test cases in `tests/test_session/test_storage_transaction_serialization.py`:
  - `test_initialize_schema_holds_write_lock`: Verifies `_write_lock` is held during schema initialization and migration.
  - `test_reentrant_serialized_write_does_not_deadlock`: Verifies nested `@_serialized_write` invocations inside the same task reenter cleanly.
  - `test_concurrent_initialize_schema_serialized`: Verifies concurrent initialization calls execute without collision.

### Verification

- `uv run pytest tests/test_session/test_storage_transaction_serialization.py -v` (6/6 passed)
- `uv run pytest tests/test_session -q` (237 passed)
- `uv run pytest tests/test_gateway -q` (1452 passed, 1 skipped)
- `uv run ruff check src/agentos/session/storage.py tests/test_session/test_storage_transaction_serialization.py` (Clean)
- `uv run mypy src/agentos/session/storage.py --show-error-codes` (Clean)
