### PR TITLE
fix(gateway): fail pending RPC calls when the client is closed

### DIFF
--- a/src/agentos/gateway_client.py
+++ b/src/agentos/gateway_client.py
@@ -179,6 +179,9 @@ class GatewayRPCClient:
 
     async def close(self) -> None:
         self._closing = True
+        # The listener deliberately stays quiet during an intentional close, so
+        # a pending call has no other way to learn the connection went away.
+        self._fail_pending(ConnectionError("Gateway connection closed"))
         for task in (self._heartbeat_task, self._listener_task):
             if task is None:
                 continue
@@ -231,6 +234,12 @@ class GatewayRPCClient:
         except Exception as exc:
             self._mark_connection_failed(exc)
 
+    def _fail_pending(self, err: ConnectionError) -> None:
+        for fut in self._pending.values():
+            if not fut.done():
+                fut.set_exception(err)
+        self._pending.clear()
+
     def _mark_connection_failed(self, exc: BaseException) -> ConnectionError:
         if isinstance(exc, ConnectionError):
             err = exc
@@ -240,10 +249,7 @@ class GatewayRPCClient:
             self._connection_error = err
         else:
             err = self._connection_error
-        for fut in self._pending.values():
-            if not fut.done():
-                fut.set_exception(err)
-        self._pending.clear()
+        self._fail_pending(err)
         current_task = asyncio.current_task()
         for task in (self._heartbeat_task, self._listener_task):
             if task is not None and task is not current_task and not task.done():

--- a/tests/test_mcp_server/test_gateway_client.py
+++ b/tests/test_mcp_server/test_gateway_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import sys
 from types import SimpleNamespace
@@ -62,3 +63,124 @@ async def test_gateway_connect_closes_socket_after_bad_handshake(monkeypatch) ->
 
     assert ws.closed is True
     assert client._ws is None
+
+
+async def _start_pending_call(client: GatewayRPCClient, method: str = "sessions.list"):
+    """Start a ``call`` and wait until its request is registered as pending."""
+
+    task = asyncio.ensure_future(client.call(method, {"limit": 1}))
+    while not client._pending:
+        await asyncio.sleep(0)
+    return task
+
+
+@pytest.mark.asyncio
+async def test_close_fails_pending_call_without_a_request_timeout() -> None:
+    # With no request timeout there is no other escape hatch: before the fix
+    # this task stayed blocked on ``await fut`` forever.
+    client = GatewayRPCClient(request_timeout_s=None)
+    client._ws = _SilentWebSocket()
+    task = await _start_pending_call(client)
+
+    await client.close()
+
+    with pytest.raises(ConnectionError, match="Gateway connection closed"):
+        await asyncio.wait_for(task, timeout=2)
+    assert client._pending == {}
+
+
+@pytest.mark.asyncio
+async def test_close_fails_pending_call_promptly_under_a_request_timeout() -> None:
+    # A generous timeout would eventually fire, but with the wrong story: the
+    # connection was closed, it did not time out.
+    client = GatewayRPCClient(request_timeout_s=300.0)
+    client._ws = _SilentWebSocket()
+    task = await _start_pending_call(client)
+
+    await client.close()
+
+    with pytest.raises(ConnectionError, match="Gateway connection closed"):
+        await asyncio.wait_for(task, timeout=2)
+
+
+@pytest.mark.asyncio
+async def test_close_fails_every_pending_call() -> None:
+    client = GatewayRPCClient(request_timeout_s=None)
+    client._ws = _SilentWebSocket()
+    first = await _start_pending_call(client, "sessions.list")
+    second = asyncio.ensure_future(client.call("sessions.resolve", {"key": "agent:main:main"}))
+    while len(client._pending) < 2:
+        await asyncio.sleep(0)
+
+    await client.close()
+
+    for task in (first, second):
+        with pytest.raises(ConnectionError, match="Gateway connection closed"):
+            await asyncio.wait_for(task, timeout=2)
+    assert client._pending == {}
+
+
+@pytest.mark.asyncio
+async def test_reconnect_fails_the_previous_connections_pending_calls(monkeypatch) -> None:
+    # ``connect`` closes a live client first, so the old socket's in-flight
+    # calls must not be left waiting on a connection that no longer exists.
+    client = GatewayRPCClient(request_timeout_s=None)
+    ws = _SilentWebSocket()
+    client._ws = ws
+    task = await _start_pending_call(client)
+
+    async def connect(_url: str):
+        raise RuntimeError("gateway unreachable")
+
+    monkeypatch.setitem(sys.modules, "websockets", SimpleNamespace(connect=connect))
+
+    with pytest.raises(RuntimeError, match="gateway unreachable"):
+        await client.connect("ws://127.0.0.1:18791/ws")
+
+    assert ws.closed is True
+    with pytest.raises(ConnectionError, match="Gateway connection closed"):
+        await asyncio.wait_for(task, timeout=2)
+
+
+@pytest.mark.asyncio
+async def test_close_leaves_an_already_settled_future_alone() -> None:
+    # A cancelled call can linger in ``_pending``; setting an exception on it
+    # would raise InvalidStateError or log an unretrieved exception.
+    client = GatewayRPCClient(request_timeout_s=None)
+    client._ws = _SilentWebSocket()
+    task = await _start_pending_call(client)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    await client.close()
+
+    assert client._pending == {}
+
+
+@pytest.mark.asyncio
+async def test_close_still_closes_the_socket_with_no_pending_calls() -> None:
+    client = GatewayRPCClient(request_timeout_s=None)
+    ws = _SilentWebSocket()
+    client._ws = ws
+
+    await client.close()
+
+    assert ws.closed is True
+    assert client._ws is None
+    assert client._pending == {}
+
+
+@pytest.mark.asyncio
+async def test_connection_failure_still_fails_pending_calls() -> None:
+    # ``_mark_connection_failed`` shares the settle-and-clear step with
+    # ``close``; an unexpected drop must keep reporting the lost connection.
+    client = GatewayRPCClient(request_timeout_s=None)
+    client._ws = _SilentWebSocket()
+    task = await _start_pending_call(client)
+
+    client._mark_connection_failed(OSError("socket reset"))
+
+    with pytest.raises(ConnectionError, match="Gateway connection lost: socket reset"):
+        await asyncio.wait_for(task, timeout=2)
+    assert client._pending == {}


