### PR TITLE
fix(mcp): report events_wait timeouts only when the deadline expires

### DIFF
--- a/src/agentos/mcp_server/bridge.py
+++ b/src/agentos/mcp_server/bridge.py
@@ -152,6 +152,7 @@ class AgentOSMCPBridge:
             )
 
             events: list[dict[str, Any]] = []
+            timed_out = False
             current_stream_seq = int(
                 subscription.get("current_stream_seq") or since_stream_seq or 0
             )
@@ -165,10 +166,12 @@ class AgentOSMCPBridge:
                 # above ``timeout_s``, handing ``recv_event`` more than the cap.
                 remaining = min(deadline - time.monotonic(), timeout_s)
                 if remaining <= 0:
+                    timed_out = True
                     break
                 try:
                     frame = await client.recv_event(timeout=remaining)
                 except TimeoutError:
+                    timed_out = True
                     break
                 normalized = _normalize_event_frame(frame)
                 payload = normalized.get("payload")
@@ -190,7 +193,9 @@ class AgentOSMCPBridge:
                 "current_stream_seq": current_stream_seq,
                 "replay_complete": subscription.get("replay_complete"),
                 "replay_gap_reason": subscription.get("replay_gap_reason"),
-                "timed_out": not events or (events[-1]["event"] not in _TERMINAL_EVENTS),
+                # Only an exhausted deadline is a timeout. Filling ``max_events``
+                # or seeing a terminal event both end the wait on purpose.
+                "timed_out": timed_out,
             }
         finally:
             await client.close()

--- a/tests/test_mcp_server/test_bridge.py
+++ b/tests/test_mcp_server/test_bridge.py
@@ -411,3 +411,113 @@ async def test_events_wait_preserves_max_events_below_the_cap() -> None:
     result = await bridge.events_wait("agent:main:main", timeout_ms=200, max_events=2)
 
     assert len(result["events"]) == 2
+
+
+class SilentEventClient(FakeGatewayClient):
+    """Fake client whose ``recv_event`` always times out, like an idle session."""
+
+    async def recv_event(self, timeout: float | None = None) -> dict[str, Any]:
+        raise TimeoutError
+
+
+class BurstThenSilentClient(FakeGatewayClient):
+    """Fake client that yields ``burst`` non-terminal events, then goes idle."""
+
+    def __init__(self, burst: int = 2) -> None:
+        super().__init__()
+        self.burst = burst
+        self.recv_count = 0
+
+    async def recv_event(self, timeout: float | None = None) -> dict[str, Any]:
+        self.recv_count += 1
+        if self.recv_count > self.burst:
+            raise TimeoutError
+        return {
+            "event": "session.event.text_delta",
+            "payload": {
+                "session_key": "agent:main:main",
+                "stream_seq": self.recv_count,
+                "text": "x",
+            },
+        }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("max_events", [1, 2, 5])
+async def test_events_wait_filling_max_events_is_not_a_timeout(max_events: int) -> None:
+    # A long text stream fills the default max_events=100 routinely. The wait
+    # ends because the caller's own cap was reached, not because the deadline
+    # expired, so the poll succeeded and the client should keep polling.
+    client = EndlessEventClient()
+    bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)
+
+    result = await bridge.events_wait("agent:main:main", timeout_ms=300_000, max_events=max_events)
+
+    assert len(result["events"]) == max_events
+    assert result["timed_out"] is False
+    # The cursor must still cover the last event so the caller can resume.
+    assert result["current_stream_seq"] >= max_events
+
+
+@pytest.mark.asyncio
+async def test_events_wait_reports_timeout_when_the_deadline_expires() -> None:
+    client = SilentEventClient()
+    bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)
+
+    result = await bridge.events_wait("agent:main:main", timeout_ms=50, max_events=100)
+
+    assert result["events"] == []
+    assert result["timed_out"] is True
+
+
+@pytest.mark.asyncio
+async def test_events_wait_reports_timeout_on_an_exhausted_budget() -> None:
+    # ``remaining <= 0`` is a separate exit from ``recv_event`` raising, and a
+    # zero budget must not be mistaken for a completed wait.
+    client = EndlessEventClient()
+    bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)
+
+    result = await bridge.events_wait("agent:main:main", timeout_ms=0, max_events=100)
+
+    assert result["events"] == []
+    assert result["timed_out"] is True
+    assert client.recv_count == 0
+
+
+@pytest.mark.asyncio
+async def test_events_wait_reports_timeout_after_a_partial_burst() -> None:
+    # The direction the report did not cover: events were collected but the
+    # stream then stalled, so this really is a timeout and must stay one.
+    client = BurstThenSilentClient(burst=2)
+    bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)
+
+    result = await bridge.events_wait("agent:main:main", timeout_ms=50, max_events=100)
+
+    assert len(result["events"]) == 2
+    assert result["timed_out"] is True
+
+
+@pytest.mark.asyncio
+async def test_events_wait_terminal_event_is_not_a_timeout() -> None:
+    client = RecordingEventClient()
+    bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)
+
+    result = await bridge.events_wait("agent:main:main", timeout_ms=300_000, max_events=100)
+
+    assert [event["event"] for event in result["events"]] == ["session.event.done"]
+    assert result["timed_out"] is False
+
+
+@pytest.mark.asyncio
+async def test_events_wait_terminal_only_timeout_still_reports_timed_out() -> None:
+    # ``terminal_only`` filters the collected list, so a stream of non-terminal
+    # events can never fill ``max_events`` and the wait ends at the deadline.
+    client = BurstThenSilentClient(burst=3)
+    bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)
+
+    result = await bridge.events_wait(
+        "agent:main:main", timeout_ms=50, max_events=100, terminal_only=True
+    )
+
+    assert result["events"] == []
+    assert result["timed_out"] is True


