### PR TITLE
feat(router): default c0 to deepseek-v4.1-flash on bankr/opencap/surplus; fix Windows-flaky approval wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   configs are not migrated -- `deepseek-v4-flash` still resolves on every
   gateway -- and the direct `deepseek` profile is unchanged.
 
+### Fixed
+
+- `ApprovalQueue.wait()` could leave an approval pending forever after its full
+  default timeout had elapsed. The wait deadline was measured on the monotonic
+  clock but the "has the approval's lifespan expired?" check re-read
+  `time.time()`; on Windows the wall clock ticks at ~15.6ms, so after a short
+  wait it could still report the approval as younger than its lifespan and skip
+  the deny. The lifespan is now converted to the monotonic clock once at entry.
+  This was the intermittent
+  `test_approval_queue_wait_denies_once_the_full_default_timeout_elapses`
+  failure in the Windows CI job on `main`.
+
 ## [2026.9.11] - 2026-09-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- The `c0` router tier on the `bankr`, `opencap` and `surplus` tier profiles
+  now defaults to DeepSeek V4.1 Flash (`deepseek-v4.1-flash`) instead of V4
+  Flash. All three gateways publish the id with a 1M context and 384K max
+  output, so the bare id needs no gateway window override, and it is declared
+  in `model_registry` with `supports_image` left off: it is a text tier, and a
+  vision-flagged text tier would become a random pick for image turns
+  alongside `image_model`. The `openrouter` profile deliberately stays on
+  `deepseek/deepseek-v4-flash`: OpenRouter routes V4 Flash cheaper than
+  `openai/gpt-5.6-luna` but prices V4.1 Flash above it, so the router's
+  cost-aware override would hand every OpenRouter c0 turn to c1. Existing
+  configs are not migrated -- `deepseek-v4-flash` still resolves on every
+  gateway -- and the direct `deepseek` profile is unchanged.
+
 ## [2026.9.11] - 2026-09-11
 
 ### Added

--- a/docs/providers-and-models.md
+++ b/docs/providers-and-models.md
@@ -96,7 +96,7 @@ router profile selects bare OpenCAP model IDs across
 
 | Tier | Model | Role |
 | --- | --- | --- |
-| `c0` | `deepseek-v4-flash` | trivial chat, short rewrites, extraction |
+| `c0` | `deepseek-v4.1-flash` | trivial chat, short rewrites, extraction |
 | `c1` | `gpt-5.6-luna` | default balanced route for normal agent work |
 | `c2` | `glm-5.3` | multi-step coding, structured reasoning, larger synthesis |
 | `c3` | `claude-opus-5` | difficult planning, deep review, high-stakes synthesis |
@@ -138,7 +138,7 @@ Surplus model IDs across
 
 | Tier | Model | Role |
 | --- | --- | --- |
-| `c0` | `deepseek-v4-flash` | trivial chat, short rewrites, extraction |
+| `c0` | `deepseek-v4.1-flash` | trivial chat, short rewrites, extraction |
 | `c1` | `gpt-5.6-luna` | default balanced route for normal agent work |
 | `c2` | `glm-5.3` | multi-step coding, structured reasoning, larger context |
 | `c3` | `claude-opus-5` | difficult planning, deep review, high-stakes synthesis |

--- a/src/agentos/application/approval_queue.py
+++ b/src/agentos/application/approval_queue.py
@@ -172,7 +172,15 @@ class ApprovalQueue:
         if entry.resolved:
             return entry.approved
         t = timeout if timeout is not None else self._timeout
-        deadline = time.monotonic() + t
+        now = time.monotonic()
+        deadline = now + t
+        # The approval's overall lifespan (created_at + default_timeout) is a
+        # wall-clock fact, but it is compared against a monotonic deadline, so
+        # convert it once here rather than re-reading time.time() after the
+        # loop. Windows' wall clock ticks at ~15.6ms; read afresh after a 20ms
+        # monotonic wait it can still show the approval as younger than its
+        # lifespan and leave a timed-out approval pending forever.
+        lifespan_deadline = now + max(0.0, entry.created_at + self._timeout - time.time())
         while True:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
@@ -188,7 +196,7 @@ class ApprovalQueue:
             if entry.resolved:
                 return entry.approved
 
-        if time.time() - entry.created_at < self._timeout:
+        if time.monotonic() < lifespan_deadline:
             # The caller's own timeout elapsed, but the approval's overall
             # lifespan (created_at + default_timeout) hasn't -- leave it
             # pending instead of denying it, so a human operator can still