### PR DESCRIPTION
Fixes #1780

## The bug

`close()` tears down the transport but never settles the requests riding on it:

```python
async def close(self) -> None:
    self._closing = True
    for task in (self._heartbeat_task, self._listener_task):
        ...
        task.cancel()
    if self._ws is not None:
        await self._ws.close()
```

Every in-flight `call()` is parked on a future in `self._pending`, and the only
code that ever settles those futures is `_mark_connection_failed`. During an
intentional close nothing reaches it:

- the listener is cancelled, so it stops delivering `res` frames;
- even if it drains first, its end-of-stream branch is guarded by
  `if not self._closing`, which `close()` has just set to `True` — by design,
  so a deliberate close is not reported as a connection failure.

So the futures are orphaned, and what the caller sees depends on
`request_timeout_s`:

| `request_timeout_s` | Caller blocked in `call()` | Reported before |
|---|---|---|
| `None` | forever | never returns |
| `30.0` (default) | 30s | `TimeoutError("sessions.list timed out after 30s")` |

Neither is true. The request did not time out; the connection was closed under
it. `_pending` is also left populated, so the entries leak for the lifetime of
the client object.

This is reachable from ordinary shutdown, not just an explicit `close()` call:
`connect()` begins with `if self._ws is not None: await self.close()`, so any
reconnect strands the previous socket's in-flight calls the same way.

Measured with the fake socket already in `tests/test_mcp_server/test_gateway_client.py`
(`_SilentWebSocket`, which accepts a send and never answers) — the new tests take
**8.24s** against `upstream/main` @ `4ca69fff`, all of it spent in their own 2s
safety timeouts waiting for calls that never settle, versus **0.08s** with the fix.

## The fix

`close()` settles and clears pending calls before it takes the connection apart:

```python
async def close(self) -> None:
    self._closing = True
    # The listener deliberately stays quiet during an intentional close, so
    # a pending call has no other way to learn the connection went away.
    self._fail_pending(ConnectionError("Gateway connection closed"))
```

The settle-and-clear step is the three lines `_mark_connection_failed` already
ran, lifted into a helper so the two paths cannot drift:

```python
def _fail_pending(self, err: ConnectionError) -> None:
    for fut in self._pending.values():
        if not fut.done():
            fut.set_exception(err)
    self._pending.clear()
```

