### PR TITLE
fix(scheduler): clamp JobStore.list_executions' limit at the shared store method

### DIFF
--- a/src/agentos/scheduler/persistence.py
+++ b/src/agentos/scheduler/persistence.py
@@ -457,6 +457,26 @@ def _upsert_update_clause(write_reservation: bool) -> str:
     return _UPSERT_CLAUSE_KEEPING_RESERVATION
 
 
+#: Ceiling for list_executions()'s `limit`. See _clamp_list_executions_limit.
+_MAX_LIST_EXECUTIONS_LIMIT = 1000
+
+
+def _clamp_list_executions_limit(limit: int) -> int:
+    """Clamp list_executions()'s `limit` into [1, _MAX_LIST_EXECUTIONS_LIMIT].
+
+    SQLite treats a negative LIMIT as "no limit" (returns the job's entire
+    run history in one response), and an unbounded positive value has no
+    ceiling at all. Split out as its own function so the boundary can be
+    unit-tested directly, without needing to seed a database past the
+    ceiling to prove it holds. engine.get_runs() and ops.get_runs() are
+    pure passthroughs to list_executions() with no clamping of their own
+    (confirmed by reading both directly), so every caller -- including
+    rpc_cron.py's cron.runs RPC handler, which itself does no clamping --
+    is protected by fixing it here rather than at each call site.
+    """
+    return min(max(1, limit), _MAX_LIST_EXECUTIONS_LIMIT)
+
+
 class JobStore:
     """Async SQLite store for CronJob records."""
 
@@ -959,9 +979,14 @@ class JobStore:
                 await self._db().commit()
 
     async def list_executions(self, job_id: str, limit: int = 20) -> list[JobExecution]:
+        # See _clamp_list_executions_limit for why: this is the shared sink
+        # every read path (engine.get_runs, ops.get_runs, and rpc_cron.py's
+        # cron.runs RPC handler) funnels into unclamped, so the guard
+        # belongs here rather than duplicated at each call site.
+        clamped_limit = _clamp_list_executions_limit(limit)
         async with self._db().execute(
             "SELECT * FROM scheduler_runs WHERE job_id = ? ORDER BY started_at DESC LIMIT ?",
-            (job_id, limit),
+            (job_id, clamped_limit),
         ) as cur:
             rows = await cur.fetchall()
             return [_row_to_execution(r) for r in rows]

--- a/tests/test_scheduler/test_list_executions_limit_clamp.py
+++ b/tests/test_scheduler/test_list_executions_limit_clamp.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from agentos.scheduler.persistence import (
+    _MAX_LIST_EXECUTIONS_LIMIT,
+    JobStore,
+    _clamp_list_executions_limit,
+)
+from agentos.scheduler.types import JobExecution
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (-1_000_000, 1),
+        (-100, 1),
+        (-1, 1),
+        (0, 1),
+        (1, 1),
+        (20, 20),
+        (_MAX_LIST_EXECUTIONS_LIMIT, _MAX_LIST_EXECUTIONS_LIMIT),
+        (_MAX_LIST_EXECUTIONS_LIMIT + 1, _MAX_LIST_EXECUTIONS_LIMIT),
+        (10_000_000, _MAX_LIST_EXECUTIONS_LIMIT),
+    ],
+)
+def test_clamp_list_executions_limit_boundaries(raw: int, expected: int) -> None:
+    assert _clamp_list_executions_limit(raw) == expected
+
+
+async def _seeded_store(tmp_path: Path, job_id: str, count: int) -> tuple[JobStore, list[datetime]]:
+    store = JobStore(str(tmp_path / "cron.db"))
+    await store.open()
+    base = datetime.now(UTC)
+    started_ats = [base + timedelta(seconds=i) for i in range(count)]
+    for started_at in started_ats:
+        await store.save_execution(JobExecution(job_id=job_id, success=True, started_at=started_at))
+    return store, started_ats
+
+
+@pytest.mark.asyncio
+async def test_list_executions_negative_limit_does_not_return_entire_history(
+    tmp_path: Path,
+) -> None:
+    store, _ = await _seeded_store(tmp_path, "job-1", count=5)
+    try:
+        rows = await store.list_executions("job-1", limit=-1)
+        assert len(rows) == 1
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_list_executions_zero_limit_still_returns_something(tmp_path: Path) -> None:
+    store, _ = await _seeded_store(tmp_path, "job-1", count=3)
+    try:
+        rows = await store.list_executions("job-1", limit=0)
+        assert len(rows) == 1
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_list_executions_normal_limit_is_unaffected(tmp_path: Path) -> None:
+    store, started_ats = await _seeded_store(tmp_path, "job-1", count=5)
+    try:
+        rows = await store.list_executions("job-1", limit=3)
+        assert len(rows) == 3
+        # Most-recent-first: the last 3 of the 5 seeded timestamps, newest first.
+        expected_newest_first = list(reversed(started_ats[-3:]))
+        assert [r.started_at for r in rows] == expected_newest_first
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_list_executions_ceiling_holds_against_real_seeded_rows(tmp_path: Path) -> None:
+    """Not just the pure function: prove the ceiling holds end-to-end against
+    a database that actually has more than _MAX_LIST_EXECUTIONS_LIMIT rows.
+    """
+    store, _ = await _seeded_store(tmp_path, "job-1", count=_MAX_LIST_EXECUTIONS_LIMIT + 5)
+    try:
+        rows = await store.list_executions("job-1", limit=_MAX_LIST_EXECUTIONS_LIMIT + 500)
+        assert len(rows) == _MAX_LIST_EXECUTIONS_LIMIT
+    finally:
+        await store.close()


