### PR TITLE
fix(provider): release the half-open probe slot on a non-tripping fai…

### DIFF
--- a/src/agentos/provider/circuit_breaker.py
+++ b/src/agentos/provider/circuit_breaker.py
@@ -250,7 +250,16 @@ class ProviderCircuitBreaker:
         if kind is not None and not trips_breaker(kind):
             with self._lock:
                 entry = self._entries.get(provider)
-                return entry.state if entry else BreakerState.CLOSED
+                if entry is None:
+                    return BreakerState.CLOSED
+                if entry.state is BreakerState.HALF_OPEN:
+                    # The probe itself failed for a request-shaped reason --
+                    # that proves nothing about provider health. Release the
+                    # slot so it doesn't sit "occupied" by a failure that will
+                    # never resolve it, blocking every other caller for a full
+                    # cooldown window over nothing.
+                    entry.probe_started_at = None
+                return entry.state
         with self._lock:
             entry = self._entries.setdefault(provider, _Entry())
             now = self._clock()

--- a/tests/test_provider_circuit_breaker.py
+++ b/tests/test_provider_circuit_breaker.py
@@ -202,6 +202,27 @@ def test_abandoned_probe_does_not_wedge_the_breaker() -> None:
     assert breaker.allow("openrouter") is True
 
 
+def test_request_shaped_failure_during_probe_releases_the_slot() -> None:
+    """Regression for #1602: a non-tripping failure during the half-open probe
+    must not extend the outage. The probe itself failed for a reason that has
+    nothing to do with provider health, so an unrelated request right after it
+    must still be admitted -- not blocked for a full cooldown window."""
+    clock = FakeClock()
+    breaker = _breaker(clock, threshold=1, cooldown=60.0)
+    _fail(breaker, "openrouter", 1)
+
+    clock.advance(60.0)
+    assert breaker.allow("openrouter") is True  # probe admitted
+    assert breaker.state("openrouter") is BreakerState.HALF_OPEN
+
+    breaker.record_failure("openrouter", ProviderFailureKind.MODEL_NOT_FOUND, "bad model id")
+
+    # No cooldown advance: the slot must be free immediately, not after 60s.
+    assert breaker.allow("openrouter") is True
+    # Still half-open -- the request-shaped failure proved nothing either way.
+    assert breaker.state("openrouter") is BreakerState.HALF_OPEN
+
+
 def test_disabled_breaker_always_admits() -> None:
     clock = FakeClock()
     breaker = _breaker(clock, threshold=1, enabled=False)


### PR DESCRIPTION
Summary
record_failure()'s early-return branch for a non-tripping failure kind (MODEL_NOT_FOUND, BAD_REQUEST, etc.) returned the entry's current state without resetting probe_started_at. When that failure landed on the single in-flight half-open probe, the slot stayed "occupied" by a request that never actually tested provider health, and allow() would then block every other caller for a full cooldown window (up to max_cooldown_seconds) even though nothing indicated the provider itself was unhealthy.
A non-tripping failure on a half-open entry now releases probe_started_at, so the next unrelated request can probe immediately, while leaving the breaker state itself unchanged — the failure proved nothing either way.
Test plan
Added test_request_shaped_failure_during_probe_releases_the_slot, reproducing the issue's exact scenario: trip the breaker, let the cooldown elapse to admit a half-open probe, fail that probe with a request-shaped kind, then confirm an immediate unrelated call is still admitted.
Verified the new test fails against the pre-fix code (via git stash on circuit_breaker.py) and passes with the fix.
uv run ruff check and uv run mypy src/agentos — clean.
Full provider/engine suite (tests/test_provider_circuit_breaker.py, tests/test_provider_circuit_breaker_surfaces.py, tests/test_engine/) — 1124 passed, 1 unrelated flaky timeout test (test_iteration_timeout_caps_tool_execution) confirmed to pass in isolation.
Fixes #1602 