### PR TITLE
fix(gateway): return most recent tasks in list_agent_tasks to prevent active task truncation (Closes #1805)

### DIFF
--- a/src/agentos/gateway/task_runtime.py
+++ b/src/agentos/gateway/task_runtime.py
@@ -506,12 +506,17 @@ class TaskRuntime:
         self,
         session_key: str | None = None,
         status: str | AgentTaskStatus | None = None,
+        limit: int | None = 100,
     ) -> list[AgentTaskRecord]:
         if session_key is not None:
             session_key = canonicalize_session_key(session_key)
         return cast(
             list[AgentTaskRecord],
-            await self._storage.list_agent_tasks(session_key=session_key, status=status),
+            await self._storage.list_agent_tasks(
+                session_key=session_key,
+                status=status,
+                limit=limit,
+            ),
         )
 
     async def cancel(

--- a/src/agentos/session/storage.py
+++ b/src/agentos/session/storage.py
@@ -998,7 +998,7 @@ class SessionStorage:
         self,
         session_key: str | None = None,
         status: str | AgentTaskStatus | None = None,
-        limit: int = 100,
+        limit: int | None = 100,
         offset: int = 0,
     ) -> list[AgentTaskRecord]:
         clauses: list[str] = []
@@ -1010,11 +1010,19 @@ class SessionStorage:
             clauses.append("status = ?")
             params.append(str(status))
         where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
-        params += [limit, offset]
-        sql = (
-            f"SELECT * FROM agent_tasks {where} "
-            "ORDER BY created_at ASC, rowid ASC LIMIT ? OFFSET ?"
-        )
+        if limit is not None and limit >= 0:
+            params += [limit, offset]
+            sql = (
+                f"SELECT * FROM ("
+                f"  SELECT * FROM agent_tasks {where} "
+                f"  ORDER BY created_at DESC, rowid DESC LIMIT ? OFFSET ?"
+                f") ORDER BY created_at ASC, task_id ASC"
+            )
+        else:
+            sql = (
+                f"SELECT * FROM agent_tasks {where} "
+                "ORDER BY created_at ASC, rowid ASC"
+            )
         async with self.conn.execute(sql, params) as cur:
             rows = await cur.fetchall()
         return [AgentTaskRecord(**_deserialize_row(dict(row))) for row in rows]

--- a/tests/test_session/test_agent_task_storage.py
+++ b/tests/test_session/test_agent_task_storage.py
@@ -138,3 +138,41 @@ async def test_list_agent_tasks_for_sessions_groups_visible_session_tasks(tmp_pa
     assert set(grouped) == {"agent:main:webchat:one", "agent:main:webchat:two"}
     assert [row.task_id for row in grouped["agent:main:webchat:one"]] == ["one-new"]
     assert [row.task_id for row in grouped["agent:main:webchat:two"]] == ["two-task"]
+
+
+@pytest.mark.asyncio
+async def test_list_agent_tasks_returns_most_recent_tasks_when_truncated(tmp_path) -> None:
+    storage = SessionStorage(str(tmp_path / "sessions_truncation.db"))
+    await storage.connect()
+    key = "agent:main:webchat:many-tasks"
+    try:
+        # Create 105 tasks: tasks 0-103 are succeeded, task 104 is running
+        for i in range(105):
+            await storage.create_agent_task(
+                AgentTaskRecord(
+                    task_id=f"task-{i:03d}",
+                    session_key=key,
+                    source_kind="webui",
+                    queue_mode="followup",
+                    run_kind="web_turn",
+                    status=AgentTaskStatus.SUCCEEDED if i < 104 else AgentTaskStatus.RUNNING,
+                    created_at=1000 + i,
+                    updated_at=1000 + i,
+                )
+            )
+
+        # Truncated query with default limit 100
+        rows_100 = await storage.list_agent_tasks(session_key=key, limit=100)
+        assert len(rows_100) == 100
+        # Should contain the newest tasks (task-005 through task-104) in ASC order
+        assert rows_100[0].task_id == "task-005"
+        assert rows_100[-1].task_id == "task-104"
+        assert rows_100[-1].status == AgentTaskStatus.RUNNING
+
+        # Query without limit (limit=None)
+        all_rows = await storage.list_agent_tasks(session_key=key, limit=None)
+        assert len(all_rows) == 105
+        assert all_rows[0].task_id == "task-000"
+        assert all_rows[-1].task_id == "task-104"
+    finally:
+        await storage.close()


### PR DESCRIPTION
### Summary
Fixes #1805

### Problem
`SessionStorage.list_agent_tasks()` ordered results by `created_at ASC, rowid ASC` with a default `LIMIT 100`. In busy or long-running sessions with >100 tasks:
1. `sessions_yield` calls `runtime.list(session_key=key)`, sorts ASC, and inspects `latest = rows[-1]`. Because older tasks fill the first 100 slots, `latest` resolves to task 100 (which is already completed) rather than the newly spawned task 101+, causing `sessions_yield` to immediately exit without waiting for the running task.
2. `rpc_sessions` only displays the first 100 tasks, omitting currently running or recent tasks.

### Fix
- In `src/agentos/session/storage.py`, select the most recent tasks first (`ORDER BY created_at DESC, rowid DESC LIMIT ? OFFSET ?`) inside a subquery, and sort the resulting window back chronologically (`ORDER BY created_at ASC, task_id ASC`). Also support `limit=None` for querying without limit.
- In `src/agentos/gateway/task_runtime.py`, accept `limit: int | None = 100` on `TaskRuntime.list()` and forward to `_storage.list_agent_tasks`.
- Add regression test in `tests/test_session/test_agent_task_storage.py` verifying that queries on >100 tasks return the most recent tasks ending with the latest active task.
