### PR TITLE
fix(sandbox): anchor the /root/.ssh sensitive-path check at a segment…

### DIFF
--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -259,12 +259,7 @@ def is_sensitive_path(path: str) -> str | None:
         return None
     candidates = _comparison_path_candidates(path)
     for expanded in candidates:
-        if (
-            expanded == "/root/.ssh"
-            or expanded.startswith("/root/.ssh/")
-            or expanded.endswith("/root/.ssh")
-            or "/root/.ssh/" in expanded
-        ):
+        if _path_contains(expanded, "/root/.ssh"):
             return "~/.ssh"
     for prefix in _SENSITIVE_PREFIXES:
         for expanded in candidates:

--- a/tests/test_sandbox/test_sensitive_paths.py
+++ b/tests/test_sandbox/test_sensitive_paths.py
@@ -110,6 +110,19 @@ def test_posix_sensitive_paths_stay_blocked_on_windows_runners() -> None:
     )
 
 
+def test_root_ssh_check_does_not_match_an_unrelated_path_containing_the_substring() -> None:
+    """Regression for #1794: the ``/root/.ssh`` special case used unanchored
+    ``endswith``/``in`` string checks, so a workspace path that merely
+    *contains* the literal substring "root/.ssh" -- with nothing to do with
+    the real /root home directory -- was incorrectly flagged."""
+    assert is_sensitive_path("/home/dev/myproject/backup-root/root/.ssh/notes.txt") is None
+
+
+def test_root_ssh_check_still_matches_the_real_directory() -> None:
+    assert is_sensitive_path("/root/.ssh") == "~/.ssh"
+    assert is_sensitive_path("/root/.ssh/id_rsa") == "~/.ssh"
+
+
 def test_every_rm_in_a_compound_command_is_checked() -> None:
     """Issue #676: a benign leading ``rm`` must not shadow a later one.
 


### PR DESCRIPTION
Summary

is_sensitive_path's /root/.ssh special case used unanchored endswith()/in string checks alongside the anchored ones, so a workspace path merely containing the literal substring "root/.ssh" anywhere was hard-blocked, even nowhere near the real /root home directory.
/root is already in _SYSTEM_SENSITIVE_PREFIXES, so this special case exists only to relabel the marker as "~/.ssh"; it now reuses _path_contains, the same anchored-prefix helper _SENSITIVE_PREFIXES already uses.
Test plan

Added two tests: one confirming an unrelated path is no longer flagged, one confirming the real /root/.ssh directory still is.
Verified via stash that the new test fails pre-fix and passes post-fix.
ruff/mypy clean; full sandbox suite (106 passed, 26 pre-existing skips) passed.
Fixes #1794 