### PR TITLE
feat(session): add retain_compacted option to delete_session (#1772)

### DIFF
--- a/src/agentos/gateway/rpc_sessions.py
+++ b/src/agentos/gateway/rpc_sessions.py
@@ -1962,11 +1962,13 @@ async def _handle_sessions_delete(params: dict | None, ctx: RpcContext) -> dict:
 
     # Support both single key and bulk keys
     keys: list[str] = []
+    retain_compacted = False
     if isinstance(params, dict):
         if "keys" in params:
             keys = params["keys"]
         elif "key" in params:
             keys = [params["key"]]
+        retain_compacted = bool(params.get("retain_compacted", False))
 
     if not keys:
         raise ValueError("params.key or params.keys is required")
@@ -1998,7 +2000,7 @@ async def _handle_sessions_delete(params: dict | None, ctx: RpcContext) -> dict:
                 except Exception:
                     log.warning("sessions.delete.task_cancel_failed", session_key=canonical)
             evict_session_runtime_state(canonical)
-            await storage.delete_session(canonical)
+            await storage.delete_session(canonical, retain_compacted=retain_compacted)
             deleted.append(k)
         except Exception as exc:
             errors.append(f"{k}: {exc}")

--- a/src/agentos/session/manager.py
+++ b/src/agentos/session/manager.py
@@ -843,7 +843,7 @@ class SessionManager:
                 "session.task_cancel_failed", session_key=session_key, reason=reason
             )
 
-    async def delete(self, session_key: str) -> None:
+    async def delete(self, session_key: str, *, retain_compacted: bool = False) -> None:
         """Remove a session: cancel its tasks, evict runtime state, then delete.
 
         The single removal choke point for maintenance paths. Ordering matters:
@@ -854,7 +854,7 @@ class SessionManager:
         session_key = canonicalize_session_key(session_key)
         await self._cancel_task_runtime(session_key, reason="session_delete")
         evict_session_runtime_state(session_key)
-        await self._storage.delete_session(session_key)
+        await self._storage.delete_session(session_key, retain_compacted=retain_compacted)
 
     async def branch(
         self,
@@ -1540,7 +1540,7 @@ class SessionManager:
 
     # ── Maintenance ──────────────────────────────────────────────────────────
 
-    async def prune_stale(self, max_age_ms: int) -> int:
+    async def prune_stale(self, max_age_ms: int, *, retain_compacted: bool = False) -> int:
         """Delete sessions older than max_age_ms. Returns number pruned.
 
         The keys are collected up front rather than delegating to
@@ -1551,10 +1551,12 @@ class SessionManager:
         cutoff = _now_ms() - max_age_ms
         session_keys = await self._storage.list_stale_session_keys(cutoff)
         for session_key in session_keys:
-            await self.delete(session_key)
+            await self.delete(session_key, retain_compacted=retain_compacted)
         return len(session_keys)
 
-    async def cap_entries(self, max_entries: int = 500) -> int:
+    async def cap_entries(
+        self, max_entries: int = 500, *, retain_compacted: bool = False
+    ) -> int:
         """Delete oldest sessions beyond max_entries. Returns number deleted."""
         total = await self._storage.count_sessions()
         if total <= max_entries:
@@ -1563,7 +1565,7 @@ class SessionManager:
         # sorted by updated_at asc — oldest first
         to_delete = sorted(sessions, key=lambda s: s.updated_at)[: total - max_entries]
         for s in to_delete:
-            await self.delete(s.session_key)
+            await self.delete(s.session_key, retain_compacted=retain_compacted)
         return len(to_delete)
 
     async def archive(self, session_key: str) -> None:

--- a/src/agentos/session/storage.py
+++ b/src/agentos/session/storage.py
@@ -724,7 +724,9 @@ class SessionStorage:
         return [SessionNode(**_deserialize_row(dict(r))) for r in rows]
 
     @_serialized_write
-    async def delete_session(self, session_key: str) -> None:
+    async def delete_session(
+        self, session_key: str, *, retain_compacted: bool = False
+    ) -> None:
         session_key = canonicalize_session_key(session_key)
         session = await self.get_session(session_key)
         if session is None:
@@ -739,14 +741,15 @@ class SessionStorage:
                 "DELETE FROM transcript_entries WHERE session_id = ?",
                 (session.session_id,),
             )
