### PR TITLE
fix(skills): keep bundled git-diff and pptx output byte-exact on non-UTF-8 code pages

### DIFF
--- a/src/agentos/skills/bundled/git-diff/scripts/git_diff.py
+++ b/src/agentos/skills/bundled/git-diff/scripts/git_diff.py
@@ -5,6 +5,13 @@ Returns the diff text on stdout, the literal ``NO_DIFF`` when the
 diff is empty, and exits non-zero with the git error on stderr when
 git itself fails (not a repo, missing binary, etc.).
 
+git's output is carried as bytes from capture to stdout: SKILL.md
+promises the diff back raw, and the text layer cannot keep that
+promise — it decodes with the locale encoding (ASCII under a C
+locale), re-encodes with the console code page (cp936/cp1252 on
+Windows, where a piped stdout does not get the UTF-8 path), and
+translates CRLF to LF, rewriting the diff of a CRLF file.
+
 Used by workflows that need repository diffs while skipping a full
 sub-Agent loop just to call ``git diff``.
 """
@@ -15,6 +22,7 @@ import argparse
 import subprocess
 import sys
 from pathlib import Path
+from typing import TextIO
 
 _VALID_MODES = {
     "cached_fallback_worktree",
@@ -24,18 +32,42 @@ _VALID_MODES = {
 }
 
 
-def _run_git(args: list[str], cwd: Path) -> tuple[int, str, str]:
+def _emit(data: bytes, stream: TextIO) -> None:
+    """Write bytes verbatim, surviving a non-UTF-8 or wrapped stream.
+
+    The binary buffer is the primary path: it keeps UTF-8 content and CRLF
+    intact even when the stream's own encoding cannot represent them. A stream
+    without a usable ``buffer`` — a wrapper, or a captured stdout — still gets
+    the payload, escaped rather than lost or raised over.
+    """
+    buffer = getattr(stream, "buffer", None)
+    if buffer is not None:
+        try:
+            buffer.write(data)
+            buffer.flush()
+            return
+        except (AttributeError, OSError, ValueError):
+            # Buffer closed or not writable — fall through to the text layer.
+            pass
+
+    encoding = getattr(stream, "encoding", None) or "utf-8"
+    text = data.decode("utf-8", errors="backslashreplace")
+    # Lossless: unencodable chars become \\uXXXX escapes, not "?".
+    stream.write(text.encode(encoding, errors="backslashreplace").decode(encoding))
+    stream.flush()
+
+
+def _run_git(args: list[str], cwd: Path) -> tuple[int, bytes, bytes]:
     proc = subprocess.run(  # noqa: S603 — argv is constructed from a static allowlist
         ["git", *args],
         cwd=str(cwd),
         capture_output=True,
-        text=True,
         check=False,
     )
     return proc.returncode, proc.stdout, proc.stderr
 
 
-def _diff_for_mode(mode: str, cwd: Path) -> tuple[int, str, str]:
+def _diff_for_mode(mode: str, cwd: Path) -> tuple[int, bytes, bytes]:
     if mode == "cached_fallback_worktree":
         rc, out, err = _run_git(["diff", "--cached", "HEAD"], cwd)
         if rc != 0:
@@ -77,10 +109,10 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     if rc != 0:
-        sys.stderr.write(err)
+        _emit(err, sys.stderr)
         return rc
 
-    sys.stdout.write(out if out.strip() else "NO_DIFF")
+    _emit(out if out.strip() else b"NO_DIFF", sys.stdout)
     return 0
 
 

--- a/src/agentos/skills/bundled/pptx/scripts/extract_text.py
+++ b/src/agentos/skills/bundled/pptx/scripts/extract_text.py
@@ -102,6 +102,32 @@ def _notes_text(slide) -> str:
     return "\n".join(p.text for p in tf.paragraphs if p.text.strip())
 
 
+def _write(text: str) -> None:
+    """Write extracted text to stdout, surviving a non-UTF-8 stdout encoding.
+
+    Slide text is whatever the deck's author typed, so it routinely carries
+    non-Latin characters and emoji. On a Windows code page (cp936/cp1252) — which
+    is what a redirected or piped stdout falls back to — handing those to the
+    text layer raises ``UnicodeEncodeError`` before a byte is written, so the
+    binary buffer is the primary path. A stream without a usable ``buffer``
+    still gets the text, escaped rather than lost.
+    """
+    buffer = getattr(sys.stdout, "buffer", None)
+    if buffer is not None:
+        try:
+            buffer.write(text.encode("utf-8"))
+            buffer.flush()
+            return
+        except (AttributeError, OSError, ValueError):
+            # Buffer closed or not writable — fall through to the text layer.
+            pass
+
+    encoding = getattr(sys.stdout, "encoding", None) or "utf-8"
+    # Lossless: unencodable chars become \\uXXXX escapes, not "?".
+    sys.stdout.write(text.encode(encoding, errors="backslashreplace").decode(encoding))
+    sys.stdout.flush()
+
+
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description="Extract slide text from a .pptx file.")
     ap.add_argument("path", type=Path, help="Path to .pptx file")
@@ -141,17 +167,16 @@ def main(argv: list[str] | None = None) -> int:
         )
 
     if args.json:
-        json.dump(slides_data, sys.stdout, ensure_ascii=False, indent=2)
-        sys.stdout.write("\n")
+        _write(json.dumps(slides_data, ensure_ascii=False, indent=2) + "\n")
         return 0
 
     for entry in slides_data:
-        sys.stdout.write(f"--- slide {entry['slide']} ---\n")
+        _write(f"--- slide {entry['slide']} ---\n")
         for line in entry["text"]:
-            sys.stdout.write(line + "\n")
+            _write(line + "\n")
         if args.include_notes and entry.get("notes"):
-            sys.stdout.write("[notes]\n")
-            sys.stdout.write(entry["notes"] + "\n")
+            _write("[notes]\n")
+            _write(entry["notes"] + "\n")
     return 0
 
 

--- a/tests/test_skill_pptx_extract_text.py
+++ b/tests/test_skill_pptx_extract_text.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import io
 import json
+import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -68,3 +70,83 @@ def test_shape_text_and_table_text_extraction(tmp_path: Path) -> None:
     assert "Secondary point" in slide_data["text"]
     assert "Metric | Value" in slide_data["text"]
     assert "Q1 Revenue (USD) | $100M" in slide_data["text"]
+
+
+#: "季度回顾 🎉" — CJK plus an astral emoji: cp936 fails on the emoji, cp1252
+#: on every character.
+_NON_ASCII = "季度回顾 \U0001f389"
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "agentos"
+    / "skills"
+    / "bundled"
+    / "pptx"
+    / "scripts"
+    / "extract_text.py"
+)
+
+
+def _deck_with_non_ascii(tmp_path: Path) -> Path:
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    box = slide.shapes.add_textbox(Inches(1), Inches(1), Inches(6), Inches(2))
+    box.text_frame.text = _NON_ASCII
+    path = tmp_path / "deck.pptx"
+    prs.save(str(path))
+    return path
+
+
+def _run_script(deck: Path, *args: str, encoding: str) -> subprocess.CompletedProcess[bytes]:
+    # A child process is the only way to give the script a stdout whose
+    # encoding cannot represent the slide text, which is what a piped stdout
+    # on a Windows code page does (Issue #1834).
+    env = {**os.environ, "PYTHONIOENCODING": encoding}
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), str(deck), *args],
+        capture_output=True,
+        env=env,
+    )
+
+
+def test_non_ascii_slide_text_survives_a_non_utf8_stdout_encoding(tmp_path: Path) -> None:
+    deck = _deck_with_non_ascii(tmp_path)
+
+    proc = _run_script(deck, encoding="cp936")
+
+    assert proc.returncode == 0, proc.stderr.decode("utf-8", "replace")
+    assert _NON_ASCII.encode() in proc.stdout
+
+
+def test_non_ascii_json_output_survives_a_non_utf8_stdout_encoding(tmp_path: Path) -> None:
+    # ``--json`` is a second write path: json.dump wrote straight to the text
+    # stream, so it failed independently of the plain listing.
+    deck = _deck_with_non_ascii(tmp_path)
+
+    proc = _run_script(deck, "--json", encoding="cp1252")
+
+    assert proc.returncode == 0, proc.stderr.decode("utf-8", "replace")
+    payload = json.loads(proc.stdout.decode("utf-8"))
+    assert payload[0]["text"] == [_NON_ASCII]
+
+
+def test_write_falls_back_when_stdout_has_no_buffer() -> None:
+    # Reviewer note on #764: the writer must stay correct when ``buffer`` is
+    # absent or the stream is wrapped, rather than raising. The existing tests
+    # in this file patch sys.stdout with a bare StringIO, so this path is live.
+    class NoBufferStream(io.StringIO):
+        encoding = "cp936"
+
+    stream = NoBufferStream()
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(sys, "stdout", stream)
+    try:
+        extract_text._write(f"{_NON_ASCII}\n")
+    finally:
+        monkeypatch.undo()
+
+    written = stream.getvalue()
+    assert "季度回顾" in written
+    # The emoji has no cp936 form, so it is escaped rather than dropped.
+    assert "?" not in written

--- a/tests/test_skills/test_git_diff_skill_encoding.py
+++ b/tests/test_skills/test_git_diff_skill_encoding.py
@@ -1,0 +1,185 @@
+"""The bundled ``git-diff`` script must hand back git's bytes unchanged.
+
+SKILL.md promises "raw unified diff text on stdout", and the script is run by
+the agent through the shell tool, so its stdout is always a pipe — the case
+where Python falls back to the locale code page instead of a console's UTF-8
+path. These drive the real script in a child process and assert on raw bytes,
+because the defect lives in the stream layer and a monkeypatched stdout would
+not exercise it (Issue #1834).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "src" / "agentos" / "skills" / "bundled" / "git-diff" / "scripts" / "git_diff.py"
+
+#: "你好世界 🎉" — CJK plus an astral emoji, so cp936 fails on the emoji and
+#: cp1252 fails on every character.
+NON_ASCII = "你好世界 \U0001f389"
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.email=test@example.com",
+            "-c",
+            "user.name=test",
+            "-c",
+            "commit.gpgsign=false",
+            "-c",
+            "core.autocrlf=false",
+            *args,
+        ],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A repo with one commit and a staged change holding non-ASCII text."""
+    _git(tmp_path, "init", "-q", ".")
+    (tmp_path / "f.txt").write_bytes(b"hello\n")
+    _git(tmp_path, "add", "f.txt")
+    _git(tmp_path, "commit", "-qm", "base")
+    (tmp_path / "f.txt").write_bytes(f"{NON_ASCII}\n".encode())
+    _git(tmp_path, "add", "f.txt")
+    return tmp_path
+
+
+def _run(repo: Path, **env_overrides: str) -> subprocess.CompletedProcess[bytes]:
+    env = {**os.environ, **env_overrides}
+    env.pop("PYTHONIOENCODING", None)
+    env.update(env_overrides)
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--cwd", str(repo)],
+        capture_output=True,
+        env=env,
+    )
+
+
+def _raw_git_diff(repo: Path) -> bytes:
+    return subprocess.run(
+        ["git", "diff", "--cached", "HEAD"],
+        cwd=repo,
+        capture_output=True,
+        check=True,
+    ).stdout
+
+
+def test_non_ascii_diff_survives_a_non_utf8_stdout_encoding(repo: Path) -> None:
+    # A Windows box whose active code page is cp936: the encode side used to
+    # raise UnicodeEncodeError on the emoji before a byte was written.
+    proc = _run(repo, PYTHONIOENCODING="cp936")
+
+    assert proc.returncode == 0, proc.stderr.decode("utf-8", "replace")
+    assert NON_ASCII.encode() in proc.stdout
+
+
+def test_non_ascii_diff_survives_a_c_locale(repo: Path) -> None:
+    # The decode side, a separate mechanism: ``text=True`` decoded git's bytes
+    # with the locale encoding, which is ASCII once C-locale coercion is off.
+    proc = _run(
+        repo,
+        LC_ALL="C",
+        LANG="C",
+        PYTHONCOERCECLOCALE="0",
+        PYTHONUTF8="0",
+    )
+
+    assert proc.returncode == 0, proc.stderr.decode("utf-8", "replace")
+    assert NON_ASCII.encode() in proc.stdout
+
+
+def test_diff_is_byte_identical_to_git(repo: Path) -> None:
+    proc = _run(repo)
+
+    assert proc.returncode == 0
+    assert proc.stdout == _raw_git_diff(repo)
+
+
+def test_crlf_diff_keeps_its_carriage_returns(tmp_path: Path) -> None:
+    # Universal newlines translated CRLF to LF, so the script rewrote the diff
+    # of a CRLF file even on a UTF-8 system. Byte-exactness is the contract.
+    _git(tmp_path, "init", "-q", ".")
+    (tmp_path / "w.txt").write_bytes(b"a\r\nb\r\n")
+    _git(tmp_path, "add", "w.txt")
+    _git(tmp_path, "commit", "-qm", "base")
+    (tmp_path / "w.txt").write_bytes(b"a\r\nCHANGED\r\n")
+    _git(tmp_path, "add", "w.txt")
+
+    proc = _run(tmp_path)
+
+    assert proc.returncode == 0
+    assert b"\r\n" in proc.stdout
+    assert proc.stdout == _raw_git_diff(tmp_path)
+
+
+def test_no_diff_marker_when_nothing_is_staged(tmp_path: Path) -> None:
+    _git(tmp_path, "init", "-q", ".")
+    (tmp_path / "f.txt").write_bytes(b"hello\n")
+    _git(tmp_path, "add", "f.txt")
+    _git(tmp_path, "commit", "-qm", "base")
+
+    proc = _run(tmp_path, PYTHONIOENCODING="cp936")
+
+    assert proc.returncode == 0
+    assert proc.stdout == b"NO_DIFF"
+
+
+def test_git_failure_still_reports_on_stderr(tmp_path: Path) -> None:
+    # Not a repo: the exit code stays git's own and stderr carries its output,
+    # which this change deliberately leaves as it is.
+    proc = _run(tmp_path, PYTHONIOENCODING="cp936")
+
+    assert proc.returncode != 0
+    assert proc.stderr
+
+
+def _load_script() -> object:
+    # ``git-diff`` is not a Python identifier, so the module is loaded by path.
+    spec = importlib.util.spec_from_file_location("bundled_git_diff", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_emit_falls_back_when_the_stream_has_no_buffer() -> None:
+    # Reviewer note on #764: the writer must stay correct when ``buffer`` is
+    # absent or the stream is wrapped, rather than raising.
+    module = _load_script()
+
+    class NoBufferStream(io.StringIO):
+        encoding = "cp936"
+
+    stream = NoBufferStream()
+    module._emit(f"{NON_ASCII}\n".encode(), stream)
+
+    written = stream.getvalue()
+    assert "你好世界" in written
+    # The emoji cannot be represented in cp936, so it is escaped, not dropped.
+    assert "?" not in written
+
+
+def test_emit_writes_bytes_verbatim_through_the_buffer() -> None:
+    module = _load_script()
+    raw = io.BytesIO()
+    stream = io.TextIOWrapper(raw, encoding="cp936")
+
+    payload = f"{NON_ASCII}\n".encode()
+    module._emit(payload, stream)
+
+    assert raw.getvalue() == payload


### PR DESCRIPTION
Fixes #1834

## The bug

Two bundled skill scripts hand non-ASCII text to the *text* layer of stdout.
Both are run by the agent through the shell tool, so their stdout is always a
pipe — the case where Python falls back to the locale code page rather than a
console's UTF-8 path:

```python
# git-diff/scripts/git_diff.py
proc = subprocess.run([...], capture_output=True, text=True, check=False)   # :32
...
sys.stdout.write(out if out.strip() else "NO_DIFF")                        # :83

# pptx/scripts/extract_text.py
json.dump(slides_data, sys.stdout, ensure_ascii=False, indent=2)           # :144
sys.stdout.write(line + "\n")                                              # :151
```

Measured on Python 3.14.7 against `upstream/main` @ `4ca69fff`. Every row returns
the right content under `LC_ALL=C.UTF-8`, so only the stream encoding decides
whether the skill works at all:

| script / path | code page | before |
|---|---|---|
| `git_diff.py` | cp936 | `UnicodeEncodeError: 'gbk' codec … '\U0001f389'` → exit 1 |
| `git_diff.py` | C/ASCII | `UnicodeDecodeError: 'ascii' codec … byte 0xe4` → exit 1 |
| `extract_text.py` | cp936 | `UnicodeEncodeError: 'gbk' codec … '\U0001f389'` → exit 1 |
| `extract_text.py` | cp1252 | `UnicodeEncodeError: 'charmap' codec … position 0-3` → exit 1 |
| `extract_text.py --json` | cp1252 | `UnicodeEncodeError: 'charmap' codec … position 9-12` → exit 1 |

`git-diff/SKILL.md` promises "Non-empty diff: raw unified diff text on stdout"
and `NO_DIFF` for an empty one. The agent gets a Python traceback instead — and
since `NO_DIFF` is the documented "nothing to do" signal, a caller that only
distinguishes empty from non-empty can read the failure as "no changes".

**`text=True` has a third symptom, present even on a UTF-8 system.** Universal
newlines translate CRLF to LF, so the diff of a CRLF file was silently rewritten:

```
$ git diff --cached HEAD | grep -c $'\r'     # a repo with CRLF content
3
$ python git_diff.py --cwd .  | grep -c $'\r'
0
```

**Precedent.** This class is already accepted and fixed twice here, both at
different sites: #764 (`cli/output.py`, `--json` on non-UTF-8 terminals) and
#1547/#1548 (multibyte UTF-8 in the background stdout reader). Neither touched
`skills/bundled/*/scripts/`. The repo also holds the correct pattern in
`text-file-read/scripts/read.py:56`, whose comment — *"Write through the binary
buffer to bypass the Windows console cp936 encoder"* — describes exactly the
situation these two files were in.

## The fix

**`git_diff.py` carries git's output as bytes end to end.** Dropping `text=True`
removes the decode, the re-encode and the newline translation in one move, so the
promise of raw output is kept by construction rather than by a codec working out:

```python
def _run_git(args: list[str], cwd: Path) -> tuple[int, bytes, bytes]:
    proc = subprocess.run([...], capture_output=True, check=False)
...
    _emit(out if out.strip() else b"NO_DIFF", sys.stdout)
```

**`extract_text.py` routes its five writes through one `_write`**, and `--json`
serializes with `json.dumps` first instead of streaming into `sys.stdout`.

Both writers follow `cli/output.py::_write_json_text` — the shape accepted for
#764 — including the reviewer's note there that it must stay correct *when
`buffer` is absent or the stream is wrapped*:

```python
buffer = getattr(stream, "buffer", None)
if buffer is not None:
    try:
        buffer.write(data); buffer.flush(); return
    except (AttributeError, OSError, ValueError):
        pass                      # closed or not writable — use the text layer
encoding = getattr(stream, "encoding", None) or "utf-8"
stream.write(text.encode(encoding, errors="backslashreplace").decode(encoding))
```

`backslashreplace` rather than `replace` for the same reason given in
`output.py`: an unrepresentable character becomes `\uXXXX`, not `?`.

The helper is duplicated in the two scripts rather than shared. Bundled scripts
run standalone as `python {baseDir}/scripts/x.py` under whatever interpreter
satisfies `anyBins: [python, python3]`, so they cannot import `agentos` —
`text-file-read` inlines the same way. Happy to lift it into a shared module
inside `skills/bundled/` if you would rather have one copy.

Deliberately left alone:

- **The exit-code path.** `git_diff.py:79-81` still returns git's own code, so
  outside a repo it exits 129 with git's usage dump rather than the documented
  `1`. That is the distinct defect noted at the end of #1834 — the contract it
  breaks is the exit code, not the payload — and a test pins the current
  behaviour so this PR cannot be read as having changed it.
- **`git-diff/SKILL.md`.** Its output contract was already right; the code was
  wrong. No CLI surface (command, flag, config key, port, path) changes here, so
  `docs/cli.md` and the `agentos` SKILL.md need nothing.
- **The nine other scripts** with the same shape (`http-fetch`,
  `multi-search-engine`, `weather`, `deep-research`, the `gmgn-*` trio,
  `video-merger`). They need network or an external CLI to exercise, and #1834
  lists them as a list rather than a claim. Say the word and I will extend this
  PR to cover them.

## Tests

`tests/test_skills/test_git_diff_skill_encoding.py` (new, 8 cases) and
`tests/test_skill_pptx_extract_text.py` (+3). All offline, no credentials, no
network. Basename checked against the suite — no collision.

The end-to-end cases drive the real script in a **child process** with
`PYTHONIOENCODING` set, following `tests/test_skills/test_cron_watchers.py`: the
defect lives in the stream layer, and a monkeypatched `sys.stdout` would not
reproduce it. Repos are built in `tmp_path` with `-c user.email=…`/`-c
core.autocrlf=false` so nothing depends on the machine's git config.

Fail on `upstream/main` for the documented behaviour (5):

- `test_non_ascii_diff_survives_a_non_utf8_stdout_encoding` — cp936, the encode side.
- `test_non_ascii_diff_survives_a_c_locale` — `LC_ALL=C` with coercion and UTF-8
  mode off: the decode side, a mechanism independent of the one above.
- `test_crlf_diff_keeps_its_carriage_returns` — the CRLF symptom; fails on a
  plain UTF-8 Linux runner, so it does not depend on a code page at all.
- `test_non_ascii_slide_text_survives_a_non_utf8_stdout_encoding` — cp936.
- `test_non_ascii_json_output_survives_a_non_utf8_stdout_encoding` — cp1252 on
  `--json`, the second write path in that script.

Cannot run against `upstream/main` at all (3) — they call the new writer
directly, so without it they raise `AttributeError`. Listing them separately
because an `AttributeError` proves nothing about the bug:

- `test_emit_falls_back_when_the_stream_has_no_buffer`,
  `test_write_falls_back_when_stdout_has_no_buffer` — a `StringIO` subclass with
  `encoding = "cp936"` and no `buffer`: the text survives, the emoji is escaped,
  and no `?` appears.
- `test_emit_writes_bytes_verbatim_through_the_buffer` — bytes reach a
  `TextIOWrapper`'s buffer unchanged.

Pass either way by design (3) — the guards that this change did not move
anything else:

- `test_diff_is_byte_identical_to_git` — passes on `upstream/main` too, because
  on a UTF-8 host with LF content the old round-trip happened to be lossless.
  It is the CRLF case above that separates them; this one keeps the byte-exact
  contract asserted for the ordinary path.
- `test_no_diff_marker_when_nothing_is_staged` — `NO_DIFF` still emitted, now as
  bytes, under cp936.
- `test_git_failure_still_reports_on_stderr` — non-zero exit and non-empty
  stderr outside a repo, pinning the exit-code behaviour left out of scope.

One existing test is worth noting: `test_shape_text_and_table_text_extraction`
patches `sys.stdout` with a bare `io.StringIO`, which has no `buffer` — so the
fallback branch is exercised by the suite that was already there, not only by the
new tests.

## Verification

```
$ uv run pytest tests/test_skills/test_git_diff_skill_encoding.py tests/test_skill_pptx_extract_text.py -q
12 passed in 1.26s

$ git show upstream/main:.../git_diff.py > .../git_diff.py
$ git show upstream/main:.../extract_text.py > .../extract_text.py
$ uv run pytest tests/test_skills/test_git_diff_skill_encoding.py tests/test_skill_pptx_extract_text.py -q
8 failed, 4 passed in 1.28s

$ uv run ruff check src tests
All checks passed!

$ uv run ruff format --check <the four changed files>
4 files already formatted

$ uv run mypy --show-error-codes src
Success: no issues found in 625 source files

$ uv run pytest -q
6 failed, 10447 passed, 34 skipped, 4 warnings, 3 errors in 257.19s
```

Re-running the original reproductions from #1834 after the fix: all five exit 0
and emit the expected UTF-8 bytes, and the CRLF diff is now byte-identical to
`git diff --cached HEAD`.

The 6 failures and 3 errors in the full run are pre-existing on pristine
`upstream/main` in my environment and untouched by this change — an unhydrated
MiniLM ONNX asset (`test_pilot_encoder`, `test_build_wheelhouse_zip`,
`test_pilot_benchmark`) and a local-timezone hygiene guard
(`test_tracked_public_files_do_not_carry_this_machines_timezone`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01As6ug1t9iDHvHMWQqeEM2R