--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -747,18 +747,18 @@ def _default_tiers() -> dict:
 def _bankr_tiers() -> dict:
     """Bankr LLM Gateway routing config.
 
-    Model ids are bare (e.g. ``deepseek-v4-flash``) as served by the Bankr
-    gateway at ``llm.bankr.bot``. ``deepseek-v4-flash`` shares its bare id with
-    the DeepSeek direct contract (393K max output); the bankr entry in
-    ``_PROVIDER_STATIC_FALLBACK`` (model_catalog) caps it at the gateway's 128K
-    output limit.
+    Model ids are bare (e.g. ``deepseek-v4.1-flash``) as served by the Bankr
+    gateway at ``llm.bankr.bot``. Where a bare id is shared with a direct
+    provider contract that allows more output than the gateway does (the older
+    ``deepseek-v4-flash``: 393K direct, 128K here), the bankr entry in
+    ``_PROVIDER_STATIC_FALLBACK`` (model_catalog) carries the gateway's cap.
     """
     return {
         "c0": _tier(
             provider="bankr",
-            model="deepseek-v4-flash",
+            model="deepseek-v4.1-flash",
             description=(
-                "fast DeepSeek V4 Flash route for trivial chat, short rewrites, extraction, and "
+                "fast DeepSeek V4.1 Flash route for trivial chat, short rewrites, extraction, and "
                 "low-risk simple Q&A"
             ),
             thinking_level="high",
@@ -818,9 +818,9 @@ def _opencap_tiers() -> dict:
     return {
         "c0": _tier(
             provider="opencap",
-            model="deepseek-v4-flash",
+            model="deepseek-v4.1-flash",
             description=(
-                "fast DeepSeek V4 Flash route for trivial chat, short rewrites, extraction, and "
+                "fast DeepSeek V4.1 Flash route for trivial chat, short rewrites, extraction, and "
                 "low-risk simple Q&A"
             ),
             thinking_level="high",
@@ -881,9 +881,9 @@ def _surplus_tiers() -> dict:
     return {
         "c0": _tier(
             provider="surplus",
-            model="deepseek-v4-flash",
+            model="deepseek-v4.1-flash",
             description=(
-                "fast DeepSeek V4 Flash route for trivial chat, short rewrites, extraction, and "
+                "fast DeepSeek V4.1 Flash route for trivial chat, short rewrites, extraction, and "
                 "low-risk simple Q&A"
             ),
             thinking_level="high",

--- a/src/agentos/model_registry.py
+++ b/src/agentos/model_registry.py
@@ -213,6 +213,23 @@ MODEL_FACTS: tuple[ModelFacts, ...] = (
         price=PriceFacts(1.74, 3.48),
     ),
     ModelFacts(
+        "deepseek-v4.1-flash",
+        max_output_tokens=384_000,
+        context_window=1_048_576,
+        price=PriceFacts(0.15, 0.60, cached_input_per_m=0.003),
+        note=(
+            "Bankr, OpenCAP and Surplus all publish 384K output / 1M context for "
+            "this bare id, so unlike deepseek-v4-flash no gateway window override "
+            "is needed. Vision-capable upstream, but supports_image stays False on "
+            "purpose: it is the gateways' c0 text default, and a supports_image "
+            "text tier becomes a random pick for image turns alongside "
+            "image_model -- the same treatment gpt-5.6-luna and claude-opus-5 get. "
+            "Not the OpenRouter c0: there deepseek/deepseek-v4-flash is routed "
+            "cheaper than gpt-5.6-luna while V4.1 Flash is not, so the cost-aware "
+            "override would hand every c0 turn to c1."
+        ),
+    ),
+    ModelFacts(
         "deepseek/deepseek-v3.2",
         max_output_tokens=16_384,
         context_window=163_840,

--- a/tests/test_application/test_approval_queue_wait_timeout.py
+++ b/tests/test_application/test_approval_queue_wait_timeout.py
@@ -68,3 +68,27 @@ async def test_wait_returns_immediately_once_resolved_during_the_call(tmp_path) 
 
     assert result is True
     queue.close()
+
+
+@pytest.mark.asyncio
+async def test_wait_default_timeout_denies_even_when_the_wall_clock_does_not_tick(
+    tmp_path, monkeypatch
+) -> None:
+    """Windows' time.time() advances in ~15.6ms steps, so after a short wait it
+    can still read the approval as younger than its lifespan. A frozen wall
+    clock is the extreme form of that: the wait deadline (monotonic) elapses
+    while time.time() - created_at stays 0, and the approval must still be
+    denied rather than left pending forever."""
+    db_path = tmp_path / "approval_queue.sqlite"
+    queue = ApprovalQueue(default_timeout=0.02, db_path=str(db_path), poll_interval=0.01)
+    approval_id = queue.request("exec", {"toolName": "exec_command"})
+    frozen = time.time()
+    monkeypatch.setattr(time, "time", lambda: frozen)
+
+    result = await queue.wait(approval_id)
+
+    assert result is False
+    entry = queue.get(approval_id)
+    assert entry.resolved is True
+    assert entry.approved is False
+    queue.close()

--- a/tests/test_provider_bankr.py
+++ b/tests/test_provider_bankr.py
@@ -75,7 +75,7 @@ def test_bankr_is_a_tier_profile() -> None:
     tiers = _router_tier_profile_defaults("bankr")
     assert tiers == _bankr_tiers()
     assert tiers["c0"]["provider"] == "bankr"
-    assert tiers["c0"]["model"] == "deepseek-v4-flash"
+    assert tiers["c0"]["model"] == "deepseek-v4.1-flash"
     assert tiers["c1"]["model"] == "gpt-5.6-luna"
     assert tiers["c2"]["model"] == "glm-5.2"
     assert tiers["c3"]["model"] == "claude-opus-5"

--- a/tests/test_provider_opencap.py
+++ b/tests/test_provider_opencap.py
@@ -95,7 +95,7 @@ def test_opencap_router_profile_contract() -> None:
     tiers = _router_tier_profile_defaults("opencap")
 
     assert {tier["provider"] for tier in tiers.values()} == {"opencap"}
-    assert tiers["c0"]["model"] == "deepseek-v4-flash"
+    assert tiers["c0"]["model"] == "deepseek-v4.1-flash"
     assert tiers["c1"]["model"] == "gpt-5.6-luna"
     assert tiers["c2"]["model"] == "glm-5.3"
     assert tiers["c3"]["model"] == "claude-opus-5"
@@ -127,6 +127,7 @@ def test_opencap_tier_models_are_all_served_by_the_live_catalog() -> None:
     """
     published = {
         "deepseek-v4-flash",
+        "deepseek-v4.1-flash",
         "gpt-5.6-luna",
         "glm-5.3",
         "glm-5.3-flash",
@@ -340,6 +341,13 @@ def test_opencap_gateway_uses_conservative_shared_id_limits() -> None:
     assert catalog.resolve_max_tokens("deepseek-v4-flash", provider_name="opencap") == 128_000
     assert catalog.resolve_context_window("deepseek-v4-flash", provider_name="opencap") == 1_000_000
 
+    # The V4.1 default is published at the same 384K output / 1M context on the
+    # gateway as everywhere else, so it carries no gateway override.
+    assert catalog.resolve_max_tokens("deepseek-v4.1-flash", provider_name="opencap") == 384_000
+    assert (
+        catalog.resolve_context_window("deepseek-v4.1-flash", provider_name="opencap") == 1_048_576
+    )
+
 
 def test_opencap_deepseek_v4_models_resolve_deepseek_reasoning() -> None:
     # DeepSeek V4 via the OpenCAP/Bankr gateways honors the DeepSeek-native
@@ -347,10 +355,13 @@ def test_opencap_deepseek_v4_models_resolve_deepseek_reasoning() -> None:
     # capability gate must say so or tier thinking_level silently no-ops.
     catalog = ModelCatalog()
 
+    # deepseek-v4.1-flash is the shipped c0 on both gateways, so the offline
+    # prefix heuristic has to cover the dotted id too, not just deepseek-v4-*.
     for provider in ("opencap", "bankr"):
-        caps = catalog.get_capabilities("deepseek-v4-flash", provider_name=provider)
-        assert caps.supports_reasoning is True
-        assert caps.reasoning_format == "deepseek"
+        for model in ("deepseek-v4-flash", "deepseek-v4.1-flash"):
+            caps = catalog.get_capabilities(model, provider_name=provider)
+            assert caps.supports_reasoning is True, (provider, model)
+            assert caps.reasoning_format == "deepseek", (provider, model)
 
     pro = catalog.get_capabilities("deepseek-v4-pro", provider_name="opencap")
     assert pro.supports_reasoning is True

--- a/tests/test_provider_surplus.py
+++ b/tests/test_provider_surplus.py
@@ -80,7 +80,7 @@ def test_surplus_router_profile_contract() -> None:
     tiers = _router_tier_profile_defaults("surplus")
 
     assert {tier["provider"] for tier in tiers.values()} == {"surplus"}
-    assert tiers["c0"]["model"] == "deepseek-v4-flash"
+    assert tiers["c0"]["model"] == "deepseek-v4.1-flash"
     assert tiers["c1"]["model"] == "gpt-5.6-luna"
     assert tiers["c2"]["model"] == "glm-5.3"
     assert tiers["c3"]["model"] == "claude-opus-5"
@@ -108,6 +108,7 @@ def test_surplus_tier_models_are_all_served_by_the_live_catalog() -> None:
     """
     published = {
         "deepseek-v4-flash",
+        "deepseek-v4.1-flash",
         "deepseek-v4-pro",
         "gpt-5.6-luna",
         "gpt-5.6-terra",
@@ -273,7 +274,13 @@ def test_surplus_tier_defaults_resolve_reasoning_without_a_live_catalog() -> Non
     without a reasoning format their thinking_level silently no-ops."""
     catalog = ModelCatalog()
 
-    for model in ("deepseek-v4-flash", "gpt-5.6-luna", "glm-5.3", "claude-opus-5"):
+    for model in (
+        "deepseek-v4.1-flash",
+        "deepseek-v4-flash",
+        "gpt-5.6-luna",
+        "glm-5.3",
+        "claude-opus-5",
+    ):
         caps = catalog.get_capabilities(model, provider_name="surplus")
         assert caps.supports_reasoning is True, model
         assert caps.reasoning_format == "openrouter", model


### PR DESCRIPTION
## Summary

Two commits, reviewable independently.

### 1. `c0` → `deepseek-v4.1-flash` on the `bankr`, `opencap` and `surplus` tier profiles

- `deepseek-v4.1-flash` declared in `model_registry` (384K out / 1M ctx, $0.15/$0.60, cached $0.003). All three gateways publish the same window, so unlike `deepseek-v4-flash` no `_gateway_windows` override is needed. Verified live against the OpenCAP and Surplus public catalogs; Bankr confirmed by the maintainer (its catalog is authenticated).
- `supports_image` stays False: the catalogs list V4.1 Flash as vision-capable, but text-tier defaults are declared the same way as `gpt-5.6-luna` / `claude-opus-5` — a `supports_image` text tier becomes a random pick for image turns alongside `image_model`.
- Offline capability resolution already covers the dotted id (`basename.startswith("deepseek-v4")` → `deepseek` format on bankr/opencap; `deepseek-` prefix → `openrouter` format on surplus); tests now assert this for the new default.
- **`openrouter` deliberately stays on `deepseek/deepseek-v4-flash`.** OpenRouter currently routes `openai/gpt-5.6-luna` at $0.10/$0.60 and V4.1 Flash at $0.15/$0.60 ($0.30/$1.20 weekday peak), so the cost-aware override would hand every OpenRouter c0 turn to c1. Moving that tier too surfaced as a `test_pilot_golden` accuracy regression (0.506 < 0.55) because the golden run uses live pricing.
- No config migration: `deepseek-v4-flash` still resolves on every gateway. Direct `deepseek` profile unchanged.

### 2. Fix the Windows-flaky `ApprovalQueue.wait()` (CI on `main` is red)

[Run 34682753741](https://github.com/use-agent-os/agent-os/actions/runs/34682753741) on `main` failed the Windows job with `test_approval_queue_wait_denies_once_the_full_default_timeout_elapses`.

`wait()` measured its deadline on `time.monotonic()` but decided "lifespan expired?" by re-reading `time.time() - created_at`. Windows' wall clock ticks at ~15.6ms, so after a 20ms monotonic wait it could still see the approval as younger than `default_timeout`, return `False` without denying, and leave it pending forever. Linux's µs resolution hides it. The lifespan is now converted to the monotonic clock once at entry. New regression test freezes `time.time()` and fails against the previous implementation (verified by reverting the fix).

## Verification

- `ruff check` clean; `ruff format --check` clean on every touched file (`tests/test_provider_bankr.py` has pre-existing drift on `main`, left alone).
- `mypy src`: only the pre-existing `mem0` stub error.
- Full suite locally: 10454 passed; 3 failures are local-env only (`mem0` installed in venv, PDF renderer `OSError`).
- Smoke: all three c0 defaults resolve to `deepseek-v4.1-flash` with `384000 / 1048576` windows and the expected reasoning format per gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kx3oawSbrgPrkrMeWdH4nF