### PR DESCRIPTION
## Linked issue
Fixes #1734

## Summary
`JobStore.list_executions()` passes `limit` straight into a raw SQL
`LIMIT ?` with no validation. SQLite treats a negative `LIMIT` as
"no limit," so `list_executions(job_id, limit=-1)` returns a job's
entire run history instead of a bounded slice — verified directly
against the method, not just described:

    limit=-1 -> returns every row for that job, not clamped

`engine.get_runs()` and `ops.get_runs()` are pure passthroughs with
no clamping of their own (checked both directly). Neither is
`rpc_cron.py`'s `cron.runs` RPC handler — `_handle_cron_runs` does
`limit = params.get("limit", 20)` and passes it straight through, no
guard. So today every caller that reaches this method is exposed;
fixing the shared method protects all of them at once, including
that RPC handler, without needing to touch it separately.

## Fix
Clamp extracted into its own function, `_clamp_list_executions_limit`,
rather than inlined in the method — mirrors this codebase's existing
convention for this kind of bounds-check (see `ops.py`'s
`timeout_seconds` validation and its parametrized boundary tests in
`test_timeout_seconds_bound.py`). Keeping it as a standalone function
means the boundary logic itself is unit-testable without needing a
real database.

## Tests
New file `tests/test_scheduler/test_list_executions_limit_clamp.py`:
- `test_clamp_list_executions_limit_boundaries` — 9-case parametrized
  matrix on the pure function: large negative, -1, 0, 1, in-range,
  exactly at the ceiling, just over, far over.
- `test_list_executions_negative_limit_does_not_return_entire_history`
  — the exact repro against the underlying method directly.
- `test_list_executions_zero_limit_still_returns_something`
- `test_list_executions_normal_limit_is_unaffected` — asserts exact
  most-recent-first ordering against known seeded timestamps, not
  just row count.
- `test_list_executions_ceiling_holds_against_real_seeded_rows` — the
  1000-row ceiling proven against a database that actually has more
  than that many rows, not just the pure function.

13/13 new tests pass. Full scheduler suite: 532/532, zero regressions.

Commands run:
- `uv run ruff check src/agentos/scheduler/persistence.py tests/test_scheduler/test_list_executions_limit_clamp.py` → All checks passed!
- `uv run ruff format --check ...` → clean
- `uv run mypy src/agentos/scheduler/persistence.py --show-error-codes` → Success: no issues found
- `uv run pytest tests/test_scheduler/ -q` → 532 passed

Third-party origin: none.