### PR TITLE
fix(gateway): confine UploadStore._marker_path to marker_dir

### DIFF
--- a/src/agentos/gateway/uploads.py
+++ b/src/agentos/gateway/uploads.py
@@ -176,7 +176,14 @@ class UploadStore:
     def _marker_path(self, file_uuid: str) -> Path | None:
         if self.marker_dir is None:
             return None
-        return self.marker_dir / f"{file_uuid}.meta"
+        root = self.marker_dir.resolve()
+        path = (self.marker_dir / f"{file_uuid}.meta").resolve()
+        if path.parent != root:
+            # file_uuid crosses RPC boundaries unvalidated; a traversal shape
+            # ("../x", an absolute path — pathlib replaces the base) must never
+            # resolve outside marker_dir. Markers are flat direct children.
+            raise ValueError(f"file_uuid {file_uuid!r} escapes marker_dir")
+        return path
 
     def _read_marker(self, file_uuid: str) -> dict[str, Any] | None:
         path = self._marker_path(file_uuid)

--- a/tests/test_gateway/test_uploads_endpoint.py
+++ b/tests/test_gateway/test_uploads_endpoint.py
@@ -80,6 +80,42 @@ def test_upload_round_trip(store: UploadStore) -> None:
     assert meta["size"] == len(payload)
 
 
+# ---------------------------------------------------------------------------
+# file_uuid traversal guards: _marker_path must never resolve outside
+# marker_dir, whatever string reaches it over an RPC boundary.
+# ---------------------------------------------------------------------------
+
+
+def test_marker_path_rejects_relative_traversal(store: UploadStore, tmp_path: Path) -> None:
+    """evict('../decoy/x') must raise ValueError, not unlink outside marker_dir."""
+    decoy_dir = tmp_path / "decoy"
+    decoy_dir.mkdir()
+    decoy = decoy_dir / "x.meta"
+    decoy.write_text("{}", encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        asyncio.run(store.evict("../decoy/x"))
+    assert decoy.exists()
+
+
+def test_marker_path_rejects_absolute_uuid(store: UploadStore, tmp_path: Path) -> None:
+    """An absolute uuid replaces the base entirely in pathlib; must be rejected."""
+    outside = tmp_path / "outside.meta"
+    outside.write_text("{}", encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        asyncio.run(store.evict(str(outside.with_suffix(""))))
+    assert outside.exists()
+
+
+def test_marker_path_keeps_internal_uuids_working(store: UploadStore) -> None:
+    """Contained-but-non-canonical uuids keep the old semantics (no over-blocking)."""
+
+    with pytest.raises(AttachmentNotFoundError):
+        asyncio.run(store.get("u-doesnotexist"))
+    assert asyncio.run(store.evict("u-doesnotexist")) is False
+
+
 def test_upload_too_large_30mb_plus_rejected(store: UploadStore) -> None:
     # 30 MB + 1 byte exceeds the locked cap.
     too_big = b"%PDF-1.4\n" + b"a" * MAX_STAGED_PDF_BYTES


### PR DESCRIPTION
Fixes #1759

## Problem

`UploadStore._marker_path` joined `file_uuid` straight into `marker_dir / f"{file_uuid}.meta"` with no validation. `file_uuid` crosses RPC boundaries unvalidated, so a traversal shape (`"../../tmp/test"`) — or an absolute uuid, which makes pathlib **replace** the base entirely — resolved outside `marker_dir`. Because `_delete_marker` runs `path.unlink(missing_ok=True)`, `store.evict("../../tmp/test")` deleted a targeted `.meta` file anywhere the gateway can reach (same shape via `get()` when a crafted outside marker exists).

## Fix

`_marker_path` (`src/agentos/gateway/uploads.py`) now enforces containment before returning:

- `path = (marker_dir / f"{file_uuid}.meta").resolve()`; if `path.parent != marker_dir.resolve()` → `raise ValueError` (the behavior the issue expects for traversal attempts). Markers are flat direct children, so the parent check is exact.
- Chose resolve-containment over strict `^u-[0-9a-f]{32}$` validation: existing tests legitimately use contained-but-non-canonical uuids (`"u-doesnotexist"`, `"u-expired-restart"`), and strict regex would break that contract with no added safety — containment blocks every escape shape (relative, absolute, nested, backslash-on-Windows).
- Contained uuids keep the old semantics: `get("u-doesnotexist")` still raises `AttachmentNotFoundError`, `evict()` still returns `False`.

## Testing

Regression tests in `tests/test_gateway/test_uploads_endpoint.py`:

- `test_marker_path_rejects_relative_traversal` — writes a decoy file **outside** `marker_dir`, calls `evict("../decoy/x")`; asserts `ValueError` raised and the decoy still exists.
- `test_marker_path_rejects_absolute_uuid` — absolute uuid (pathlib base-replacement shape) must raise, target file survives.
- `test_marker_path_keeps_internal_uuids_working` — guards against over-blocking: non-canonical contained uuids keep old semantics.

**RED→GREEN proven**: with the fix stashed (`git stash -- src/agentos/gateway/uploads.py`), the two traversal tests fail with `DID NOT RAISE ValueError` (old code unlinks the outside file); with the fix, all 3 pass.

- `pytest tests/test_gateway/test_uploads_endpoint.py tests/test_gateway/test_rpc_sessions.py` — 132 passed
- `ruff check src tests` — clean
- `mypy src/agentos --show-error-codes` — Success, 625 files
- Full suite: 25 failed / 3 errors, **10424 passed** — identical to clean-tree baseline @ `4ca69ff` (32→25: 2 are the new RED-in-baseline tests, 1 is a timing flake in `test_rate_limit_trusted_proxy.py::test_sweep_expired_entries` that passed here); delta of new failures vs baseline is **empty**.
