### PR TITLE
fix(tools): validate artifact size before reading file into memory (#1760)

### DIFF
--- a/src/agentos/artifacts.py
+++ b/src/agentos/artifacts.py
@@ -19,6 +19,7 @@ ARTIFACT_SESSION_BUCKET = "s"
 ARTIFACT_MATERIAL_NAME = "data"
 DEFAULT_ARTIFACT_MAX_BYTES = 30 * 1024 * 1024
 DEFAULT_ARTIFACT_DISK_BUDGET_BYTES = 512 * 1024 * 1024
+DEFAULT_HASH_CHUNK_BYTES = 64 * 1024
 
 _UNSAFE_FILENAME_RE = re.compile(r'[\x00-\x1f\x7f<>:"/\\|?*]+')
 _SAFE_TOKEN_RE = re.compile(r"[^A-Za-z0-9._-]+")
@@ -135,6 +136,16 @@ def artifact_download_url(artifact_id: str) -> str:
     return f"/api/v1/artifacts/{_validate_artifact_id(artifact_id)}"
 
 
+def file_sha256(path: str | Path, *, chunk_size: int = DEFAULT_HASH_CHUNK_BYTES) -> str:
+    """Compute the SHA-256 hex digest of a file in streaming chunks."""
+    p = Path(path)
+    hasher = hashlib.sha256()
+    with p.open("rb") as f:
+        while chunk := f.read(chunk_size):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
 class ArtifactStore:
     """Session-scoped artifact store rooted outside the web static tree."""
 
@@ -219,12 +230,27 @@ class ArtifactStore:
         max_bytes: int | None = DEFAULT_ARTIFACT_MAX_BYTES,
         disk_budget_bytes: int | None = DEFAULT_ARTIFACT_DISK_BUDGET_BYTES,
     ) -> ArtifactRef:
