### PR TITLE
fix(tools): check artifact name in publish_artifact deduplication (Closes #1793)

### DIFF
--- a/src/agentos/tools/builtin/artifacts.py
+++ b/src/agentos/tools/builtin/artifacts.py
@@ -210,8 +210,15 @@ async def publish_artifact(
         raise ToolError(f"artifact path is not a file: {path}")
 
     target_sha256 = hashlib.sha256(target.read_bytes()).hexdigest()
+    artifact_name, artifact_mime = _publish_artifact_metadata(
+        target=target,
+        name=name,
+        mime=mime,
+    )
     for published in reversed(ctx.published_artifacts):
         if published.get("sha256") != target_sha256:
+            continue
+        if published.get("name") not in {artifact_name, target.name}:
             continue
         llm_artifact = _llm_artifact_payload(
             published,
@@ -227,12 +234,6 @@ async def publish_artifact(
             },
             ensure_ascii=False,
         )
-
-    artifact_name, artifact_mime = _publish_artifact_metadata(
-        target=target,
-        name=name,
-        mime=mime,
-    )
 
     store = ArtifactStore(ctx.artifact_media_root)
     existing = store.find_existing_ref(

--- a/tests/test_tools/test_artifacts_publish.py
+++ b/tests/test_tools/test_artifacts_publish.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agentos.tools.builtin.artifacts import publish_artifact
+from agentos.tools.types import CallerKind, ToolContext, current_tool_context
+
+
+@pytest.mark.asyncio
+async def test_publish_artifact_distinguishes_files_with_identical_content(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    artifacts_root = tmp_path / "artifacts"
+    artifacts_root.mkdir()
+
+    file1 = workspace / "first.txt"
+    file2 = workspace / "second.txt"
+    content = "shared identical content"
+    file1.write_text(content, encoding="utf-8")
+    file2.write_text(content, encoding="utf-8")
+
+    ctx = ToolContext(
+        workspace_dir=str(workspace),
+        artifact_media_root=str(artifacts_root),
+        artifact_session_id="sess_1",
+        session_key="key_1",
+        caller_kind=CallerKind.CLI,
+    )
+    token = current_tool_context.set(ctx)
+    try:
+        r1 = json.loads(await publish_artifact("first.txt"))
+        assert r1["status"] == "published"
+        assert r1["artifact"]["name"] == "first.txt"
+
+        r2 = json.loads(await publish_artifact("second.txt"))
+        assert r2["status"] == "published"
+        assert r2["artifact"]["name"] == "second.txt"
+
+        # Publishing first.txt again should be recognized as already published
+        r1_again = json.loads(await publish_artifact("first.txt"))
+        assert r1_again["status"] == "already_published"
+        assert r1_again["artifact"]["name"] == "first.txt"
+    finally:
+        current_tool_context.reset(token)


### PR DESCRIPTION
### Summary
Fixes #1793

### Problem
In `publish_artifact` (`src/agentos/tools/builtin/artifacts.py`), in-turn deduplication previously checked only `published.get("sha256") == target_sha256`. If two distinct files shared identical content (e.g. empty files, duplicate config templates, backups), publishing the second file immediately returned `status: "already_published"` pointing to the first file's artifact name and ID.

### Fix
- In `publish_artifact`, resolve `artifact_name` before deduplication and ensure that `published.get("name") in {artifact_name, target.name}` before treating an artifact as already published.
- Add regression tests verifying that two distinct workspace files with identical content are each published and registered with their respective names.
