### PR TITLE
fix(memory): notify on_memory_write snapshot refresh on memory_delete (Closes #1806)

### DIFF
--- a/src/agentos/tools/builtin/memory_tools.py
+++ b/src/agentos/tools/builtin/memory_tools.py
@@ -1222,6 +1222,12 @@ def create_memory_tools(
         index_path = file_path.resolve().relative_to(workspace_dir.resolve()).as_posix()
         await r.store.remove_file(index_path)
 
+        # Notify snapshot refresh on successful delete
+        if on_memory_write is not None:
+            ctx = current_tool_context.get()
+            _aid = (ctx.agent_id if ctx else None) or "main"
+            on_memory_write(_aid)
+
         logger.info("memory_delete.ok", path=path)
         return f"Deleted {path} and removed from index."
 

--- a/tests/test_tools/test_memory_delete_notify.py
+++ b/tests/test_tools/test_memory_delete_notify.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentos.memory.retrieval import MemoryRetriever
+from agentos.memory.store import LongTermMemoryStore
+from agentos.tools.builtin.memory_tools import create_memory_tools
+from agentos.tools.registry import ToolRegistry
+from agentos.tools.types import ToolContext, current_tool_context
+
+
+@pytest.mark.asyncio
+async def test_memory_delete_notifies_on_memory_write(tmp_path: Path) -> None:
+    db_path = tmp_path / "test_memory.db"
+    store = LongTermMemoryStore(db_path)
+    await store.initialize()
+
+    mem_file = tmp_path / "memory" / "notes.md"
+    mem_file.parent.mkdir(parents=True, exist_ok=True)
+    mem_file.write_text("Old notes to delete", encoding="utf-8")
+
+    retriever = MemoryRetriever(store)
+    registry = ToolRegistry()
+    mock_on_write = MagicMock()
+
+    create_memory_tools(
+        store,
+        retriever,
+        memory_dir=str(tmp_path / "memory"),
+        registry=registry,
+        on_memory_write=mock_on_write,
+        memory_source="workspace",
+    )
+
+    delete_tool = registry.get("memory_delete")
+    assert delete_tool is not None
+
+    ctx = ToolContext(workspace_dir=str(tmp_path), agent_id="agent-xyz")
+    token = current_tool_context.set(ctx)
+    try:
+        result = await delete_tool.handler(path="memory/notes.md")
+        assert "Deleted memory/notes.md" in result
+        assert not mem_file.exists()
+        # Verify on_memory_write was invoked with the agent ID
+        mock_on_write.assert_called_once_with("agent-xyz")
+    finally:
+        current_tool_context.reset(token)
+        await store.close()


### PR DESCRIPTION
### Summary
Fixes #1806

### Problem
When `memory_delete` successfully deletes a memory file and removes it from the vector index, it did not invoke `on_memory_write(_aid)` (unlike `memory_save`). Consequently, `TurnRunner` retained the deleted memory file contents in its cached `MemorySnapshot`, continuing to inject deleted memories into the agent's prompt during subsequent turns.

### Fix
- In `src/agentos/tools/builtin/memory_tools.py`, trigger `on_memory_write(_aid)` after removing the file and deleting its index in `memory_delete`.
- Add unit test in `tests/test_tools/test_memory_delete_notify.py`.
