### PR TITLE
fix(tools): raise FileNotFoundError on non-existent path in glob_search and grep_search (Closes #1802)

### DIFF
--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -1004,6 +1004,8 @@ async def glob_search(pattern: str, path: str | None = None) -> str:
     if blocked is not None:
         return json.dumps(blocked)
     _gate_workspace_strict_read("glob_search", base, path or str(base))
+    if not base.exists():
+        raise FileNotFoundError(f"Path not found: {path or base}")
 
     loop = asyncio.get_running_loop()
     strict_roots = _strict_read_roots()
@@ -1056,6 +1058,8 @@ async def grep_search(
     if blocked is not None:
         return json.dumps(blocked)
     _gate_workspace_strict_read("grep_search", base, path or str(base))
+    if not base.exists():
+        raise FileNotFoundError(f"Path not found: {path or base}")
 
     loop = asyncio.get_running_loop()
     strict_roots = _strict_read_roots()

--- a/tests/test_tools/test_filesystem_read_workspace.py
+++ b/tests/test_tools/test_filesystem_read_workspace.py
@@ -435,3 +435,17 @@ async def test_write_file_records_workspace_write_on_both_create_and_overwrite(
         current_tool_context.reset(token)
 
 
+@pytest.mark.asyncio
+async def test_glob_search_and_grep_search_raise_file_not_found_on_missing_path(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    nonexistent = workspace / "nonexistent_dir"
+
+    with tool_context(workspace):
+        with pytest.raises(FileNotFoundError, match="Path not found"):
+            await fs.glob_search("*.py", path=str(nonexistent))
+
+        with pytest.raises(FileNotFoundError, match="Path not found"):
+            await fs.grep_search("needle", path=str(nonexistent))


### PR DESCRIPTION
### Summary
Fixes #1802

### Problem
When `glob_search` or `grep_search` is called with a non-existent directory or file `path` within the workspace, both tools previously executed `base.glob(pattern)` or `base.rglob("*")`, which silently evaluated to empty lists. This returned misleading "No files matched" or "No matches" messages, masking path errors from the model instead of raising `FileNotFoundError` as do all other filesystem tools (`list_dir`, `read_file`, etc.).

### Fix
- In `glob_search` and `grep_search`, verify `if not base.exists(): raise FileNotFoundError(f"Path not found: {path or base}")` after workspace strict read gating.
- Add regression tests verifying `FileNotFoundError` on non-existent paths.
