### PR TITLE
fix(tools): check artifact name and mime in file authoring deduplication

### DIFF
--- a/src/agentos/tools/builtin/file_authoring.py
+++ b/src/agentos/tools/builtin/file_authoring.py
@@ -214,7 +214,11 @@ def _published_response(
 
     target_sha256 = hashlib.sha256(payload).hexdigest()
     for published in reversed(ctx.published_artifacts):
-        if published.get("sha256") != target_sha256:
+        if (
+            published.get("sha256") != target_sha256
+            or published.get("name") != name
+            or published.get("mime") != mime
+        ):
             continue
         llm_artifact = {k: v for k, v in published.items() if k != "download_url"}
         return json.dumps(

--- a/tests/test_tools/test_file_authoring_tools.py
+++ b/tests/test_tools/test_file_authoring_tools.py
@@ -23,7 +23,7 @@ def _channel_artifact_context(tmp_path: Path) -> ToolContext:
     workspace = tmp_path / "workspace"
     workspace.mkdir(exist_ok=True)
     return ToolContext(
-                caller_kind=CallerKind.CHANNEL,
+        caller_kind=CallerKind.CHANNEL,
         workspace_dir=str(workspace),
         artifact_media_root=str(tmp_path / "media"),
         artifact_session_id="session-1",
@@ -227,3 +227,32 @@ async def test_create_pdf_report_uses_unicode_fonts_for_channel_artifact(tmp_pat
 
     assert not any("ZapfDingbats" in font_name for font_name in base_fonts)
     assert any("STSong-Light" in font_name for font_name in base_fonts)
+
+
+@pytest.mark.asyncio
+async def test_file_authoring_distinct_files_with_identical_content_not_deduplicated(
+    tmp_path: Path,
+) -> None:
+    ctx = _channel_artifact_context(tmp_path)
+    token = current_tool_context.set(ctx)
+    try:
+        r1 = json.loads(await create_csv(name="first.csv", rows=[["a", "b"]]))
+        r2 = json.loads(await create_csv(name="second.csv", rows=[["a", "b"]]))
+        r3 = json.loads(await create_csv(name="first.csv", rows=[["a", "b"]]))
+    finally:
+        current_tool_context.reset(token)
+
+    assert r1["status"] == "published"
+    assert r1["artifact"]["name"] == "first.csv"
+
+    assert r2["status"] == "published"
+    assert r2["artifact"]["name"] == "second.csv"
+    assert r2["artifact"]["id"] != r1["artifact"]["id"]
+
+    assert r3["status"] == "already_published"
+    assert r3["artifact"]["name"] == "first.csv"
+    assert r3["artifact"]["id"] == r1["artifact"]["id"]
+
+    assert len(ctx.published_artifacts) == 2
+    assert ctx.published_artifacts[0]["name"] == "first.csv"
+    assert ctx.published_artifacts[1]["name"] == "second.csv"


### PR DESCRIPTION
Fixes #1836

### Problem
In `_published_response` (`src/agentos/tools/builtin/file_authoring.py`), in-turn deduplication previously checked only `published.get("sha256") == target_sha256`. If two distinct files created in the same turn/session context shared identical content (e.g., empty CSV/Excel sheets, two template presentations, or reports sharing identical rows like `first.csv` and `second.csv`), calling the second authoring tool immediately returned `status: "already_published"` pointing to the first file's artifact name and ID. The second file was never published or registered in `ctx.published_artifacts`.

### Solution
- In `_published_response`, require that `published.get("name") == name` and `published.get("mime") == mime` in addition to `published.get("sha256") == target_sha256` before considering an artifact already published in the current turn. This aligns with `ArtifactStore.find_existing_ref`'s matching contract.
- Add regression test in `tests/test_tools/test_file_authoring_tools.py` verifying that two distinct files with identical content are each published and tracked with their own names, while an identical re-creation call still correctly returns `already_published`.