-        payload = Path(path).read_bytes()
+        target_path = Path(path)
+        file_size = target_path.stat().st_size
+        if file_size == 0:
+            raise ArtifactBudgetError("artifact payload is empty")
+        if max_bytes is not None and file_size > max_bytes:
+            raise ArtifactBudgetError(
+                f"artifact exceeds per-file budget ({file_size} > {max_bytes})"
+            )
+        if disk_budget_bytes is not None:
+            current = self._disk_usage_bytes()
+            if current + file_size > disk_budget_bytes:
+                raise ArtifactBudgetError(
+                    "artifact material exceeds disk budget "
+                    f"({current} + {file_size} > {disk_budget_bytes})"
+                )
+        payload = target_path.read_bytes()
         return self.publish_bytes(
             payload,
             session_id=session_id,
             session_key=session_key,
-            name=name or Path(path).name,
+            name=name or target_path.name,
             mime=mime,
             source=source,
             max_bytes=max_bytes,

--- a/src/agentos/engine/artifact_delivery.py
+++ b/src/agentos/engine/artifact_delivery.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import logging
 import mimetypes
 from dataclasses import dataclass, field
@@ -15,6 +14,7 @@ from agentos.artifacts import (
     ArtifactBudgetError,
     ArtifactStore,
     artifact_payload,
+    file_sha256,
 )
 from agentos.tools.types import ToolContext
 
@@ -111,8 +111,20 @@ def auto_publish_omitted_workspace_artifacts(
         if not _text_mentions_written_file(final_text, record):
             continue
 
+        effective_max_bytes = (
+            ctx.artifact_max_bytes
+            if ctx.artifact_max_bytes is not None
+            else DEFAULT_ARTIFACT_MAX_BYTES
+        )
         try:
-            target_sha256 = hashlib.sha256(target.read_bytes()).hexdigest()
+            file_size = target.stat().st_size
+            if file_size == 0:
+                continue
+            if effective_max_bytes is not None and file_size > effective_max_bytes:
+                raise ArtifactBudgetError(
+                    f"artifact exceeds per-file budget ({file_size} > {effective_max_bytes})"
+                )
+            target_sha256 = file_sha256(target)
             artifact_key = (target_sha256, target.name)
             if artifact_key in known_artifact_keys:
                 continue
@@ -132,9 +144,7 @@ def auto_publish_omitted_workspace_artifacts(
                     name=target.name,
                     mime=artifact_mime,
                     source="auto_publish_omitted",
-                    max_bytes=ctx.artifact_max_bytes
-                    if ctx.artifact_max_bytes is not None
-                    else DEFAULT_ARTIFACT_MAX_BYTES,
+                    max_bytes=effective_max_bytes,
                     disk_budget_bytes=ctx.artifact_disk_budget_bytes
                     if ctx.artifact_disk_budget_bytes is not None
                     else DEFAULT_ARTIFACT_DISK_BUDGET_BYTES,

--- a/src/agentos/tools/builtin/artifacts.py
+++ b/src/agentos/tools/builtin/artifacts.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
 import mimetypes
 import os
@@ -16,6 +15,7 @@ from agentos.artifacts import (
     ArtifactBudgetError,
     ArtifactStore,
     artifact_payload,
+    file_sha256,
 )
 from agentos.tools.path_aliases import resolve_workspace_alias
 from agentos.tools.path_policy import reject_foreign_host_path
@@ -209,7 +209,16 @@ async def publish_artifact(
     if not target.is_file():
         raise ToolError(f"artifact path is not a file: {path}")
 
-    target_sha256 = hashlib.sha256(target.read_bytes()).hexdigest()
+    effective_max_bytes = (
+        ctx.artifact_max_bytes if ctx.artifact_max_bytes is not None else DEFAULT_ARTIFACT_MAX_BYTES
+    )
+    file_size = target.stat().st_size
+    if file_size == 0:
+        raise ToolError("artifact payload is empty")
+    if effective_max_bytes is not None and file_size > effective_max_bytes:
+        raise ToolError(f"artifact exceeds per-file budget ({file_size} > {effective_max_bytes})")
+
+    target_sha256 = file_sha256(target)
     for published in reversed(ctx.published_artifacts):
         if published.get("sha256") != target_sha256:
             continue
@@ -268,9 +277,7 @@ async def publish_artifact(
             name=artifact_name,
             mime=artifact_mime,
             source="publish_artifact",
-            max_bytes=ctx.artifact_max_bytes
-            if ctx.artifact_max_bytes is not None
-            else DEFAULT_ARTIFACT_MAX_BYTES,
+            max_bytes=effective_max_bytes,
             disk_budget_bytes=ctx.artifact_disk_budget_bytes
             if ctx.artifact_disk_budget_bytes is not None
             else DEFAULT_ARTIFACT_DISK_BUDGET_BYTES,

--- a/tests/test_tools/test_publish_artifact_budget.py
+++ b/tests/test_tools/test_publish_artifact_budget.py
@@ -1,0 +1,164 @@
+"""Tests for publish_artifact and artifact size validation before reading (#1760)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agentos.artifacts import (
+    DEFAULT_ARTIFACT_MAX_BYTES,
+    ArtifactBudgetError,
+    ArtifactStore,
+    file_sha256,
+)
+from agentos.engine.artifact_delivery import auto_publish_omitted_workspace_artifacts
+from agentos.tools.builtin.artifacts import publish_artifact
+from agentos.tools.types import ToolContext, ToolError, current_tool_context
+
+
+def test_file_sha256_streaming_matches_hashlib(tmp_path: Path) -> None:
+    test_file = tmp_path / "sample.bin"
+    # Create ~150 KB data (spanning multiple 64 KB chunks)
+    data = b"x" * (150 * 1024)
+    test_file.write_bytes(data)
+
+    import hashlib
+
+    expected_sha = hashlib.sha256(data).hexdigest()
+    assert file_sha256(test_file) == expected_sha
+    assert file_sha256(test_file, chunk_size=32 * 1024) == expected_sha
+
+
+@pytest.mark.asyncio
+async def test_publish_artifact_rejects_oversized_file_without_reading(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    media_root = tmp_path / "media"
+    media_root.mkdir()
+
+    # File exceeding the custom max_bytes budget
+    large_file = workspace / "large.bin"
+    large_file.write_bytes(b"A" * 5000)
+
+    ctx = ToolContext(
+        workspace_dir=str(workspace),
+        artifact_media_root=str(media_root),
+        artifact_session_id="sess-1",
+        session_key="agent:main:main",
+        artifact_max_bytes=1000,
+    )
+    token = current_tool_context.set(ctx)
+    try:
+        with patch.object(Path, "read_bytes") as mock_read_bytes:
+            with pytest.raises(ToolError, match="artifact exceeds per-file budget"):
+                await publish_artifact("large.bin")
+            mock_read_bytes.assert_not_called()
+    finally:
+        current_tool_context.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_publish_artifact_rejects_empty_file_without_reading(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    media_root = tmp_path / "media"
+    media_root.mkdir()
+
+    empty_file = workspace / "empty.bin"
+    empty_file.write_bytes(b"")
+
+    ctx = ToolContext(
+        workspace_dir=str(workspace),
+        artifact_media_root=str(media_root),
+        artifact_session_id="sess-1",
+        session_key="agent:main:main",
+        artifact_max_bytes=1000,
+    )
+    token = current_tool_context.set(ctx)
+    try:
+        with patch.object(Path, "read_bytes") as mock_read_bytes:
+            with pytest.raises(ToolError, match="artifact payload is empty"):
+                await publish_artifact("empty.bin")
+            mock_read_bytes.assert_not_called()
+    finally:
+        current_tool_context.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_publish_artifact_computes_hash_in_chunks_and_publishes(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    media_root = tmp_path / "media"
+    media_root.mkdir()
+
+    # 100 KB file within budget
+    content = b"valid artifact content" * 4000
+    valid_file = workspace / "report.pdf"
+    valid_file.write_bytes(content)
+
+    ctx = ToolContext(
+        workspace_dir=str(workspace),
+        artifact_media_root=str(media_root),
+        artifact_session_id="sess-1",
+        session_key="agent:main:main",
+        artifact_max_bytes=DEFAULT_ARTIFACT_MAX_BYTES,
+    )
+    token = current_tool_context.set(ctx)
+    try:
+        result_json = await publish_artifact("report.pdf")
+        assert '"status": "published"' in result_json
+        assert len(ctx.published_artifacts) == 1
+        assert ctx.published_artifacts[0]["size"] == len(content)
+    finally:
+        current_tool_context.reset(token)
+
+
+def test_artifact_store_publish_file_validates_size_before_reading(tmp_path: Path) -> None:
+    media_root = tmp_path / "media"
+    store = ArtifactStore(media_root)
+
+    oversized_file = tmp_path / "oversized.bin"
+    oversized_file.write_bytes(b"B" * 10000)
+
+    with patch.object(Path, "read_bytes") as mock_read_bytes:
+        with pytest.raises(ArtifactBudgetError, match="artifact exceeds per-file budget"):
+            store.publish_file(
+                oversized_file,
+                session_id="sess-1",
+                session_key="agent:main:main",
+                source="test",
+                max_bytes=2000,
+            )
+        mock_read_bytes.assert_not_called()
+
+
+def test_auto_publish_omitted_workspace_artifacts_validates_size_before_reading(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    media_root = tmp_path / "media"
+    media_root.mkdir()
+
+    oversized_file = workspace / "large.pdf"
+    oversized_file.write_bytes(b"C" * 10000)
+
+    ctx = ToolContext(
+        workspace_dir=str(workspace),
+        artifact_media_root=str(media_root),
+        artifact_session_id="sess-1",
+        session_key="agent:main:main",
+        artifact_max_bytes=1000,
+        workspace_file_writes=[{"path": str(oversized_file), "name": "large.pdf"}],
+    )
+
+    with patch.object(Path, "read_bytes") as mock_read_bytes:
+        result = auto_publish_omitted_workspace_artifacts(
+            ctx,
+            final_text="I have generated the file large.pdf for you.",
+        )
+        mock_read_bytes.assert_not_called()
+        assert len(result.artifacts) == 0
+        assert any("artifact exceeds per-file budget" in err for err in result.failure_summaries)


### PR DESCRIPTION
### Summary

Fixes #1760.

Previously, `publish_artifact` called `target.read_bytes()` to compute a SHA-256 hash before `store.publish_file` or `publish_bytes` performed size validation. Attempting to publish large files (e.g. multi-gigabyte datasets) would load the entire payload into the gateway process memory simultaneously, causing high memory spikes, latency, or `MemoryError`.

Similarly, `auto_publish_omitted_workspace_artifacts` and `ArtifactStore.publish_file` called `read_bytes()` prior to checking `max_bytes` or disk budget limits.

### Changes

- **Streaming SHA-256 hashing**: Added `file_sha256(path, *, chunk_size=64*1024)` in `src/agentos/artifacts.py` to stream files in 64 KB chunks rather than reading entire files into RAM.
- **Early size checks in `publish_artifact`**: In `src/agentos/tools/builtin/artifacts.py`, checks `target.stat().st_size` against `effective_max_bytes` (and rejects 0-byte empty payloads) before computing hashes or publishing.
- **Early budget validation in `ArtifactStore.publish_file`**: Validates `st_size == 0`, `st_size > max_bytes`, and `st_size + current > disk_budget_bytes` before loading `target_path.read_bytes()`.
- **Early size checks in `auto_publish_omitted_workspace_artifacts`**: Validates file size against `effective_max_bytes` before chunked hashing and publication.
- **Regression tests**: Added tests in `tests/test_tools/test_publish_artifact_budget.py` asserting that oversized/empty files are rejected without invoking `read_bytes()`, and that streaming hash matches `hashlib.sha256`.

### Verification

- `uv run ruff check` & `uv run ruff format --check`: Passed
- `uv run mypy src/agentos/artifacts.py src/agentos/tools/builtin/artifacts.py src/agentos/engine/artifact_delivery.py --show-error-codes`: Passed
- `uv run pytest tests/test_tools/test_publish_artifact_budget.py`: 6 passed
- `uv run pytest tests/test_artifacts.py tests/test_tools/test_inline_artifacts.py tests/test_gateway/test_artifacts_download.py`: 42 passed
