### PR TITLE
fix(session): cap FTS token length to prevent parser DoS (Closes #1776)

### DIFF
--- a/src/agentos/session/storage.py
+++ b/src/agentos/session/storage.py
@@ -380,6 +380,8 @@ END
 """
 
 _SQLITE_VARIABLE_CHUNK_SIZE = 900
+_FTS_MAX_TOKENS = 20
+_FTS_MAX_TOKEN_LENGTH = 128
 
 
 def _now_ms() -> int:
@@ -1817,8 +1819,11 @@ class SessionStorage:
         tokens = cleaned.split()
         if not tokens:
             return '""'
-        # Wrap each token in double-quotes for literal matching
-        return " ".join(f'"{t}"' for t in tokens[:20])  # cap at 20 terms
+        # Wrap each token in double-quotes for literal matching, capped in count
+        # and per-token length to prevent parser denial of service.
+        return " ".join(
+            f'"{t[:_FTS_MAX_TOKEN_LENGTH]}"' for t in tokens[:_FTS_MAX_TOKENS]
+        )
 
     async def search_transcript(
         self,

--- a/tests/test_session/test_session_search_fts_unicode.py
+++ b/tests/test_session/test_session_search_fts_unicode.py
@@ -69,7 +69,7 @@ def test_fts_operators_stripped() -> None:
 
 def test_punctuation_stripped() -> None:
     """Punctuation and special characters are stripped."""
-    result = SessionStorage.sanitize_fts_query("hello, world! how's \"it\" going?")
+    result = SessionStorage.sanitize_fts_query('hello, world! how\'s "it" going?')
     assert result == '"hello" "world" "how" "s" "it" "going"'
 
 
@@ -87,15 +87,42 @@ def test_whitespace_only() -> None:
 
 def test_token_limit_20() -> None:
     """Input with more than 20 tokens is capped to 20 tokens."""
-    result = SessionStorage.sanitize_fts_query('a b c d e f g h i j k l m n o p q r s t u v w x y')
+    result = SessionStorage.sanitize_fts_query("a b c d e f g h i j k l m n o p q r s t u v w x y")
     tokens = result.split()
     assert len(tokens) == 20
 
 
 def test_unicode_token_limit() -> None:
     """Unicode tokens count toward the 20-token limit correctly."""
-    tokens_list = [chr(0x4e00 + i) for i in range(25)]
+    tokens_list = [chr(0x4E00 + i) for i in range(25)]
     query = " ".join(tokens_list)
     result = SessionStorage.sanitize_fts_query(query)
     tokens = result.split()
     assert len(tokens) == 20
+
+
+def test_token_length_cap() -> None:
+    """Individual tokens longer than 128 characters are capped to 128 characters."""
+    giant_word = "a" * 50_000
+    result = SessionStorage.sanitize_fts_query(giant_word)
+    assert result == f'"{giant_word[:128]}"'
+    assert len(result) == 130  # 128 chars + 2 quotes
+
+
+def test_token_length_cap_unicode() -> None:
+    """Long unicode tokens are also capped to 128 characters."""
+    giant_unicode = "\u4e2d" * 500
+    result = SessionStorage.sanitize_fts_query(giant_unicode)
+    assert result == f'"{giant_unicode[:128]}"'
+    assert len(result) == 130
+
+
+async def test_search_transcript_with_giant_query() -> None:
+    """search_transcript safely executes when provided with an oversized token query."""
+    storage = SessionStorage(":memory:")
+    try:
+        await storage.connect()
+        results = await storage.search_transcript("word " + "x" * 50_000)
+        assert results == []
+    finally:
+        await storage.close()


### PR DESCRIPTION
Closes #1776

### Summary of Changes

- **Bounded FTS Token Length**: Updated `SessionStorage.sanitize_fts_query` in `src/agentos/session/storage.py` to truncate each token to `_FTS_MAX_TOKEN_LENGTH` (128 characters), alongside the existing `_FTS_MAX_TOKENS` (20 tokens) limit.
- **Prevented Denial of Service**: Eliminates memory exhaustion and CPU spikes in the SQLite FTS5 query parser when receiving arbitrarily long words (e.g. 50,000-character tokens), capping total sanitized query output to ~2.6 KB.
- **Added Regression Tests**: Added 3 tests in `tests/test_session/test_session_search_fts_unicode.py`:
  - `test_token_length_cap`: Asserts that an oversized 50,000-character ASCII token is truncated to 128 characters.
  - `test_token_length_cap_unicode`: Asserts that long multi-byte Unicode tokens are also truncated to 128 characters.
  - `test_search_transcript_with_giant_query`: End-to-end integration test ensuring `search_transcript` executes safely with oversized tokens without SQLite FTS5 errors.

### Verification

- `uv run pytest tests/test_session/test_session_search_fts_unicode.py -v` (17/17 passed in 2.18s)
- `uv run pytest tests/test_session -q` (237 passed in 18.20s)
- `uv run ruff check src/agentos/session/storage.py tests/test_session/test_session_search_fts_unicode.py` (Clean)
- `uv run mypy src/agentos/session/storage.py --show-error-codes` (Clean)
