### PR TITLE
fix(channels/email): refuse to send on an unknown thread instead of guessing the recipient

### DIFF
--- a/src/agentos/channels/email.py
+++ b/src/agentos/channels/email.py
@@ -780,16 +780,28 @@ class EmailChannel:
         reply_to = (message.reply_to or "").strip()
         thread = self._threads.get(reply_to)
         metadata = message.metadata or {}
-        # The message tool writes "recipient", channel replies write "to", and
-        # scheduler/heartbeat delivery sends the bare address as reply_to, so
-        # every producer has to be able to name the mailbox.
+        # The message tool writes "recipient", channel replies write "to",
+        # and scheduler/heartbeat delivery (scheduler/delivery.py) sets "to"
+        # explicitly for email specifically, for exactly this reason.
+        #
+        # ``reply_to`` here names a *thread* (an inbound Message-ID, tracked
+        # in self._threads) -- it must never be treated as a mailbox itself.
+        # A Message-ID is syntactically indistinguishable from an address
+        # (RFC 5322 gives both a local@domain shape), and its domain is
+        # chosen by whoever sent the original mail: falling back to
+        # "reply_to looks like an address" meant that a thread aging out of
+        # self._threads (LRU eviction, or any process restart -- the cache
+        # is in-memory only) would silently redirect the reply to whatever
+        # domain the original sender's Message-ID happened to carry, which
+        # they control.
         to_address = str(
             metadata.get("to") or metadata.get("recipient") or (thread.to_address if thread else "")
         ).strip()
-        if not to_address and is_email_address(reply_to):
-            to_address = normalize_address(reply_to)
         if not to_address:
-            raise ValueError("email.send has no recipient for reply_to")
+            raise ValueError(
+                "email.send has no recipient for reply_to "
+                f"{reply_to!r}: no known thread and no explicit to/recipient"
+            )
         subject = str(metadata.get("subject") or "").strip()
         if not subject:
             subject = reply_subject(thread.subject) if thread else _DEFAULT_OUTBOUND_SUBJECT

--- a/src/agentos/scheduler/delivery.py
+++ b/src/agentos/scheduler/delivery.py
@@ -473,7 +473,8 @@ class DeliveryChain:
                         metadata={"channel": channel_id, "thread_ts": None},
                     )
             else:
-                msg = OutgoingMessage(content=text, reply_to=channel_id or None)
+                metadata = {"to": channel_id} if channel_name == "email" and channel_id else {}
+                msg = OutgoingMessage(content=text, reply_to=channel_id or None, metadata=metadata)
             await asyncio.wait_for(adapter.send(msg), timeout=30.0)
             log.info("delivery.channel_sent", job_id=job_id, channel=channel_name)
             return "delivered"

