### PR TITLE
fix(session): match on session_key as well as session_id in search_transcript (Closes #1801)

### DIFF
--- a/src/agentos/session/storage.py
+++ b/src/agentos/session/storage.py
@@ -1841,8 +1841,8 @@ class SessionStorage:
         params: list[Any] = [safe_q]
         joins = ""
         if session_id:
-            clauses.append("t.session_id = ?")
-            params.append(session_id)
+            clauses.append("(t.session_id = ? OR t.session_key = ?)")
+            params.extend([session_id, canonicalize_session_key(session_id)])
         if project_id:
             joins = "JOIN sessions s ON s.session_id = t.session_id "
             clauses.append("s.project_id = ?")

--- a/tests/test_session/test_projects.py
+++ b/tests/test_session/test_projects.py
@@ -173,6 +173,12 @@ async def test_search_transcript_scoped_to_project(manager, storage):
     scoped = await storage.search_transcript("quantum widget", project_id=project["project_id"])
     assert [hit["session_key"] for hit in scoped] == [inside.session_key]
 
+    scoped_by_key = await storage.search_transcript("quantum widget", session_id=inside.session_key)
+    assert [hit["session_key"] for hit in scoped_by_key] == [inside.session_key]
+
+    scoped_by_id = await storage.search_transcript("quantum widget", session_id=inside.session_id)
+    assert [hit["session_key"] for hit in scoped_by_id] == [inside.session_key]
+
 
 @pytest.mark.asyncio
 async def test_update_project_rename_does_not_clobber_concurrent_knowledge(manager):

--- a/tests/test_tools/test_session_search.py
+++ b/tests/test_tools/test_session_search.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agentos.session.manager import SessionManager
+from agentos.session.storage import SessionStorage
+from agentos.tools.builtin.session_search import create_session_search_tool
+from agentos.tools.registry import ToolRegistry
+
+
+@pytest.fixture
+async def session_env(tmp_path: Path):
+    db_path = tmp_path / "test_session_search.db"
+    storage = SessionStorage(str(db_path))
+    await storage.connect()
+    manager = SessionManager(storage=storage)
+    try:
+        yield manager, storage
+    finally:
+        await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_session_search_with_session_key_and_id(session_env) -> None:
+    manager, storage = session_env
+    node1 = await manager.create("main:chat_1", agent_id="main")
+    node2 = await manager.create("main:chat_2", agent_id="main")
+
+    await manager.append_message(node1.session_key, role="user", content="quantum widget deployed")
+    await manager.append_message(node2.session_key, role="user", content="quantum widget pending")
+
+    registry = ToolRegistry()
+    create_session_search_tool(storage, registry=registry)
+    tool = registry.get("session_search")
+    assert tool is not None
+
+    # Search with session_key as session_id filter
+    res_key = json.loads(await tool.handler(query="deployed", session_id="main:chat_1"))
+    assert res_key.get("result_count") == 1
+    assert res_key["results"][0]["session_key"] == "main:chat_1"
+
+    # Search with UUID session_id filter
+    res_uuid = json.loads(await tool.handler(query="deployed", session_id=node1.session_id))
+    assert res_uuid.get("result_count") == 1
+    assert res_uuid["results"][0]["session_key"] == "main:chat_1"
+
+    # Search for "deployed" in chat_2 should yield no matches
+    res_other = json.loads(await tool.handler(query="deployed", session_id="main:chat_2"))
+    assert res_other.get("results") == []


### PR DESCRIPTION
### Summary
Fixes #1801

### Problem
In `SessionStorage.search_transcript`, when `session_id` was supplied as a filter, the query constructed `t.session_id = ?`. Throughout AgentOS (and in `session_search` tool parameters and returned hit payloads), callers and models pass `session_key` (such as `"main:chat_1"`) to identify sessions. Because `t.session_id` stores an internal UUID, filtering exclusively by `t.session_id = ?` returned 0 results when a `session_key` was provided.

### Fix
- Update the clause in `SessionStorage.search_transcript` to match `(t.session_id = ? OR t.session_key = ?)` using canonicalized session key.
- Add regression tests in `test_projects.py` and `test_session_search.py` testing searches filtered by both UUID `session_id` and human-readable `session_key`.
