### PR TITLE
fix(provider): handle null details and alternate model keys in Ollama list_models

### DIFF
--- a/src/agentos/provider/ollama.py
+++ b/src/agentos/provider/ollama.py
@@ -390,14 +390,20 @@ class OllamaProvider:
                 resp = await client.get(f"{self._base_url}/api/tags")
                 resp.raise_for_status()
                 data = resp.json()
-                return [
-                    ModelInfo(
-                        provider=self.provider_name,
-                        model_id=m["name"],
-                        display_name=m.get("name", ""),
-                        context_window=m.get("details", {}).get("context_length", 0),
+                models: list[ModelInfo] = []
+                for m in data.get("models", []):
+                    model_id = m.get("name") or m.get("model") or ""
+                    if not model_id:
+                        continue
+                    details = m.get("details") or {}
+                    models.append(
+                        ModelInfo(
+                            provider=self.provider_name,
+                            model_id=model_id,
+                            display_name=model_id,
+                            context_window=details.get("context_length", 0),
+                        )
                     )
-                    for m in data.get("models", [])
-                ]
+                return models
         except Exception:
             return []

--- a/tests/test_provider_ollama.py
+++ b/tests/test_provider_ollama.py
@@ -31,7 +31,8 @@ def _patch_transport(
 ) -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         captured["url"] = str(request.url)
-        captured["payload"] = json.loads(request.content.decode("utf-8"))
+        if request.content:
+            captured["payload"] = json.loads(request.content.decode("utf-8"))
         if isinstance(response_body, bytes):
             return httpx.Response(status_code, content=response_body)
         return httpx.Response(status_code, text=response_body)
@@ -366,3 +367,68 @@ def test_ollama_non_model_404_keeps_the_plain_http_message(
 
     assert isinstance(error, ErrorEvent)
     assert error.message == "HTTP 404: 404 page not found"
+
+
+def test_ollama_list_models_handles_null_details_and_model_field(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    response_payload = {
+        "models": [
+            {
+                "name": "llama3.2:latest",
+                "model": "llama3.2:latest",
+                "details": {
+                    "parent_model": "",
+                    "format": "gguf",
+                    "family": "llama",
+                    "context_length": 8192,
+                },
+            },
+            {
+                # Custom imported or manifest with null details
+                "name": "custom-model:latest",
+                "details": None,
+            },
+            {
+                # Model using only "model" field and missing "details"
+                "model": "qwen2.5:3b",
+            },
+            {
+                # Empty entry that should be skipped
+                "name": "",
+                "model": "",
+                "details": {},
+            },
+        ]
+    }
+    _patch_transport(monkeypatch, captured, json.dumps(response_payload))
+    provider = OllamaProvider()
+
+    models = asyncio.run(provider.list_models())
+
+    assert len(models) == 3
+    assert models[0].model_id == "llama3.2:latest"
+    assert models[0].display_name == "llama3.2:latest"
+    assert models[0].context_window == 8192
+    assert models[0].provider == "ollama"
+
+    assert models[1].model_id == "custom-model:latest"
+    assert models[1].display_name == "custom-model:latest"
+    assert models[1].context_window == 0
+    assert models[1].provider == "ollama"
+
+    assert models[2].model_id == "qwen2.5:3b"
+    assert models[2].display_name == "qwen2.5:3b"
+    assert models[2].context_window == 0
+    assert models[2].provider == "ollama"
+
+
+def test_ollama_list_models_returns_empty_on_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_raising_transport(monkeypatch, httpx.ConnectError("Connection refused"))
+    provider = OllamaProvider()
+
+    models = asyncio.run(provider.list_models())
+    assert models == []


### PR DESCRIPTION
## Summary
Fixes an issue where `OllamaProvider.list_models()` silently crashes and returns `[]` when Ollama's `/api/tags` response contains models with `details: null` or models that use `"model"` instead of `"name"`.

Closes #1830

## Root Cause
1. In Python, `m.get("details", {})` returns `None` when the `"details"` key exists with value `None` (common with custom imported models / minimal manifests in Ollama). Chaining `.get("context_length", 0)` on `None` throws an `AttributeError`.
2. Accessing `m["name"]` throws `KeyError` if a tag entry only contains `"model"`.
3. Because `list_models` has a broad `try: ... except Exception: return []`, any single malformed or minimal model tag object causes the entire model list to fail silently.

## Changes
- Safely extract details with `(m.get("details") or {}).get("context_length", 0)`.
- Use fallback `m.get("name") or m.get("model") or ""` and skip entries without an identifier.
- Add comprehensive unit tests in `tests/test_provider_ollama.py` asserting proper handling of `details: null`, missing keys, and empty models.

## Verification
- `uv run ruff check src/agentos/provider/ollama.py tests/test_provider_ollama.py` -> Passed
- `uv run ruff format --check src/agentos/provider/ollama.py tests/test_provider_ollama.py` -> Passed
- `uv run mypy src/agentos/provider/ollama.py` -> Passed
- `uv run pytest tests/test_provider_ollama.py -q` -> 14 passed
- `uv run pytest -k "provider or ollama" -q` -> 1274 passed
