### PR TITLE
fix(engine): flush the protocol-leak guard on stream error, not just …

### DIFF
--- a/src/agentos/engine/turn_runner/stream_consumer_stage.py
+++ b/src/agentos/engine/turn_runner/stream_consumer_stage.py
@@ -425,6 +425,15 @@ class _ErrorHandler:
             )
         if event.code in {"incomplete_tool_stream", "provider_output_truncated"}:
             state.turn_segments[:] = _drop_unpaired_tool_use_segments(state.turn_segments)
+        # Text still held back pending disambiguation (it merely resembled the
+        # start of a tool-protocol marker) is genuine assistant output once
+        # the stream ends here instead of continuing -- flush it the same way
+        # _DoneHandler and _ToolUseStartHandler do, or it's silently dropped
+        # from the recovered partial response.
+        pending_text = state.protocol_text_guard.flush()
+        if pending_text:
+            state.final_text_parts.append(pending_text)
+            state.current_text_parts.append(pending_text)
         state.error_message = event.message or "Unknown error"
         state.pending_error_event = event
         return _SUPPRESS

--- a/tests/test_engine/turn_runner/test_stream_consumer_stage_unit.py
+++ b/tests/test_engine/turn_runner/test_stream_consumer_stage_unit.py
@@ -539,6 +539,32 @@ def test_error_handler_drops_unpaired_tool_use_on_output_truncation() -> None:
     assert state.turn_segments == [{"type": "text", "text": "partial"}]
 
 
+def test_error_handler_flushes_pending_protocol_guard_text() -> None:
+    """Regression for #1796: text held back by the protocol-leak guard
+    because it merely resembled the start of a tool-protocol marker (e.g.
+    "<details>") is genuine assistant output once the stream ends in an
+    error instead of continuing. It must be flushed into final_text_parts /
+    current_text_parts the same way _DoneHandler and _ToolUseStartHandler
+    already do, not silently dropped.
+    """
+    state = _make_state()
+    delta_handler = _TextDeltaHandler()
+
+    delta_handler.handle(TextDeltaEvent(text="Sure, here is a collapsible section: "), state)
+    delta_handler.handle(TextDeltaEvent(text="<details>"), state)
+
+    # The guard is holding "<details>" back pending disambiguation -- it
+    # hasn't reached current_text_parts/final_text_parts yet.
+    assert "".join(state.final_text_parts) == "Sure, here is a collapsible section: "
+
+    handler = _ErrorHandler()
+    result = handler.handle(ErrorEvent(message="boom", code="timeout"), state)
+
+    assert result is _SUPPRESS
+    assert "".join(state.final_text_parts) == "Sure, here is a collapsible section: <details>"
+    assert "".join(state.current_text_parts) == "Sure, here is a collapsible section: <details>"
+
+
 def test_warning_handler_forwards_through_transformer() -> None:
     captured: list[WarningEvent] = []
 


### PR DESCRIPTION
Summary

ProtocolTextLeakGuard buffers trailing text resembling the start of a tool-protocol marker pending disambiguation. _DoneHandler and _ToolUseStartHandler both flush it before finishing, but _ErrorHandler (stream ends in timeout/disconnect/provider failure) never did — silently dropping up to 19 characters of genuine trailing assistant text with no log.
_ErrorHandler now flushes the guard into final_text_parts/current_text_parts before recording the error, matching the other two terminal handlers.
Test plan

Added test_error_handler_flushes_pending_protocol_guard_text, driving _TextDeltaHandler then _ErrorHandler directly.
Verified via stash that it fails pre-fix and passes post-fix.
ruff/mypy clean; full engine suite (1078 passed).
Fixes #1796 