### PR TITLE
fix(tools): honor limit=0 as headers-only in read_spreadsheet

### DIFF
--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -543,7 +543,10 @@ async def read_file(path: str, offset: int | None = None, limit: int | None = No
         },
         "limit": {
             "type": "integer",
-            "description": "Maximum rows per sheet to return (default 200).",
+            "description": (
+                "Maximum rows per sheet to return (default 200; 0 returns "
+                "headers and sheet metadata only)."
+            ),
         },
     },
     required=["path"],
@@ -566,7 +569,10 @@ async def read_spreadsheet(
 
     ext = p.suffix.lower()
     row_offset = offset if offset and offset > 0 else 1
-    row_limit = limit if limit and limit > 0 else 200
+    # limit=0 is meaningful ("headers only", consistent with read_file's
+    # limit handling) — it must not fall through the falsy-zero check to the
+    # 200-row default. Negative limits keep the old 200-row fallback.
+    row_limit = 200 if limit is None or limit < 0 else limit
     loop = asyncio.get_running_loop()
 
     if ext in {".csv", ".tsv"}:
@@ -789,6 +795,11 @@ def _format_spreadsheet(
             parts.append(
                 f"(Offset {offset} exceeds this sheet's {total_rows} rows; no rows shown.)"
             )
+            continue
+        if limit == 0:
+            # Headers-only read: the standard continuation note below would
+            # render the nonsensical "Showing rows 1-0 ... Use offset=1".
+            parts.append("(limit=0: headers only; pass a higher limit to read rows.)")
             continue
         # Window applied here, at render time, against the sparse map --
         # not by slicing a materialised prefix. A gap between real rows

--- a/tests/test_tools/test_read_spreadsheet_xlsx.py
+++ b/tests/test_tools/test_read_spreadsheet_xlsx.py
@@ -437,6 +437,69 @@ async def test_read_spreadsheet_large_limit_renders_the_whole_sheet(tmp_path: Pa
     assert "1048576 rows" in out
 
 
+# ---------------------------------------------------------------------------
+# limit=0 semantics (headers-only) vs the falsy-zero fallback.
+# ---------------------------------------------------------------------------
+
+
+def _write_rich_csv(tmp_path: Path, rows: int) -> Path:
+    target = tmp_path / "data.csv"
+    lines = ["c1,c2"] + [f"r{i},v{i}" for i in range(1, rows + 1)]
+    target.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return target
+
+
+async def test_read_spreadsheet_limit_zero_returns_headers_only(tmp_path: Path) -> None:
+    """limit=0 must return 0 data rows (metadata only), consistent with
+    read_file's limit handling -- it used to hit the falsy-zero fallback
+    and silently dump the 200-row default into the LLM context."""
+    target = _write_rich_csv(tmp_path, 250)
+
+    with tool_context(tmp_path):
+        out = await fs.read_spreadsheet(str(target), limit=0)
+
+    assert "251 rows" in out  # sheet metadata is still present
+    assert "r1\t" not in out  # no data row rendered at all
+    assert "(limit=0: headers only; pass a higher limit to read rows.)" in out
+    assert "Showing rows 1-0" not in out
+
+
+async def test_read_spreadsheet_omitted_limit_still_defaults_to_200(tmp_path: Path) -> None:
+    """Anti-drift: omitting limit keeps the 200-row default."""
+    target = _write_rich_csv(tmp_path, 250)
+
+    with tool_context(tmp_path):
+        out = await fs.read_spreadsheet(str(target))
+
+    assert "\n200\tr199\tv199" in out
+    assert "\n201\tr200\tv200" not in out
+    assert "Showing rows 1-200 of 251" in out
+
+
+async def test_read_spreadsheet_negative_limit_keeps_default_fallback(tmp_path: Path) -> None:
+    """Anti-drift: a negative limit keeps the old 200-row fallback."""
+    target = _write_rich_csv(tmp_path, 250)
+
+    with tool_context(tmp_path):
+        out = await fs.read_spreadsheet(str(target), limit=-5)
+
+    assert "\n200\tr199\tv199" in out
+    assert "\n201\tr200\tv200" not in out
+
+
+async def test_read_spreadsheet_small_positive_limit_still_honored(tmp_path: Path) -> None:
+    """Anti-drift: small positive limits behave exactly as before."""
+    target = _write_rich_csv(tmp_path, 250)
+
+    with tool_context(tmp_path):
+        out = await fs.read_spreadsheet(str(target), limit=2)
+
+    assert "\n1\tc1\tc2" in out
+    assert "\n2\tr1\tv1" in out
+    assert "\n3\tr2\tv2" not in out
+    assert "Showing rows 1-2 of 251" in out
+
+
 def test_read_xlsx_sheets_reading_does_not_scale_with_sheet_count(tmp_path: Path) -> None:
     """_read_xlsx_sheets parses every sheet before a single one is selected,
     so its own cost -- independent of whatever `limit` a caller later


### PR DESCRIPTION
Fixes #1791

## Problem

`read_spreadsheet` computed its row cap as:

```python
row_limit = limit if limit and limit > 0 else 200
```

`limit=0` falls through the falsy-zero check (`0 and 0 > 0` is falsy) to the 200-row default, so a headers-only read silently dumped 200 data rows into the LLM context — the exact flooding the caller was trying to avoid. `read_file` already honors `limit=0` as zero lines (`if limit is not None and emitted >= limit`), so the two tools disagree on the same parameter convention.

## Fix

- `src/agentos/tools/builtin/filesystem.py` — `row_limit = 200 if limit is None or limit < 0 else limit`. `limit=0` now renders 0 data rows; omitted and negative limits keep the old 200-row fallback, so only the reported bug changes behavior.
- `_format_spreadsheet` gets a headers-only branch: the zero-width window would otherwise print the nonsensical continuation line `(Showing rows 1-0 of 251. Use offset=1 to continue.)`; it now prints `(limit=0: headers only; pass a higher limit to read rows.)` after the sheet metadata.
- Tool param description updated to document the `0 = headers only` convention.

## Testing

Regression tests in `tests/test_tools/test_read_spreadsheet_xlsx.py`:

- `test_read_spreadsheet_limit_zero_returns_headers_only` — 251-row CSV with `limit=0`: sheet metadata present (`251 rows x 2 columns`), no data row rendered (`r1\t` absent), headers-only note present, no bogus `Showing rows 1-0` line.
- Three anti-drift guards: omitted limit still defaults to 200 rows, negative limit keeps the 200-row fallback, small positive limit (`limit=2`) behaves exactly as before.

**RED→GREEN proven**: with the fix stashed (`git stash -- src/agentos/tools/builtin/filesystem.py`), only the core test fails (`r1\t` present in output — the 200-row dump); with the fix, all 4 pass.

- `pytest tests/test_tools/test_read_spreadsheet_xlsx.py` — 23 passed
- `ruff check src tests` — clean
- `mypy src/agentos --show-error-codes` — Success, 625 files
- Full suite: **25 failed / 3 errors / 10425 passed** — delta vs clean-tree baseline @ `4ca69ff` is empty; the only baseline-only failure is the new RED-by-design test.
