### PR TITLE
fix(session): escape LIKE wildcards in list_degraded_summaries (#1771)

### DIFF
--- a/src/agentos/session/storage.py
+++ b/src/agentos/session/storage.py
@@ -395,6 +395,11 @@ def _serialize(value: Any) -> Any:
     return value
 
 
+def _escape_like(value: str) -> str:
+    """Escape SQLite LIKE wildcards (%, _, \\) for exact literal matching."""
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 def _deserialize_row(row: dict[str, Any]) -> dict[str, Any]:
     """Deserialize JSON text fields back to Python objects."""
     json_fields = {
@@ -1647,8 +1652,8 @@ class SessionStorage:
         clauses = ["flush_receipt_status IN ('degraded_forensic', 'failed_retryable')"]
         params: list[Any] = []
         if session_key_prefix:
-            clauses.append("session_key LIKE ?")
-            params.append(f"{session_key_prefix}%")
+            clauses.append("session_key LIKE ? ESCAPE '\\'")
+            params.append(f"{_escape_like(session_key_prefix)}%")
         params.append(limit)
         sql = (
             "SELECT * FROM session_summaries "

--- a/tests/test_session/test_storage_degraded_summaries_prefix.py
+++ b/tests/test_session/test_storage_degraded_summaries_prefix.py
@@ -1,0 +1,114 @@
+"""Tests for list_degraded_summaries LIKE wildcard escaping (#1771).
+
+Pins the contract that wildcard characters like '_' and '%' in session_key_prefix
+are escaped and matched literally, rather than acting as SQL pattern wildcards.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from agentos.session.models import SessionNode, SessionSummary
+from agentos.session.storage import SessionStorage, _escape_like
+
+
+@pytest.fixture
+async def storage():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "test.db"
+        store = SessionStorage(str(path))
+        await store.connect()
+        try:
+            yield store
+        finally:
+            await store.close()
+
+
+def test_escape_like_helper() -> None:
+    assert _escape_like("plain_text") == "plain\\_text"
+    assert _escape_like("100%") == "100\\%"
+    assert _escape_like("path\\to") == "path\\\\to"
+    assert _escape_like("mix_%\\") == "mix\\_\\%\\\\"
+    assert _escape_like("normal-key:123") == "normal-key:123"
+
+
+@pytest.mark.asyncio
+async def test_list_degraded_summaries_escapes_underscore_wildcard(
+    storage: SessionStorage,
+) -> None:
+    # Seed sessions and degraded summaries
+    # session_1_test has literal underscore after session
+    # session1_test has digit '1' at that position (would match unescaped 'session_%')
+    # session_a_test has literal underscore after session
+    keys_and_ids = [
+        ("session_1_test", "sid-1"),
+        ("session1_test", "sid-2"),
+        ("session_a_test", "sid-3"),
+    ]
+
+    for key, sid in keys_and_ids:
+        await storage.upsert_session(
+            SessionNode(
+                session_key=key,
+                session_id=sid,
+                created_at=1000,
+                updated_at=1000,
+            )
+        )
+        summary = SessionSummary(
+            session_id=sid,
+            session_key=key,
+            compaction_id=f"cmp-{sid}",
+            compaction_index=0,
+            summary_text=f"summary for {key}",
+            flush_receipt_status="degraded_forensic",
+        )
+        await storage.save_summary(summary)
+
+    # Query with prefix "session_"
+    results = await storage.list_degraded_summaries(session_key_prefix="session_")
+    matched_keys = [s.session_key for s in results]
+
+    # Should match "session_1_test" and "session_a_test", but NOT "session1_test"
+    assert "session_1_test" in matched_keys
+    assert "session_a_test" in matched_keys
+    assert "session1_test" not in matched_keys
+    assert len(matched_keys) == 2
+
+
+@pytest.mark.asyncio
+async def test_list_degraded_summaries_escapes_percent_wildcard(
+    storage: SessionStorage,
+) -> None:
+    keys_and_ids = [
+        ("session%special", "sid-pct"),
+        ("sessionXspecial", "sid-other"),
+    ]
+
+    for key, sid in keys_and_ids:
+        await storage.upsert_session(
+            SessionNode(
+                session_key=key,
+                session_id=sid,
+                created_at=1000,
+                updated_at=1000,
+            )
+        )
+        summary = SessionSummary(
+            session_id=sid,
+            session_key=key,
+            compaction_id=f"cmp-{sid}",
+            compaction_index=0,
+            summary_text=f"summary for {key}",
+            flush_receipt_status="failed_retryable",
+        )
+        await storage.save_summary(summary)
+
+    # Query with prefix "session%"
+    results = await storage.list_degraded_summaries(session_key_prefix="session%")
+    matched_keys = [s.session_key for s in results]
+
+    assert matched_keys == ["session%special"]


### PR DESCRIPTION
markdown
## Problem
In `SessionStorage.list_degraded_summaries`, filtering by `session_key_prefix` was performed using an unescaped SQLite pattern:
```sql
session_key LIKE ?
with parameter f"{session_key_prefix}%".

In SQLite LIKE queries, _ matches any single character and % matches any sequence of characters. As a result, querying by a prefix such as "session_" matched unrelated session keys like session1_test (where 1 matched _), rather than performing a literal prefix match.

Fixes #1771

Solution
Added _escape_like() helper function in src/agentos/session/storage.py that escapes \, %, and _.
Updated list_degraded_summaries to pair the SQL clause with ESCAPE '\\':
python
clauses.append("session_key LIKE ? ESCAPE '\\'")
params.append(f"{_escape_like(session_key_prefix)}%")
Verification
Added regression tests in tests/test_session/test_storage_degraded_summaries_prefix.py:
Verified _escape_like() escapes _, %, \, and mixed strings correctly.
Verified session_ prefix matching includes session_1_test and session_a_test, while strictly excluding session1_test.
Verified session% prefix matching matches literal percent keys (session%special) while excluding sessionXspecial.
Quality gates:
uv run ruff check src tests passed with 0 errors.
uv run mypy src/agentos --show-error-codes passed across all 625 files.
uv run pytest tests/test_session -q passed (237 passed).