### PR TITLE
fix(channels): support single-underscore italics and preserve code span whitespace in telegram formatting (Closes #1748)

### DIFF
--- a/src/agentos/channels/_telegram_formatting.py
+++ b/src/agentos/channels/_telegram_formatting.py
@@ -36,7 +36,10 @@ def _replace_code_spans(text: str) -> tuple[str, list[str]]:
             output.append(marker)
             cursor = marker_end
             continue
-        content = text[marker_end:closing].strip()
+        raw_content = text[marker_end:closing]
+        content = raw_content.replace("\r\n", " ").replace("\n", " ")
+        if content.startswith(" ") and content.endswith(" ") and any(c != " " for c in content):
+            content = content[1:-1]
         placeholder = f"\x00TG_CODE_{len(chunks)}\x00"
         chunks.append(f"<code>{html.escape(content)}</code>")
         output.append(placeholder)
@@ -67,6 +70,7 @@ def _render_inline(text: str) -> str:
     rendered = re.sub(r"__(?=\S)(.+?)(?<=\S)__", r"<b>\1</b>", rendered)
     rendered = re.sub(r"~~(?=\S)(.+?)(?<=\S)~~", r"<s>\1</s>", rendered)
     rendered = re.sub(r"(?<!\*)\*(?=\S)(.+?)(?<=\S)\*(?!\*)", r"<i>\1</i>", rendered)
+    rendered = re.sub(r"(?<!\w)_(?=\S)(.+?)(?<=\S)_(?!\w)", r"<i>\1</i>", rendered)
     # Restore in reverse order of protection: code spans were parked first, so
     # they come back last and a restored code span is never rescanned.
     for index, href in enumerate(hrefs):

--- a/tests/test_channels/test_telegram_formatting.py
+++ b/tests/test_channels/test_telegram_formatting.py
@@ -338,3 +338,27 @@ def test_a_url_inside_a_code_span_is_untouched() -> None:
     assert render_telegram_html("`https://x.test/a__b__c`") == (
         "<code>https://x.test/a__b__c</code>"
     )
+
+
+def test_single_underscore_italics_renders_correctly() -> None:
+    assert render_telegram_html("This is _italic_ text.") == "This is <i>italic</i> text."
+    assert render_telegram_html("_whole line italic_") == "<i>whole line italic</i>"
+    assert render_telegram_html("(_parenthesized italic_)") == "(<i>parenthesized italic</i>)"
+    assert (
+        render_telegram_html("snake_case_variable is not italic")
+        == "snake_case_variable is not italic"
+    )
+    assert render_telegram_html("foo_bar_baz") == "foo_bar_baz"
+
+
+def test_code_span_whitespace_preserved_per_commonmark() -> None:
+    # Single space is preserved, not collapsed to empty
+    assert render_telegram_html("` `") == "<code> </code>"
+    assert render_telegram_html("`  `") == "<code>  </code>"
+    # Padded content strips only a single space from ends
+    assert render_telegram_html("` foo `") == "<code>foo</code>"
+    assert render_telegram_html("`  foo  `") == "<code> foo </code>"
+    # Asymmetric padding is not stripped
+    assert render_telegram_html("` foo`") == "<code> foo</code>"
+    assert render_telegram_html("`foo `") == "<code>foo </code>"
+


### PR DESCRIPTION
### Summary
Fixes #1748

### Problem
1. `_telegram_formatting._render_inline` supported asterisk `*italic*` but omitted single-underscore `_italic_` formatting, leaving valid Markdown italics unrendered.
2. `_replace_code_spans` called `.strip()` on code span content, improperly collapsing single-space code spans (`` ` ` ``) to empty `<code></code>` and stripping leading/trailing whitespace contrary to CommonMark §6.3.

### Fix
- Add regex for single-underscore italics with word-boundary awareness (`(?<!\w)_(?=\S)(.+?)(?<=\S)_(?!\w)`), preserving identifier names with snake_case.
- Update `_replace_code_spans` to follow CommonMark: strip at most one leading and trailing space only if the span contains non-whitespace and starts and ends with space; preserve all other whitespace.