### PR DESCRIPTION
Fixes #1798

## The bug

`events_wait` never tracks *why* the collection loop ended. It reconstructs that
after the fact from the last event it happened to keep:

```python
"timed_out": not events or (events[-1]["event"] not in _TERMINAL_EVENTS),
```

The loop has four exits, and only one of them is a real timeout:

| Loop exit | Actually a timeout? | Reported before |
|---|---|---|
| `len(events) == max_events` | no — the caller's own cap was reached | **`True`** |
| `remaining <= 0` (deadline gone) | yes | `True` |
| `recv_event` raises `TimeoutError` | yes | `True` |
| terminal event → `break` | no | `False` |

Filling `max_events` and expiring the deadline both leave a non-terminal event
last, so they are indistinguishable in the returned payload. `events_wait` is
exposed straight through as an MCP tool (`mcp_server/server.py:55`) with
`max_events=100` by default — a cap any ordinary text stream reaches — so the
common success path is the one that gets mislabelled.

Measured on `upstream/main` @ `4ca69fff` with the reporter's endless-event client:

```
case                             timed_out   events   elapsed
max_events reached fast          True        2          0.0ms
deadline expired (no events)     True        0         50.0ms
terminal event                   False       1          0.0ms
```

The first row is the defect: a poll that returned in 0.0ms, well inside a 200ms
budget, having collected exactly what the caller asked for, is reported as a
timeout. A client polling a healthy streaming session sees `timed_out: true` on
every full batch and can only conclude the session is stalled.

## The fix

Record the exit reason where it happens instead of inferring it later:

```python
events: list[dict[str, Any]] = []
timed_out = False
...
    if remaining <= 0:
        timed_out = True
        break
    try:
        frame = await client.recv_event(timeout=remaining)
    except TimeoutError:
        timed_out = True
        break
...
    # Only an exhausted deadline is a timeout. Filling ``max_events``
    # or seeing a terminal event both end the wait on purpose.
    "timed_out": timed_out,
```

Six added lines in `events_wait`, one changed. Deliberately unchanged:

- **`_TERMINAL_EVENTS` and the terminal `break`.** The terminal path already
  reported `False` correctly; it keeps doing so, now because the flag was never
  set rather than by coincidence.
