### PR TITLE
fix(sandbox): require approval for a trusted action escalated to STRI…

### DIFF
--- a/src/agentos/sandbox/integration.py
+++ b/src/agentos/sandbox/integration.py
@@ -371,6 +371,7 @@ async def gate_action(
         workspace,
         rt.settings,
         trusted=(hints is None or hints.trusted_source),
+        hints=hints,
     )
     request = build_request(
         action_kind=action_kind,

--- a/src/agentos/sandbox/policy.py
+++ b/src/agentos/sandbox/policy.py
@@ -203,6 +203,7 @@ def build_policy(
     settings: SandboxSettings,
     *,
     trusted: bool = True,
+    hints: LevelHints | None = None,
 ) -> SandboxPolicy:
     """Materialise a :class:`SandboxPolicy` for ``level``.
 
@@ -211,6 +212,13 @@ def build_policy(
     does not alter the level here — callers are expected to have passed the
     flag through :func:`select_level` already — but it does force approval on
     for any untrusted action.
+
+    ``hints`` is the same object (if any) already passed to
+    :func:`select_level`. A trusted-source action can still reach ``STRICT``
+    on ``writes_outside_workspace``/``crosses_trust_boundary`` alone; that
+    escalation is exactly the boundary-crossing risk ``STRICT`` exists to
+    gate, independent of whether the request's source was trusted, so it
+    also forces approval on.
 
     ``workspace`` must be an absolute path. If the caller is unsure, resolve
     it first; we do not call :meth:`Path.resolve` here to avoid surprising
@@ -224,8 +232,11 @@ def build_policy(
     network = _resolve_network(level, action_kind)
     tmp_writable = level != SecurityLevel.LOCKED
 
+    crosses_boundary = hints is not None and (
+        hints.writes_outside_workspace or hints.crosses_trust_boundary
+    )
     require_approval = level >= SecurityLevel.STRICT and (
-        level == SecurityLevel.LOCKED or not trusted
+        level == SecurityLevel.LOCKED or not trusted or crosses_boundary
     )
 
     return SandboxPolicy(

--- a/tests/test_sandbox/test_policy_approval.py
+++ b/tests/test_sandbox/test_policy_approval.py
@@ -1,0 +1,72 @@
+"""Regression tests for build_policy's require_approval gating (#1795)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentos.sandbox.config import SandboxSettings
+from agentos.sandbox.policy import LevelHints, build_policy, select_level
+from agentos.sandbox.types import SecurityLevel
+
+
+def test_trusted_write_outside_workspace_still_requires_approval(tmp_path: Path) -> None:
+    """A trusted-source fs.write escalated to STRICT for leaving the
+    workspace must still require approval -- that's the exact risk STRICT
+    exists to gate here, independent of the request's trust."""
+    hints = LevelHints(trusted_source=True, writes_outside_workspace=True)
+    level = select_level("fs.write", hints)
+    assert level is SecurityLevel.STRICT
+
+    policy = build_policy(
+        level,
+        "fs.write",
+        tmp_path,
+        SandboxSettings(sandbox=True, security_grading=True),
+        trusted=hints.trusted_source,
+        hints=hints,
+    )
+
+    assert policy.require_approval is True
+
+
+def test_trusted_action_crossing_trust_boundary_still_requires_approval(tmp_path: Path) -> None:
+    hints = LevelHints(trusted_source=True, crosses_trust_boundary=True)
+    level = select_level("git.write", hints)
+    assert level is SecurityLevel.STRICT
+
+    policy = build_policy(
+        level,
+        "git.write",
+        tmp_path,
+        SandboxSettings(sandbox=True, security_grading=True),
+        trusted=hints.trusted_source,
+        hints=hints,
+    )
+
+    assert policy.require_approval is True
+
+
+def test_untrusted_source_at_strict_still_requires_approval_without_hints(tmp_path: Path) -> None:
+    """Existing behavior (no hints passed) must be unaffected by the fix."""
+    policy = build_policy(
+        SecurityLevel.STRICT,
+        "network.fetch",
+        tmp_path,
+        SandboxSettings(sandbox=True, security_grading=True),
+        trusted=False,
+    )
+
+    assert policy.require_approval is True
+
+
+def test_trusted_standard_action_does_not_require_approval(tmp_path: Path) -> None:
+    """Existing behavior for the common case must be unaffected."""
+    policy = build_policy(
+        SecurityLevel.STANDARD,
+        "fs.write",
+        tmp_path,
+        SandboxSettings(sandbox=True, security_grading=True),
+        trusted=True,
+    )
+
+    assert policy.require_approval is False


### PR DESCRIPTION
Summary

build_policy's require_approval only checked level == LOCKED or not trusted, so a trusted-source action escalated to STRICT purely for writes_outside_workspace/crosses_trust_boundary silently bypassed approval — build_policy never received the hints that caused the escalation, only the resolved level and the trusted flag.
build_policy now accepts the same optional LevelHints already passed to select_level; require_approval also fires on a boundary-crossing hint. gate_action (the real caller with hints in scope) now threads it through — the two other call sites never pass hints today, so they're unaffected.
Test plan

Added 4 tests covering the boundary-crossing escalation, the existing untrusted-STRICT case, and the ordinary trusted-STANDARD case.
Verified via stash (fails with TypeError pre-fix, confirming the parameter didn't exist).
ruff/mypy clean; full sandbox suite (108 passed) and full tools suite (1172 passed) passed.
Fixes #1795 