-            await self.conn.execute(
-                "DELETE FROM compacted_transcript_entries WHERE session_id = ?",
-                (session.session_id,),
-            )
-            await self.conn.execute(
-                "DELETE FROM session_summaries WHERE session_id = ?",
-                (session.session_id,),
-            )
+            if not retain_compacted:
+                await self.conn.execute(
+                    "DELETE FROM compacted_transcript_entries WHERE session_id = ?",
+                    (session.session_id,),
+                )
+                await self.conn.execute(
+                    "DELETE FROM session_summaries WHERE session_id = ?",
+                    (session.session_id,),
+                )
             await self.conn.execute(
                 "DELETE FROM session_context_states WHERE session_id = ?",
                 (session.session_id,),
@@ -779,7 +782,9 @@ class SessionStorage:
             rows = await cur.fetchall()
         return [row[0] for row in rows]
 
-    async def prune_stale_sessions(self, before_ms: int) -> int:
+    async def prune_stale_sessions(
+        self, before_ms: int, *, retain_compacted: bool = False
+    ) -> int:
         """Delete sessions not updated since before_ms epoch ms. Returns count deleted.
 
         Storage-only: it does not evict the process-global runtime state keyed
@@ -787,7 +792,7 @@ class SessionStorage:
         """
         session_keys = await self.list_stale_session_keys(before_ms)
         for session_key in session_keys:
-            await self.delete_session(session_key)
+            await self.delete_session(session_key, retain_compacted=retain_compacted)
         return len(session_keys)
 
     async def count_sessions(self) -> int:

--- a/tests/test_session/test_delete_session_retention.py
+++ b/tests/test_session/test_delete_session_retention.py
@@ -1,0 +1,184 @@
+"""Tests for delete_session safety retention option (#1772).
+
+Pins the contract for retain_compacted on delete_session across storage,
+manager, and gateway RPC.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from agentos.session.models import (
+    SessionNode,
+    SessionSummary,
+    TranscriptEntry,
+)
+from agentos.session.storage import SessionStorage
+
+
+@pytest.fixture
+async def storage():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "test.db"
+        store = SessionStorage(str(path))
+        await store.connect()
+        try:
+            yield store
+        finally:
+            await store.close()
+
+
+async def _seed_session_with_compacted(
+    storage: SessionStorage, session_key: str, session_id: str
+) -> None:
+    node = SessionNode(
+        session_key=session_key,
+        session_id=session_id,
+        created_at=1000,
+        updated_at=1000,
+    )
+    await storage.upsert_session(node)
+
+    # Active transcript entry
+    await storage.append_transcript_entry(
+        TranscriptEntry(
+            session_id=session_id,
+            session_key=session_key,
+            message_id="msg-active",
+            role="user",
+            content="active message",
+            created_at=1001,
+        )
+    )
+
+    # Summary
+    summary = SessionSummary(
+        session_id=session_id,
+        session_key=session_key,
+        compaction_id="cmp-1",
+        compaction_index=0,
+        summary_text="prior discussion summary",
+    )
+    await storage.save_summary(summary)
+
+    # Compacted archived entries
+    await storage._archive_transcript_entries(
+        node=node,
+        entries=[
+            TranscriptEntry(
+                id=1,
+                session_id=session_id,
+                session_key=session_key,
+                message_id="msg-compacted-1",
+                role="user",
+                content="compacted historical message",
+                created_at=999,
+            )
+        ],
+        compaction_id="cmp-1",
+        compaction_index=0,
+    )
+    await storage.conn.commit()
+
+
+@pytest.mark.asyncio
+async def test_delete_session_default_purges_all(storage: SessionStorage) -> None:
+    key = "agent:main:webchat:direct:user-1"
+    sid = "sid-purge"
+    await _seed_session_with_compacted(storage, key, sid)
+
+    # Default retain_compacted=False
+    await storage.delete_session(key)
+
+    assert await storage.get_session(key) is None
+    assert await storage.get_transcript(sid) == []
+
+    async with storage.conn.execute(
+        "SELECT COUNT(*) FROM compacted_transcript_entries WHERE session_id = ?",
+        (sid,),
+    ) as cur:
+        assert (await cur.fetchone())[0] == 0
+
+    assert len(await storage.get_all_summaries(sid)) == 0
+
+
+@pytest.mark.asyncio
+async def test_delete_session_retain_compacted_preserves_archive(
+    storage: SessionStorage,
+) -> None:
+    key = "agent:main:webchat:direct:user-2"
+    sid = "sid-retain"
+    await _seed_session_with_compacted(storage, key, sid)
+
+    # With retain_compacted=True
+    await storage.delete_session(key, retain_compacted=True)
+
+    # Session and active transcripts are purged
+    assert await storage.get_session(key) is None
+    assert await storage.get_transcript(sid) == []
+
+    # Compacted archive and summaries are preserved for historical audit
+    async with storage.conn.execute(
+        "SELECT COUNT(*) FROM compacted_transcript_entries WHERE session_id = ?",
+        (sid,),
+    ) as cur:
+        assert (await cur.fetchone())[0] == 1
+
+    summaries = await storage.get_all_summaries(sid)
+    assert len(summaries) == 1
+    assert summaries[0].summary_text == "prior discussion summary"
+
+
+@pytest.mark.asyncio
+async def test_session_manager_delete_forwards_retain_compacted(
+    storage: SessionStorage,
+) -> None:
+    from agentos.session.manager import SessionManager
+
+    manager = SessionManager(storage)
+    key = "agent:main:webchat:direct:user-3"
+    sid = "sid-mgr"
+    await _seed_session_with_compacted(storage, key, sid)
+
+    await manager.delete(key, retain_compacted=True)
+
+    assert await storage.get_session(key) is None
+    assert await storage.get_transcript(sid) == []
+
+    async with storage.conn.execute(
+        "SELECT COUNT(*) FROM compacted_transcript_entries WHERE session_id = ?",
+        (sid,),
+    ) as cur:
+        assert (await cur.fetchone())[0] == 1
+
+
+@pytest.mark.asyncio
+async def test_rpc_sessions_delete_supports_retain_compacted(storage: SessionStorage) -> None:
+    from agentos.gateway.rpc_sessions import _handle_sessions_delete
+
+    key = "agent:main:webchat:direct:user-4"
+    sid = "sid-rpc"
+    await _seed_session_with_compacted(storage, key, sid)
+
+    from agentos.session.manager import SessionManager
+
+    class Ctx:
+        session_storage = storage
+        session_manager = SessionManager(storage)
+        task_runtime = None
+
+    result = await _handle_sessions_delete(
+        {"key": key, "retain_compacted": True},
+        Ctx(),  # type: ignore[arg-type]
+    )
+    assert result == {"deleted": [key], "errors": []}
+
+    assert await storage.get_session(key) is None
+    async with storage.conn.execute(
+        "SELECT COUNT(*) FROM compacted_transcript_entries WHERE session_id = ?",
+        (sid,),
+    ) as cur:
+        assert (await cur.fetchone())[0] == 1


### PR DESCRIPTION
## Problem

When deleting a session via `storage.delete_session()`, `manager.delete()`, or the `sessions.delete` gateway RPC, active transcripts and historical compacted transcript archives were unconditionally deleted (`DELETE FROM compacted_transcript_entries WHERE session_id = ?`).

Callers who need to delete an active session while retaining canonical compaction archives for safety retention, auditing, or compliance reporting had no option to preserve historical compacted transcripts without bypassing session deletion.

Closes #1772

## Solution

- Added an optional keyword-only argument `retain_compacted: bool = False` to:
  - `SessionStorage.delete_session`
  - `SessionStorage.prune_stale_sessions`
  - `SessionManager.delete`
  - `SessionManager.prune_stale` and `SessionManager.cap_entries`
  - Gateway RPC handler `_handle_sessions_delete` (reads `params.retain_compacted`)
- When `retain_compacted=False` (default), behavior is 100% backwards-compatible: all session-scoped rows, active transcripts, and compacted archives are completely purged.
- When `retain_compacted=True`, active transcripts, context states, agent tasks, memory receipts, and session rows are deleted as usual, but `compacted_transcript_entries` and `session_summaries` are preserved for canonical audit/retention.

## Verification

- Added comprehensive test suite in `tests/test_session/test_delete_session_retention.py`:
  - `test_delete_session_default_purges_all`: verifies default purge behavior is preserved.
  - `test_delete_session_retain_compacted_preserves_archive`: verifies compacted archive and summaries are retained when requested.
  - `test_session_manager_delete_forwards_retain_compacted`: verifies manager forwarding.
  - `test_rpc_sessions_delete_supports_retain_compacted`: verifies RPC param handling.
- Quality gates:
  - `uv run ruff check src tests` passed.
  - `uv run mypy src/agentos --show-error-codes` passed across 625 files.
  - `uv run pytest tests/test_session -q` passed (238 passed).
