### PR TITLE
fix(sandbox): match home prefixes in commands when home path contains spaces (Closes #1752)

### DIFF
--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -187,7 +187,14 @@ def _expand_env_vars(text: str) -> str:
     if "$" not in text and "%" not in text:
         return text
     try:
-        return os.path.expandvars(text)
+        expanded = os.path.expandvars(text)
+        if ("$HOME" in expanded or "${HOME}" in expanded) and "HOME" not in os.environ:
+            try:
+                home_val = os.environ.get("USERPROFILE") or str(Path.home())
+                expanded = expanded.replace("${HOME}", home_val).replace("$HOME", home_val)
+            except (OSError, RuntimeError):
+                pass
+        return expanded
     except (KeyError, TypeError, ValueError):
         return text
 
@@ -381,6 +388,29 @@ def _scan_text_for_marker(
 ) -> str | None:
     candidates: list[str] = []
     with_context: list[tuple[str, int]] = []
+    try:
+        home = Path.home()
+        home_variants = [str(home), str(home).replace("\\", "/")]
+        for var in home_variants:
+            if not var:
+                continue
+            flags = re.IGNORECASE if os.name == "nt" else 0
+            for match in re.finditer(re.escape(var), text, flags):
+                start = match.start()
+                end = match.end()
+                if start > 0 and text[start - 1] in ('"', "'", "`"):
+                    quote = text[start - 1]
+                    quote_end = text.find(quote, end)
+                    if quote_end != -1:
+                        candidates.append(text[start:quote_end])
+                        continue
+                rem = end
+                while rem < len(text) and text[rem] not in _TOKEN_EDGE_CHARS:
+                    rem += 1
+                candidates.append(text[start:rem])
+    except (OSError, RuntimeError):
+        pass
+
     try:
         candidates.extend(shlex.split(text))
     except ValueError:

--- a/tests/test_sandbox/test_sensitive_paths.py
+++ b/tests/test_sandbox/test_sensitive_paths.py
@@ -26,6 +26,22 @@ def test_sensitive_path_in_text_matches_native_separator_paths() -> None:
     assert sensitive_path_in_text(f"type {key_path}") == "~/.ssh"
 
 
+def test_sensitive_path_in_text_matches_home_path_with_spaces(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spaced_home = "C:/Users/John Doe with Spaces"
+    monkeypatch.setattr(Path, "home", lambda: Path(spaced_home))
+    monkeypatch.setenv("USERPROFILE", spaced_home)
+    monkeypatch.setenv("HOME", spaced_home)
+
+    assert sensitive_path_in_text(f"type {spaced_home}/.ssh/id_rsa") == "~/.ssh"
+    assert (
+        sensitive_path_in_text(f"cat {spaced_home}\\.config\\gh\\hosts.yml")
+        == "~/.config/gh"
+    )
+    assert sensitive_path_in_text(f'cat "{spaced_home}/.config/gh/hosts.yml"') == "~/.config/gh"
+
+
 def test_active_workspace_under_root_is_not_blocked_by_root_prefix() -> None:
     workspace = Path("/root/.agentos/workspace")
 


### PR DESCRIPTION
### Summary
When a user's home path contains spaces (such as `C:\Users\First Last`), `shlex.split` and `text.split()` in `_scan_text_for_marker` split command strings across those spaces, fragmenting the path. Consequently:
1. Suffixes (like `id_rsa`) matched instead of the higher-precedence home prefix (`~/.ssh`), causing `test_sensitive_path_in_text_matches_native_separator_paths` to report `/id_rsa` instead of `~/.ssh`.
2. Paths without matching suffix entries (e.g. `~/.config/gh/hosts.yml`) failed to match entirely.
3. On Windows without `HOME` defined in `os.environ`, `$HOME` references were left unexpanded.

### Changes
- In `src/agentos/sandbox/sensitive_paths.py`:
  - Directly match occurrences of `Path.home()` in `_scan_text_for_marker` before whitespace tokenization, preserving full candidate paths containing spaces.
  - In `_expand_env_vars`, add a fallback for `$HOME` and `${HOME}` on Windows to `USERPROFILE` / `Path.home()` when `HOME` is not explicitly exported.
- In `tests/test_sandbox/test_sensitive_paths.py`:
  - Added test `test_sensitive_path_in_text_matches_home_path_with_spaces` verifying prefix matching on commands with paths containing spaces.

Closes #1752
