### PR TITLE
fix(gateway): settle pending RPC calls when client closes

### DIFF
--- a/src/agentos/gateway_client.py
+++ b/src/agentos/gateway_client.py
@@ -179,6 +179,7 @@ class GatewayRPCClient:
 
     async def close(self) -> None:
         self._closing = True
+        self._mark_connection_failed(ConnectionError("Gateway connection closed"))
         for task in (self._heartbeat_task, self._listener_task):
             if task is None:
                 continue

--- a/tests/test_mcp_server/test_gateway_client.py
+++ b/tests/test_mcp_server/test_gateway_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import sys
 from types import SimpleNamespace
@@ -40,6 +41,25 @@ async def test_gateway_rpc_call_times_out_and_clears_pending_request() -> None:
     with pytest.raises(TimeoutError, match="sessions.list timed out"):
         await client.call("sessions.list", {"limit": 1})
 
+    assert client._pending == {}
+
+
+@pytest.mark.asyncio
+async def test_gateway_close_fails_pending_rpc_calls() -> None:
+    client = GatewayRPCClient(request_timeout_s=None)
+    client._ws = _SilentWebSocket()
+    call_task = asyncio.create_task(client.call("sessions.list", {"limit": 1}))
+
+    for _ in range(10):
+        if client._pending:
+            break
+        await asyncio.sleep(0)
+    assert client._pending
+
+    await client.close()
+
+    with pytest.raises(ConnectionError, match="Gateway connection closed"):
+        await asyncio.wait_for(call_task, timeout=0.1)
     assert client._pending == {}
 
 


### PR DESCRIPTION
## Linked issue

Fixes https://github.com/use-agent-os/agent-os/issues/1780

<!-- Use `Refs #123` instead if this only covers part of the issue. -->

- [x] This pull request fully resolves the linked issue, or the description
      says what remains.

## Summary

Make `GatewayRPCClient.close()` settle all pending RPC calls before shutting down
the WebSocket.

Previously, `close()` cancelled the listener and closed the socket without
rejecting futures stored in `_pending`. Calls using
`request_timeout_s=None` could therefore remain blocked indefinitely.

Pending calls now receive:

```text
ConnectionError("Gateway connection closed")
```

and _pending is cleared during close.


## Tests

- uv run pytest tests/test_mcp_server/test_gateway_client.py -q
- uv run pytest tests/test_mcp_server -q
- uv run ruff check src/agentos/gateway_client.py tests/test_mcp_server/test_gateway_client.py
- uv run mypy src/agentos/gateway_client.py --show-error-codes

All checks passed.