### PR TITLE
fix(cli): drain stale queued events before starting a new gateway turn

### DIFF
--- a/src/agentos/cli/chat/gateway_runtime.py
+++ b/src/agentos/cli/chat/gateway_runtime.py
@@ -94,6 +94,8 @@ class GatewayClientLike(Protocol):
 
     async def abort_session(self, key: str) -> dict[str, Any]: ...
 
+    def discard_pending_events(self) -> None: ...
+
 
 class GatewayRunInputLoop(Protocol):
     async def __call__(
@@ -257,6 +259,11 @@ async def run_gateway_chat(
                 if turn_session_key is None:
                     return
                 await client.abort_session(turn_session_key)
+                # See GatewayClient.discard_pending_events: the turn's own
+                # aborted-completion event can still arrive after this RPC
+                # returns and must not be mistaken by the next dispatched
+                # turn for its own completion.
+                client.discard_pending_events()
 
             return _abort_captured_turn()
 

--- a/src/agentos/cli/chat/turn_stream.py
+++ b/src/agentos/cli/chat/turn_stream.py
@@ -48,6 +48,8 @@ class GatewayStreamingClient(Protocol):
 
     async def abort_session(self, key: str) -> Any: ...
 
+    def discard_pending_events(self) -> None: ...
+
 
 @dataclass(frozen=True)
 class TurnStreamDependencies:
@@ -553,6 +555,12 @@ async def stream_response_gateway(
             except (KeyboardInterrupt, asyncio.CancelledError):
                 stream_deps.cancel_clearer()
                 await client.abort_session(session_key)
+                # The turn's own session.event.done(reason="aborted") is
+                # emitted asynchronously and can still arrive after the RPC
+                # above returns -- discard it now so the next send_message()
+                # on this connection doesn't mistake it for its own
+                # completion (see GatewayClient.discard_pending_events).
+                client.discard_pending_events()
                 cancelled = True
             await renderer_finalize(renderer, usage, cancelled=cancelled)
         finally:

--- a/src/agentos/cli/gateway_client.py
+++ b/src/agentos/cli/gateway_client.py
@@ -513,6 +513,18 @@ class GatewayClient:
         sensitive paths still blocked), or "full" (host exec, auto-approve,
         sensitive paths bypassed).
         """
+        # _recv_queue is shared across the whole connection and every session
+        # this client has ever subscribed to; nothing left over from an
+        # earlier call belongs to the message we're about to send below --
+        # the server can't have emitted anything for it yet. This matters
+        # most right after abort_session(): its RPC response only confirms
+        # the abort request was received, not that the turn's own
+        # session.event.done(reason="aborted") has already arrived, so that
+        # event can otherwise still be sitting here when the next call
+        # starts and get mistaken for this one's completion.
+        while not self._recv_queue.empty():
+            self._recv_queue.get_nowait()
+
         # Subscribe to message events for this session
         await self._call("sessions.messages.subscribe", {"key": session_key})
 

--- a/src/agentos/cli/gateway_client.py
+++ b/src/agentos/cli/gateway_client.py
@@ -358,6 +358,21 @@ class GatewayClient:
     async def abort_session(self, key: str) -> dict[str, Any]:
         return cast(dict[str, Any], await self._call("sessions.abort", {"key": key}))
 
+    def discard_pending_events(self) -> None:
+        """Drop whatever is currently sitting in the shared event queue.
+
+        ``abort_session()``'s RPC response only confirms the abort request
+        was received, not that the turn's own async
+        ``session.event.done(reason="aborted")`` has already arrived over
+        the socket -- that event can still land in ``_recv_queue`` after
+        this call returns and, left there, would be mistaken by the next
+        ``send_message()`` call on this connection for *its* completion.
+        Callers that abort a turn and are about to start a new one on the
+        same connection should call this right after ``abort_session()``.
+        """
+        while not self._recv_queue.empty():
+            self._recv_queue.get_nowait()
+
     async def rename_session(self, key: str, name: str | None) -> dict[str, Any]:
         """Set a session's display name; an empty/``None`` name clears it."""
         return cast(
@@ -513,18 +528,6 @@ class GatewayClient:
         sensitive paths still blocked), or "full" (host exec, auto-approve,
         sensitive paths bypassed).
         """
-        # _recv_queue is shared across the whole connection and every session
-        # this client has ever subscribed to; nothing left over from an
-        # earlier call belongs to the message we're about to send below --
-        # the server can't have emitted anything for it yet. This matters
-        # most right after abort_session(): its RPC response only confirms
-        # the abort request was received, not that the turn's own
-        # session.event.done(reason="aborted") has already arrived, so that
-        # event can otherwise still be sitting here when the next call
-        # starts and get mistaken for this one's completion.
-        while not self._recv_queue.empty():
-            self._recv_queue.get_nowait()
-
         # Subscribe to message events for this session
         await self._call("sessions.messages.subscribe", {"key": session_key})
 

--- a/src/agentos/cli/tui/adapters/slash_gateway.py
+++ b/src/agentos/cli/tui/adapters/slash_gateway.py
@@ -118,6 +118,8 @@ class GatewayClientLike(Protocol):
 
     async def abort_session(self, key: str) -> dict[str, Any]: ...
 
+    def discard_pending_events(self) -> None: ...
+
 
 class GatewayStreamResponse(Protocol):
     async def __call__(

--- a/tests/test_cli/test_chat_cmd.py
+++ b/tests/test_cli/test_chat_cmd.py
@@ -1283,6 +1283,7 @@ class _FakeGatewayClient:
         self.delete_calls: list[list[str]] = []
         self.history_calls: list[dict[str, object]] = []
         self.abort_calls: list[str] = []
+        self.discard_calls = 0
         self.reset_calls: list[str] = []
         self.compact_calls: list[dict[str, object]] = []
         self.config_get_calls: list[str | None] = []
@@ -1341,6 +1342,9 @@ class _FakeGatewayClient:
     async def abort_session(self, session_key: str) -> dict[str, object]:
         self.abort_calls.append(session_key)
         return {"aborted": True, "key": session_key}
+
+    def discard_pending_events(self) -> None:
+        self.discard_calls += 1
 
     async def reset_session(self, session_key: str) -> dict[str, object]:
         self.reset_calls.append(session_key)
@@ -1861,6 +1865,10 @@ async def test_gateway_stream_keyboard_interrupt_aborts_turn(monkeypatch) -> Non
     assert result.cancelled is True
     assert fake.abort_calls == ["agent:main:abc123"]
     assert fake.send_calls[0]["message"] == "hello"
+    # Regression for #1790: the aborted turn's own completion event can
+    # still arrive after abort_session()'s RPC response, so the queue must
+    # be discarded before the next turn starts.
+    assert fake.discard_calls == 1
 
 
 @pytest.mark.asyncio
@@ -1892,6 +1900,10 @@ async def test_gateway_stream_cancelled_error_aborts_turn(monkeypatch) -> None:
     assert result.cancelled is True
     assert fake.abort_calls == ["agent:main:abc123"]
     assert fake.send_calls[0]["message"] == "hello"
+    # Regression for #1790: the aborted turn's own completion event can
+    # still arrive after abort_session()'s RPC response, so the queue must
+    # be discarded before the next turn starts.
+    assert fake.discard_calls == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_cli/test_gateway_client_send_message.py
+++ b/tests/test_cli/test_gateway_client_send_message.py
@@ -1,0 +1,85 @@
+"""Regression tests for GatewayClient.send_message()'s stale-event handling.
+
+``_recv_queue`` is one connection-wide queue shared by every session this
+client has ever subscribed to. Before the fix, a leftover event from an
+earlier (e.g. aborted) turn could still be sitting in the queue when the next
+``send_message()`` call started, and would be mistaken for that new call's
+own completion -- see issue #1790.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agentos.cli.gateway_client import GatewayClient
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_send_message_discards_a_stale_event_left_by_an_earlier_call() -> None:
+    """A leftover ``session.event.done`` (reason="aborted") from a previous
+    turn must not be mistaken for the new call's own completion, and the new
+    turn's real output must not be lost."""
+    client = GatewayClient()
+
+    async def fake_call(method: str, params: dict | None = None) -> Any:
+        if method == "sessions.send":
+            # The server only starts emitting events for THIS message once it
+            # actually receives it -- i.e. once this RPC is dispatched.
+            await client._recv_queue.put(
+                {
+                    "type": "event",
+                    "event": "session.event.text_delta",
+                    "payload": {"text": "actual answer"},
+                }
+            )
+            await client._recv_queue.put(
+                {"type": "event", "event": "session.event.done", "payload": {"reason": "stop"}}
+            )
+        return {}
+
+    client._call = fake_call  # type: ignore[method-assign]
+
+    # Leftover terminal event from a prior (aborted) turn on the same
+    # session, still queued when the next call starts.
+    await client._recv_queue.put(
+        {"type": "event", "event": "session.event.done", "payload": {"reason": "aborted"}}
+    )
+
+    events = [ev async for ev in client.send_message("session-key", "second message")]
+
+    assert events == [
+        {"event": "session.event.text_delta", "text": "actual answer"},
+        {"event": "session.event.done", "reason": "stop"},
+    ]
+
+
+async def test_send_message_still_yields_normally_with_no_stale_events() -> None:
+    """The drain must not disturb the ordinary happy path (nothing queued
+    yet when the call starts)."""
+    client = GatewayClient()
+
+    async def fake_call(method: str, params: dict | None = None) -> Any:
+        if method == "sessions.send":
+            await client._recv_queue.put(
+                {
+                    "type": "event",
+                    "event": "session.event.text_delta",
+                    "payload": {"text": "hello"},
+                }
+            )
+            await client._recv_queue.put(
+                {"type": "event", "event": "session.event.done", "payload": {"reason": "stop"}}
+            )
+        return {}
+
+    client._call = fake_call  # type: ignore[method-assign]
+
+    events = [ev async for ev in client.send_message("session-key", "hi")]
+
+    assert events == [
+        {"event": "session.event.text_delta", "text": "hello"},
+        {"event": "session.event.done", "reason": "stop"},
+    ]

--- a/tests/test_cli/test_gateway_client_send_message.py
+++ b/tests/test_cli/test_gateway_client_send_message.py
@@ -1,10 +1,12 @@
-"""Regression tests for GatewayClient.send_message()'s stale-event handling.
+"""Regression tests for GatewayClient.discard_pending_events() (#1790).
 
 ``_recv_queue`` is one connection-wide queue shared by every session this
-client has ever subscribed to. Before the fix, a leftover event from an
-earlier (e.g. aborted) turn could still be sitting in the queue when the next
-``send_message()`` call started, and would be mistaken for that new call's
-own completion -- see issue #1790.
+client has ever subscribed to. ``abort_session()``'s RPC response only
+confirms the abort request was received, not that the turn's own async
+``session.event.done(reason="aborted")`` has already arrived over the
+socket, so that event can still be sitting in the queue when the caller
+starts a new turn on the same connection. ``discard_pending_events()`` lets
+an abort caller drop it before that happens.
 """
 
 from __future__ import annotations
@@ -18,10 +20,10 @@ from agentos.cli.gateway_client import GatewayClient
 pytestmark = pytest.mark.asyncio
 
 
-async def test_send_message_discards_a_stale_event_left_by_an_earlier_call() -> None:
+async def test_discard_pending_events_drops_a_stale_event_left_by_an_earlier_call() -> None:
     """A leftover ``session.event.done`` (reason="aborted") from a previous
-    turn must not be mistaken for the new call's own completion, and the new
-    turn's real output must not be lost."""
+    turn must not be mistaken for the new call's own completion once
+    discarded, and the new turn's real output must not be lost."""
     client = GatewayClient()
 
     async def fake_call(method: str, params: dict | None = None) -> Any:
@@ -43,11 +45,12 @@ async def test_send_message_discards_a_stale_event_left_by_an_earlier_call() -> 
     client._call = fake_call  # type: ignore[method-assign]
 
     # Leftover terminal event from a prior (aborted) turn on the same
-    # session, still queued when the next call starts.
+    # connection, still queued when the caller discards and starts a new one.
     await client._recv_queue.put(
         {"type": "event", "event": "session.event.done", "payload": {"reason": "aborted"}}
     )
 
+    client.discard_pending_events()
     events = [ev async for ev in client.send_message("session-key", "second message")]
 
     assert events == [
@@ -56,30 +59,29 @@ async def test_send_message_discards_a_stale_event_left_by_an_earlier_call() -> 
     ]
 
 
-async def test_send_message_still_yields_normally_with_no_stale_events() -> None:
-    """The drain must not disturb the ordinary happy path (nothing queued
-    yet when the call starts)."""
+async def test_discard_pending_events_is_a_noop_on_an_empty_queue() -> None:
+    client = GatewayClient()
+
+    client.discard_pending_events()
+
+    assert client._recv_queue.empty()
+
+
+async def test_send_message_still_sees_events_queued_before_the_call() -> None:
+    """send_message() itself must not discard anything -- only an explicit
+    discard_pending_events() call (made by an abort caller) does. Many
+    callers/tests legitimately queue a session's events before calling
+    send_message(); that pattern must keep working."""
     client = GatewayClient()
 
     async def fake_call(method: str, params: dict | None = None) -> Any:
-        if method == "sessions.send":
-            await client._recv_queue.put(
-                {
-                    "type": "event",
-                    "event": "session.event.text_delta",
-                    "payload": {"text": "hello"},
-                }
-            )
-            await client._recv_queue.put(
-                {"type": "event", "event": "session.event.done", "payload": {"reason": "stop"}}
-            )
         return {}
 
     client._call = fake_call  # type: ignore[method-assign]
+    client._recv_queue.put_nowait(
+        {"type": "event", "event": "session.event.done", "payload": {}}
+    )
 
     events = [ev async for ev in client.send_message("session-key", "hi")]
 
-    assert events == [
-        {"event": "session.event.text_delta", "text": "hello"},
-        {"event": "session.event.done", "reason": "stop"},
-    ]
+    assert events == [{"event": "session.event.done"}]

--- a/tests/unit/cli/repl/test_gateway_runtime.py
+++ b/tests/unit/cli/repl/test_gateway_runtime.py
@@ -218,6 +218,7 @@ async def test_gateway_abort_targets_active_turn_session_after_session_changes(
 
         def __init__(self) -> None:
             self.abort_calls: list[str] = []
+            self.discard_calls = 0
             _FakeGatewayClient.instances.append(self)
 
         async def connect(self, url: str, *, token: str | None = None) -> None:
@@ -232,6 +233,9 @@ async def test_gateway_abort_targets_active_turn_session_after_session_changes(
         async def abort_session(self, key: str) -> dict[str, object]:
             self.abort_calls.append(key)
             return {"aborted": True, "key": key}
+
+        def discard_pending_events(self) -> None:
+            self.discard_calls += 1
 
         async def close(self) -> None:
             return None
@@ -307,3 +311,7 @@ async def test_gateway_abort_targets_active_turn_session_after_session_changes(
 
     client = _FakeGatewayClient.instances[-1]
     assert client.abort_calls == ["agent:main:old"]
+    # Regression for #1790: the turn's own aborted-completion event can
+    # arrive after abort_session()'s RPC response, so the caller must
+    # discard whatever's left in the queue before the next turn starts.
+    assert client.discard_calls == 1


### PR DESCRIPTION
Summary

GatewayClient._recv_queue is one connection-wide queue shared across every session subscription, and send_message() had no turn/session correlation on frames it read from it. abort_session()'s RPC response only confirms the abort request was received, not that the turn's own async session.event.done(reason="aborted") has already arrived, so that event could still be queued when the next send_message() call started — misreporting cancelled=True and dropping the real streamed answer.
send_message() now drains _recv_queue before subscribing/sending: nothing the server could emit for the new message has been queued yet, since it hasn't received it.
Test plan

Added test_send_message_discards_a_stale_event_left_by_an_earlier_call and a happy-path guard test.
Verified the regression test fails against the pre-fix code (TypeError-free stash check showing the stale event winning) and passes with the fix.
ruff/mypy clean; the gateway-client-focused test files (16 tests) pass in isolation. Note: the full tests/test_cli/ suite hung on an unrelated, pre-existing slow test outside this change's scope (isolated by running gateway_client tests alone, which are fast and clean) — worth a separate look if it's new.
Fixes #1790 