- **The `events`/`current_stream_seq` payload and the coarse-clock re-clamp.**
  Untouched — only the `timed_out` field changes meaning.
- **The empty-list case.** `_clamp_limit` floors `max_events` at 1, so the loop
  always runs at least once and `events == []` still implies a deadline exit.
  `not events` was therefore redundant, not load-bearing.

No public name is renamed and the field keeps its type, so MCP clients need no
change — those already treating `timed_out` as "the wait gave up" now get the
truth instead of a false positive.

## Tests

`tests/test_mcp_server/test_bridge.py` — 8 new cases (6 test functions, one
parametrized over `max_events` 1/2/5), all offline, no credentials, driven by two
new in-file fakes alongside the existing `EndlessEventClient`/`RecordingEventClient`.

Fail without the fix (3):

- `test_events_wait_filling_max_events_is_not_a_timeout[1|2|5]` — a full batch
  collected inside a 300s budget reports `timed_out is False`, and
  `current_stream_seq` still covers the last event so the caller can resume.

Pass either way by design — these are the guards that the fix does not flip a
genuine timeout into a success, which is the direction the report did not cover:

- `test_events_wait_reports_timeout_when_the_deadline_expires` — idle session,
  `recv_event` raises; no events, `timed_out is True`.
- `test_events_wait_reports_timeout_on_an_exhausted_budget` — `timeout_ms=0`
  exits via `remaining <= 0`, a different branch from the one above; asserts
  `recv_count == 0` so the zero budget is honoured rather than polled once.
- `test_events_wait_reports_timeout_after_a_partial_burst` — **the inverse
  case**: 2 events arrive, then the stream stalls. Events *were* collected but
  the deadline still expired, so this must stay `True`. A fix that keyed off
  "did we collect anything" instead of the exit reason would break here.
- `test_events_wait_terminal_event_is_not_a_timeout` — terminal path still `False`.
- `test_events_wait_terminal_only_timeout_still_reports_timed_out` — under
  `terminal_only=True` the filtered list can never fill `max_events`, so a
  non-terminal stream must end at the deadline with `timed_out is True`.

## Verification

```
$ uv run pytest tests/test_mcp_server/ -q
39 passed in 4.11s

$ git show upstream/main:src/agentos/mcp_server/bridge.py > src/agentos/mcp_server/bridge.py
$ uv run pytest tests/test_mcp_server/test_bridge.py -q -k "timed_out or max_events or terminal"
3 failed, 5 passed, 21 deselected in 0.11s

$ uv run ruff check src tests
All checks passed!

$ uv run mypy --show-error-codes src
Success: no issues found in 625 source files

$ uv run pytest -q
6 failed, 10444 passed, 34 skipped, 4 warnings, 3 errors in 258.72s
```

The 6 failures and 3 errors in the full run are pre-existing on pristine
`upstream/main` in my environment and untouched by this change — an unhydrated
MiniLM ONNX asset (`test_pilot_encoder`, `test_build_wheelhouse_zip`,
`test_pilot_benchmark`) and a local-timezone hygiene guard
(`test_tracked_public_files_do_not_carry_this_machines_timezone`). Nothing under
`tests/test_mcp_server/` is affected; CI should be clean.

`ruff format` was run on the two changed files only. It also wanted to collapse
the unrelated `raw_url` assignment at `bridge.py:66`, which I reverted — this PR
restyles nothing it does not fix.

## One adjacent case, deliberately left alone

A caller cannot yet tell *which* non-timeout exit happened — a full batch and a
terminal event both return `timed_out: false`, and only re-checking the last
event against the terminal set distinguishes "the turn is over" from "there is
more to poll". An explicit `stop_reason` (`terminal` / `max_events` / `timeout`)
would say it outright, but that adds a field to the MCP tool's wire result, which
is wider than this bug. Happy to file it as a follow-up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01As6ug1t9iDHvHMWQqeEM2R