--- a/tests/test_channels/test_email_channel.py
+++ b/tests/test_channels/test_email_channel.py
@@ -534,23 +534,55 @@ async def test_send_resolves_the_recipient_from_metadata_recipient(
     assert sent[0].get("In-Reply-To") is None
 
 
-async def test_send_resolves_the_recipient_from_reply_to_address(
+async def test_send_bare_reply_to_with_no_thread_or_metadata_is_refused(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Scheduler and heartbeat delivery pass the address as ``reply_to`` alone."""
+    """A bare, address-shaped ``reply_to`` with no thread and no explicit
+    ``to``/``recipient`` must be refused rather than silently sent -- treating
+    ``reply_to`` as a mailbox is exactly the #1570 misdelivery vector: a
+    thread's Message-ID is syntactically indistinguishable from an address,
+    and its domain is chosen by whoever sent the original mail.
+    """
 
     channel = EmailChannel(config=_config())
     sent: list[EmailMessage] = []
     monkeypatch.setattr(channel, "_smtp_send", sent.append)
 
-    await channel.send(OutgoingMessage(content="alert", reply_to="alerts@example.com"))
+    with pytest.raises(ValueError, match="no recipient"):
+        await channel.send(OutgoingMessage(content="alert", reply_to="alerts@example.com"))
+
+    assert sent == []
+
+
+async def test_send_resolves_the_recipient_from_reply_to_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Scheduler and heartbeat delivery must carry the recipient explicitly
+    in ``metadata["to"]`` -- see scheduler/delivery.py's email branch. This
+    is the corrected replacement for a bare, unauthenticated ``reply_to``.
+    """
+
+    channel = EmailChannel(config=_config())
+    sent: list[EmailMessage] = []
+    monkeypatch.setattr(channel, "_smtp_send", sent.append)
+
+    await channel.send(
+        OutgoingMessage(
+            content="alert",
+            reply_to="alerts@example.com",
+            metadata={"to": "alerts@example.com"},
+        )
+    )
 
     assert sent[0]["To"] == "alerts@example.com"
     assert sent[0].get_content().strip() == "alert"
 
 
 async def test_send_recipient_resolution_precedence(monkeypatch: pytest.MonkeyPatch) -> None:
-    """``to`` beats ``recipient`` beats the thread cache beats ``reply_to``."""
+    """``to`` beats ``recipient`` beats the thread cache. A bare ``reply_to``
+    is no longer a valid fourth tier -- see
+    ``test_send_bare_reply_to_with_no_thread_or_metadata_is_refused``.
+    """
 
     channel = EmailChannel(config=_config())
     assert channel._to_incoming(_raw()) is not None
@@ -572,13 +604,11 @@ async def test_send_recipient_resolution_precedence(monkeypatch: pytest.MonkeyPa
         )
     )
     await channel.send(OutgoingMessage(content="x", reply_to="m1@example.com"))
-    await channel.send(OutgoingMessage(content="x", reply_to="fourth@example.com"))
 
     assert [m["To"] for m in sent] == [
         "first@example.com",
         "second@example.com",
         "owner@example.com",
-        "fourth@example.com",
     ]
 
 


### PR DESCRIPTION
## Linked issue
Fixes #1570 

## Summary
`_resolve_target` fell back to `is_email_address(reply_to)` -- treating a
bare `reply_to` as the recipient -- whenever there was no thread cache
entry and no explicit `to`/`recipient`. `reply_to` here names a *thread*
(an inbound Message-ID), and a Message-ID is syntactically
indistinguishable from a real address (RFC 5322 gives both a
`local@domain` shape). Its domain is chosen by whoever sent the original
mail. Once a thread ages out of the in-memory `self._threads` cache (LRU
eviction, or any process restart), a reply would silently go to whatever
domain the sender's Message-ID happened to carry -- attacker-controlled,
not the real correspondent.

## Fix
Compared against competing PR #1644, which gets the core removal right
but doesn't touch the one call site that depended on it:

- `email.py`: removed the fallback; raises with a clear message instead.
- `scheduler/delivery.py`: `_post_to_channel`'s non-Slack branch built
  `OutgoingMessage(content=text, reply_to=channel_id or None)` with empty
  metadata -- exactly the "scheduler/heartbeat sends the bare address as
  `reply_to`" producer the old code comment names, and exactly what
  breaks once the fallback is gone. **PR #1644 does not touch this file**
  (its diff against `scheduler/delivery.py` and `heartbeat_service.py`
  is byte-identical to `main`), so merging it as-is would turn every
  scheduled/cron email delivery into a hard failure. This PR fixes that
  call site to carry `metadata={"to": channel_id}` for email specifically,
  so the fix is complete rather than half-applied. No existing test
  covered this path, so CI would not have caught the regression either.

## Tests
- `test_email_channel.py`: replaced the test that encoded the now-removed
  (vulnerable) fallback as correct behavior with one proving it's refused,
  plus one proving the corrected metadata-based pattern still works;
  updated the recipient-precedence test to drop the invalid 4th tier.
- New `test_scheduler/test_post_to_channel_email_metadata.py`: proves
  scheduled email delivery still resolves the correct recipient after the
  email.py fix, and that the metadata addition doesn't leak into
  non-email channels.

Commands run:
uv run ruff check src/agentos/channels/email.py src/agentos/scheduler/delivery.py tests/test_channels/test_email_channel.py tests/test_scheduler/test_post_to_channel_email_metadata.py
uv run ruff format --check <same files>
uv run mypy <same files> --show-error-codes
uv run pytest tests/test_channels/ tests/unit/chat/ tests/test_scheduler/ -q

Results: ruff clean, ruff format clean, mypy clean (one pre-existing,
confirmed-on-`origin/main`-with-this-exact-invocation `attr-defined`
quirk in `test_email_channel.py:164`, unrelated to this change and not
introduced by it), 1056/1056 passing.

Third-party origin: none.

