### PR TITLE
fix(tools): allow whitespace around hyphen in pdf page range (Closes #1792)

### DIFF
--- a/src/agentos/tools/builtin/media.py
+++ b/src/agentos/tools/builtin/media.py
@@ -754,7 +754,7 @@ def _parse_page_range(pages: str, total: int) -> list[int]:
         if not seg:
             continue
         if "-" in seg:
-            parts = seg.split("-", 1)
+            parts = [p.strip() for p in seg.split("-", 1)]
             if len(parts) != 2 or not parts[0].isdigit() or not parts[1].isdigit():
                 raise SafeToolError(f"Invalid page range: {pages}")
             start, end = int(parts[0]), int(parts[1])

--- a/tests/test_tools/test_pdf.py
+++ b/tests/test_tools/test_pdf.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import pytest
+
+from agentos.tools.builtin.media import _parse_page_range
+from agentos.tools.types import SafeToolError
+
+
+def test_parse_page_range_accepts_spaces_around_hyphen() -> None:
+    # Page range with spaces around hyphen
+    indices = _parse_page_range("1 - 5", 10)
+    assert indices == [0, 1, 2, 3, 4]
+
+
+def test_parse_page_range_multiple_segments_with_spaces() -> None:
+    # Multiple segments with arbitrary whitespace
+    indices = _parse_page_range(" 1 - 3 , 5 - 6 , 8 ", 10)
+    assert indices == [0, 1, 2, 4, 5, 7]
+
+
+def test_parse_page_range_invalid_syntax_raises_safetoolerror() -> None:
+    with pytest.raises(SafeToolError, match="Invalid page range"):
+        _parse_page_range("1 - abc", 10)
+
+    with pytest.raises(SafeToolError, match="Invalid page range"):
+        _parse_page_range("5 - 2", 10)
+
+
+def test_parse_page_range_exceeds_total_raises_safetoolerror() -> None:
+    with pytest.raises(SafeToolError, match="exceeds document length"):
+        _parse_page_range("1 - 15", 10)


### PR DESCRIPTION
### Summary
Fixes #1792

### Problem
In `_parse_page_range` (`src/agentos/tools/builtin/media.py`), page range segments containing a hyphen were split via `seg.split("-", 1)`. When the input contained spaces around the delimiter (e.g. `"1 - 5"` or `" 1-3 , 5 - 8 "`), `parts` retained whitespace (`["1 ", " 5"]`), causing `parts[0].isdigit()` and `parts[1].isdigit()` to return `False` and incorrectly raising `SafeToolError("Invalid page range: ...")`.

### Fix
- Strip whitespace from split parts: `parts = [p.strip() for p in seg.split("-", 1)]`.
- Add unit tests in `tests/test_tools/test_pdf.py` verifying parsing with various whitespace formats as well as validating invalid ranges.