The error message is the one the report asked for, and `ConnectionError` is
already what a caller must handle from this client, so no call site changes.

Deliberately left alone:

- **`_connection_error` is not set.** Reusing `_mark_connection_failed` here
  would have been shorter, but it latches that field, which would change what a
  `call()` *after* a close raises — today `ConnectionError("Gateway connection is
  not open")` from the `self._ws is None` guard, which is already correct.
  `close()` only needs to settle what is in flight.
- **The `if not self._closing` guard in `_listen`, the task cancellation, and the
  heartbeat loop.** Unchanged; the fix adds a step rather than redirecting one.
- **`_close_failed_connect`.** The handshake uses raw `send`/`recv` rather than
  `call()`, so `_pending` is necessarily empty on that path.

## Tests

`tests/test_mcp_server/test_gateway_client.py` — 7 new cases, all offline, no
credentials, no sockets, built on the file's existing `_SilentWebSocket`. Every
wait is wrapped in `asyncio.wait_for(..., timeout=2)` so a regression fails the
suite in seconds instead of hanging it.

Fail without the fix (5):

- `test_close_fails_pending_call_without_a_request_timeout` — the reported case:
  `request_timeout_s=None`, so before the fix the task never returned.
- `test_close_fails_pending_call_promptly_under_a_request_timeout` — with
  `request_timeout_s=300`, asserts the caller gets `ConnectionError` now rather
  than a misleading `TimeoutError` five minutes later.
- `test_close_fails_every_pending_call` — two concurrent calls; both settle, and
  `_pending` ends empty. Guards against settling only the first entry.
- `test_reconnect_fails_the_previous_connections_pending_calls` — enters `close()`
  through `connect()` rather than directly, the path a reconnecting adapter takes.
- `test_close_leaves_an_already_settled_future_alone` — a cancelled `call()`
  leaves its entry in `_pending`; asserts `close()` clears it. This one also
  pins the `not fut.done()` guard: without it, `set_exception` on the cancelled
  future raises `InvalidStateError`.

Pass either way by design — the guards that the extracted helper did not change
the other caller, which is the direction the report did not cover:

- `test_connection_failure_still_fails_pending_calls` — an unexpected drop still
  reports `ConnectionError("Gateway connection lost: socket reset")`, not the new
  close message. If `_fail_pending` had been wired up wrongly, this is what would
  catch it.
- `test_close_still_closes_the_socket_with_no_pending_calls` — `close()` with an
  empty `_pending` still closes the socket and nulls `_ws`; the added call is not
  allowed to short-circuit teardown.

## Verification

```
$ uv run pytest tests/test_mcp_server/test_gateway_client.py -q
11 passed in 0.08s

$ git show upstream/main:src/agentos/gateway_client.py > src/agentos/gateway_client.py
$ uv run pytest tests/test_mcp_server/test_gateway_client.py -q
5 failed, 6 passed in 8.24s

$ uv run ruff check src tests
All checks passed!

$ uv run mypy --show-error-codes src
Success: no issues found in 625 source files

$ uv run pytest -q
6 failed, 10443 passed, 34 skipped, 4 warnings, 3 errors in 252.11s
```

The 6 failures and 3 errors in the full run are pre-existing on pristine
`upstream/main` in my environment and untouched by this change — an unhydrated
MiniLM ONNX asset (`test_pilot_encoder`, `test_build_wheelhouse_zip`,
`test_pilot_benchmark`) and a local-timezone hygiene guard
(`test_tracked_public_files_do_not_carry_this_machines_timezone`).

The test-file diff is purely additive (+122/−0). `ruff format` wants to rewrap one
pre-existing `assert` at line 33, which it also wants to rewrap on `upstream/main`
untouched, so I left it as it is rather than mix a reflow into this PR.

## One adjacent case, deliberately left alone

`call()` pops `_pending[req_id]` on `TimeoutError` but not on `CancelledError`, so
a cancelled call leaves its entry behind until something else clears the dict.
This fix makes `close()` clear it, which is why the cancellation test above
passes, but the leak itself is still there for a long-lived client that cancels
calls and never closes. It needs a `finally: self._pending.pop(req_id, None)` in
`call()` — a different statement from the one this issue is about, so I left it
out. Happy to file it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01As6ug1t9iDHvHMWQqeEM2R
