### PR TITLE
fix(scheduler): honor timezone alias and check conflicts in structure…

### DIFF
--- a/src/agentos/scheduler/schedule_normalizer.py
+++ b/src/agentos/scheduler/schedule_normalizer.py
@@ -12,16 +12,8 @@ def coerce_schedule_from_params(params: dict[str, Any]) -> tuple[ScheduleKind, s
     schedule_raw = params.get("schedule")
     if isinstance(schedule_raw, dict):
         schedule = dict(schedule_raw)
-        top_level_tz = _top_level_tz(params)
-        if top_level_tz and schedule.get("kind") == ScheduleKind.CRON.value:
-            schedule_tz = schedule.get("tz")
-            if isinstance(schedule_tz, str):
-                schedule_tz = schedule_tz.strip()
-            else:
-                schedule_tz = ""
-            if schedule_tz and schedule_tz != top_level_tz:
-                raise ValueError("schedule.tz conflicts with tz")
-            schedule["tz"] = top_level_tz
+        if schedule.get("kind") == ScheduleKind.CRON.value:
+            schedule["tz"] = _resolve_cron_tz(schedule, params)
         return coerce_schedule(schedule)
     expression = params.get("expression")
     if isinstance(expression, str) and expression.strip():
@@ -38,6 +30,31 @@ def coerce_schedule_from_params(params: dict[str, Any]) -> tuple[ScheduleKind, s
             }
         )
     raise ValueError("params required: schedule (object) or expression (string)")
+
+
+def _resolve_cron_tz(schedule: dict[str, Any], params: dict[str, Any]) -> str:
+    """Resolve a structured cron schedule's effective timezone.
+
+    Honours the ``timezone`` alias both inside ``schedule`` (mirroring
+    ``schedule.tz``) and at the top level of ``params`` (via
+    ``_top_level_tz``, already used by the expression-shorthand path), and
+    rejects any conflicting values instead of silently preferring one.
+    """
+    tz_raw = schedule.get("tz")
+    timezone_raw = schedule.get("timezone")
+    for value in (tz_raw, timezone_raw):
+        if value is not None and not isinstance(value, str):
+            raise ValueError("schedule.tz must be a string IANA timezone name")
+    tz = tz_raw.strip() if isinstance(tz_raw, str) else ""
+    timezone = timezone_raw.strip() if isinstance(timezone_raw, str) else ""
+    if tz and timezone and tz != timezone:
+        raise ValueError("schedule.tz conflicts with schedule.timezone")
+    schedule_tz = tz or timezone
+
+    top_level_tz = _top_level_tz(params)
+    if schedule_tz and top_level_tz and schedule_tz != top_level_tz:
+        raise ValueError("schedule.tz conflicts with tz")
+    return schedule_tz or top_level_tz
 
 
 def _top_level_tz(params: dict[str, Any]) -> str:

--- a/tests/test_scheduler/test_schedule_normalizer.py
+++ b/tests/test_scheduler/test_schedule_normalizer.py
@@ -42,6 +42,55 @@ def test_normalizer_rejects_conflicting_structured_and_top_level_tz() -> None:
         )
 
 
+def test_normalizer_structured_cron_accepts_timezone_alias() -> None:
+    # Regression for #1603: the `timezone` alias nested inside `schedule` was
+    # silently ignored -- only a top-level params.timezone was honoured via
+    # _top_level_tz. A caller passing {"schedule": {..., "timezone": "..."}}
+    # (no "tz" key anywhere) used to fall back to UTC with no error.
+    kind, value, tz = coerce_schedule_from_params(
+        {"schedule": {"kind": "cron", "expr": "0 9 * * 1-5", "timezone": "Asia/Shanghai"}}
+    )
+
+    assert kind == ScheduleKind.CRON
+    assert value == "0 9 * * 1-5"
+    assert tz == "Asia/Shanghai"
+
+
+def test_normalizer_rejects_conflicting_schedule_tz_and_schedule_timezone() -> None:
+    with pytest.raises(ValueError, match="schedule.tz conflicts with schedule.timezone"):
+        coerce_schedule_from_params(
+            {
+                "schedule": {
+                    "kind": "cron",
+                    "expr": "0 9 * * *",
+                    "tz": "Asia/Shanghai",
+                    "timezone": "America/Los_Angeles",
+                }
+            }
+        )
+
+
+def test_normalizer_rejects_conflicting_schedule_timezone_and_top_level_tz() -> None:
+    with pytest.raises(ValueError, match="schedule.tz conflicts with tz"):
+        coerce_schedule_from_params(
+            {
+                "schedule": {
+                    "kind": "cron",
+                    "expr": "0 9 * * *",
+                    "timezone": "Asia/Shanghai",
+                },
+                "tz": "America/Los_Angeles",
+            }
+        )
+
+
+def test_normalizer_rejects_non_string_schedule_timezone() -> None:
+    with pytest.raises(ValueError, match="schedule.tz must be a string IANA timezone name"):
+        coerce_schedule_from_params(
+            {"schedule": {"kind": "cron", "expr": "0 9 * * *", "timezone": 123}}
+        )
+
+
 def test_normalizer_accepts_every_seconds() -> None:
     kind, value, tz = coerce_schedule_from_params(
         {"schedule": {"kind": "every", "every_seconds": 300}}


### PR DESCRIPTION
Summary
coerce_schedule_from_params only consulted _top_level_tz(params) — the tz/timezone alias at the top level of the RPC params — when populating a structured cron schedule's timezone. A caller nesting the alias inside the schedule object itself ({"schedule": {"kind": "cron", ..., "timezone": "Asia/Shanghai"}}, no tz key anywhere) had it silently ignored, since _coerce_cron only ever reads raw.get("tz"), and the schedule fell back to UTC with no error raised.
Adds _resolve_cron_tz, which honors schedule.timezone as an alias for schedule.tz (matching the top-level alias contract _top_level_tz already implements), and rejects conflicts at both levels: schedule.tz vs schedule.timezone, and the resolved schedule-level value vs a conflicting top-level tz. A non-string schedule.timezone now raises the same type-validation error schedule.tz already had.
Test plan
Added test_normalizer_structured_cron_accepts_timezone_alias, reproducing the issue's exact scenario.
Added three more tests covering the follow-on expectations: schedule.tz/schedule.timezone conflict, schedule.timezone/top-level tz conflict, and a non-string schedule.timezone type error.
Verified all four new tests fail against the pre-fix code (via git stash on schedule_normalizer.py) and pass with the fix.
uv run ruff check and uv run mypy src/agentos — clean.
Full scheduler suite (tests/test_scheduler/, tests/test_cli/test_cron_cmd.py) — 578 passed, 1 unrelated pre-existing failure (test_symlink_escape_is_blocked, a Windows symlink-privilege environment limitation, not a code issue).
Fixes #1603 