### PR TITLE
fix(channels): honor target channel for message deletion in Slack (Closes #1807)

### DIFF
--- a/src/agentos/channels/slack.py
+++ b/src/agentos/channels/slack.py
@@ -476,9 +476,13 @@ class SlackChannel:
 
     async def edit(self, message_id: str, content: str) -> None:
         """Update an existing Slack message via chat.update."""
+        channel_id, sep, ts = message_id.partition("|")
+        if not sep:
+            channel_id = self.slack_channel_id
+            ts = message_id
         payload: dict[str, Any] = {
-            "channel": self.slack_channel_id,
-            "ts": message_id,
+            "channel": channel_id,
+            "ts": ts,
             "text": content,
         }
         client = self._get_client()
@@ -492,9 +496,13 @@ class SlackChannel:
 
     async def delete(self, message_id: str) -> None:
         """Delete a Slack message via chat.delete."""
+        channel_id, sep, ts = message_id.partition("|")
+        if not sep:
+            channel_id = self.slack_channel_id
+            ts = message_id
         payload: dict[str, Any] = {
-            "channel": self.slack_channel_id,
-            "ts": message_id,
+            "channel": channel_id,
+            "ts": ts,
         }
         client = self._get_client()
         resp = await retry_request(client.post, "/chat.delete", json=payload)

--- a/src/agentos/tools/builtin/messaging.py
+++ b/src/agentos/tools/builtin/messaging.py
@@ -41,7 +41,7 @@ def _outgoing_metadata(channel: str, target: str, thread_id: str | None) -> dict
 
 
 def _delete_message_id(channel: str, target: str, message_id: str) -> str:
-    if channel == "telegram" and "|" not in message_id:
+    if channel in ("telegram", "slack") and "|" not in message_id and target:
         return f"{target}|{message_id}"
     return message_id
 

--- a/tests/test_channels/test_slack_delete_target.py
+++ b/tests/test_channels/test_slack_delete_target.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agentos.channels.slack import SlackChannel
+from agentos.tools.builtin.messaging import _delete_message_id
+
+
+def test_delete_message_id_encodes_target_for_slack() -> None:
+    # Verify _delete_message_id prefixes target for Slack
+    res = _delete_message_id("slack", "C99999999", "1712345678.123456")
+    assert res == "C99999999|1712345678.123456"
+
+    # Preserves existing channel|ts
+    res_existing = _delete_message_id("slack", "C99999999", "C11111111|1712345678.123456")
+    assert res_existing == "C11111111|1712345678.123456"
+
+
+@pytest.mark.asyncio
+async def test_slack_channel_delete_honors_target_channel() -> None:
+    channel = SlackChannel(token="xoxb-test", slack_channel_id="C_DEFAULT")
+
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"ok": True}
+    mock_resp.raise_for_status = MagicMock()
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=mock_resp)
+    channel._client = mock_client
+
+    # Case 1: Default channel when no target prefix is present
+    await channel.delete("1712345678.123456")
+    mock_client.post.assert_awaited_with(
+        "/chat.delete",
+        json={"channel": "C_DEFAULT", "ts": "1712345678.123456"},
+    )
+
+    # Case 2: Explicit target channel passed via channel_id|ts
+    await channel.delete("C99999999|1712345678.123456")
+    mock_client.post.assert_awaited_with(
+        "/chat.delete",
+        json={"channel": "C99999999", "ts": "1712345678.123456"},
+    )


### PR DESCRIPTION
### Summary
Fixes #1807

### Problem
When the `message` tool with `action="delete"` was invoked for Slack, `_delete_message_id` returned the raw `message_id` without encoding `target`. In `SlackChannel.delete`, the channel parameter was hardcoded to `self.slack_channel_id`. Consequently, attempts to delete messages in non-default channels or threads ignored `target` and sent `channel=self.slack_channel_id`, causing the Slack API to fail with `message_not_found` or `channel_not_found`.

### Fix
- In `_delete_message_id`, include Slack alongside Telegram to encode `f"{target}|{message_id}"` when a target is provided.
- In `SlackChannel.delete` and `SlackChannel.edit`, support composite `channel_id|ts` by partitioning on `|`, falling back to `self.slack_channel_id` if omitted.
- Add unit tests in `tests/test_channels/test_slack_delete_target.py`.
