### PR TITLE
fix(session): log warning on JSON decode errors in _deserialize_row (#1769)

### DIFF
--- a/src/agentos/session/storage.py
+++ b/src/agentos/session/storage.py
@@ -421,7 +421,24 @@ def _deserialize_row(row: dict[str, Any]) -> dict[str, Any]:
         if k in json_fields and isinstance(v, str):
             try:
                 result[k] = json.loads(v)
-            except (json.JSONDecodeError, TypeError):
+            except (json.JSONDecodeError, TypeError) as exc:
+                row_ident = (
+                    row.get("session_key")
+                    or row.get("session_id")
+                    or row.get("message_id")
+                    or row.get("task_id")
+                    or row.get("receipt_id")
+                    or row.get("summary_id")
+                    or row.get("state_key")
+                    or row.get("id")
+                    or "<unknown>"
+                )
+                log.warning(
+                    "Failed to deserialize JSON field '%s' for row '%s': %s",
+                    k,
+                    row_ident,
+                    exc,
+                )
                 result[k] = None
         elif k in bool_fields:
             result[k] = bool(v)

--- a/tests/test_session/test_storage_deserialize_row.py
+++ b/tests/test_session/test_storage_deserialize_row.py
@@ -1,0 +1,106 @@
+"""Tests for _deserialize_row and JSON deserialization error logging."""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+
+import pytest
+
+from agentos.session.storage import SessionStorage, _deserialize_row
+
+
+def test_deserialize_row_valid_json():
+    row = {
+        "session_key": "agent:test:session-1",
+        "tool_calls": '[{"name": "test_tool", "arguments": {}}]',
+        "total_tokens_fresh": 1,
+        "raw_text": "hello",
+    }
+    deserialized = _deserialize_row(row)
+    assert deserialized["tool_calls"] == [{"name": "test_tool", "arguments": {}}]
+    assert deserialized["total_tokens_fresh"] is True
+    assert deserialized["raw_text"] == "hello"
+
+
+def test_deserialize_row_corrupted_json_logs_warning_with_session_key(caplog):
+    row = {
+        "session_key": "agent:test:session-corrupted",
+        "tool_calls": '{"name": "truncated_json',
+    }
+    with caplog.at_level(logging.WARNING, logger="agentos.session.storage"):
+        deserialized = _deserialize_row(row)
+
+    assert deserialized["tool_calls"] is None
+    assert deserialized["session_key"] == "agent:test:session-corrupted"
+    assert any(
+        "Failed to deserialize JSON field 'tool_calls' for row 'agent:test:session-corrupted'"
+        in record.message
+        for record in caplog.records
+    )
+
+
+def test_deserialize_row_corrupted_json_fallback_identifiers(caplog):
+    identifiers = [
+        ({"session_id": "sess-xyz"}, "sess-xyz"),
+        ({"message_id": "msg-123"}, "msg-123"),
+        ({"task_id": "task-abc"}, "task-abc"),
+        ({"receipt_id": "rcpt-789"}, "rcpt-789"),
+        ({"summary_id": "summ-456"}, "summ-456"),
+        ({"state_key": "state-k"}, "state-k"),
+        ({"id": "pk-999"}, "pk-999"),
+        ({}, "<unknown>"),
+    ]
+
+    for row_id_dict, expected_ident in identifiers:
+        caplog.clear()
+        row = {
+            **row_id_dict,
+            "payload": "{not valid json",
+        }
+        with caplog.at_level(logging.WARNING, logger="agentos.session.storage"):
+            deserialized = _deserialize_row(row)
+
+        assert deserialized["payload"] is None
+        assert any(
+            f"Failed to deserialize JSON field 'payload' for row '{expected_ident}'"
+            in record.message
+            for record in caplog.records
+        )
+
+
+@pytest.mark.asyncio
+async def test_session_storage_reads_corrupted_transcript_entry_with_warning(tmp_path, caplog):
+    db_path = tmp_path / "test-storage.db"
+    storage = await SessionStorage.open(str(db_path))
+
+    session_id = "sess-id-1"
+    session_key = "agent:test:sess-int"
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO transcript_entries (
+                session_id, session_key, message_id, role, content, tool_calls, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                session_id,
+                session_key,
+                "msg-corrupted",
+                "assistant",
+                "corrupted entry",
+                "{malformed json",
+                1000,
+            ),
+        )
+
+    with caplog.at_level(logging.WARNING, logger="agentos.session.storage"):
+        entries = await storage.get_transcript(session_id)
+
+    await storage.close()
+
+    assert len(entries) == 1
+    assert entries[0].tool_calls is None
+    expected_msg = f"Failed to deserialize JSON field 'tool_calls' for row '{session_key}'"
+    assert any(expected_msg in record.message for record in caplog.records)


### PR DESCRIPTION
### Summary
Fixes an issue where `_deserialize_row` silently swallowed `json.JSONDecodeError` and `TypeError` when deserializing JSON columns (such as `tool_calls`, `payload`, `delivery_context`), setting them to `None` without any warning or diagnostic log. This caused silent downstream data loss and hard-to-trace exceptions during transcript playback or session restoration.

### Changes
- Updated `_deserialize_row` in `src/agentos/session/storage.py` to catch `(json.JSONDecodeError, TypeError) as exc` and emit a structured `log.warning` identifying:
  - The corrupted column/field name (`k`).
  - The row identifier (resolving through `session_key`, `session_id`, `message_id`, `task_id`, `receipt_id`, `summary_id`, `state_key`, `id`, or `<unknown>`).
  - The exact exception message (`exc`).
- Added comprehensive unit and integration tests in `tests/test_session/test_storage_deserialize_row.py` covering:
  - Valid JSON fields deserializing cleanly without logs.
  - Corrupted JSON fields falling back to `None` while emitting a structured warning with the row identifier (`session_key` or fallback IDs).
  - Reading corrupted records from SQLite transcript storage and verifying the warning emission.

### Verification
- `uv run ruff check src/agentos/session/storage.py tests/test_session/test_storage_deserialize_row.py` passed.
- `uv run mypy src/agentos/session/storage.py --show-error-codes` passed with no issues.
- `uv run pytest tests/test_session/test_storage_deserialize_row.py -q` passed (4/4 passed).
- Session test suite verified (`tests/test_session`).

Closes #1769
