### PR TITLE
fix(mcp): events_wait no longer conflates hitting max_events with a r…

### DIFF
--- a/src/agentos/mcp_server/bridge.py
+++ b/src/agentos/mcp_server/bridge.py
@@ -160,15 +160,18 @@ class AgentOSMCPBridge:
             timeout_s = timeout_ms / 1000
             deadline = time.monotonic() + timeout_s
 
+            timed_out = False
             while len(events) < max_events:
                 # Re-clamp: on coarse clocks ``deadline - now`` can round a hair
                 # above ``timeout_s``, handing ``recv_event`` more than the cap.
                 remaining = min(deadline - time.monotonic(), timeout_s)
                 if remaining <= 0:
+                    timed_out = True
                     break
                 try:
                     frame = await client.recv_event(timeout=remaining)
                 except TimeoutError:
+                    timed_out = True
                     break
                 normalized = _normalize_event_frame(frame)
                 payload = normalized.get("payload")
@@ -190,7 +193,12 @@ class AgentOSMCPBridge:
                 "current_stream_seq": current_stream_seq,
                 "replay_complete": subscription.get("replay_complete"),
                 "replay_gap_reason": subscription.get("replay_gap_reason"),
-                "timed_out": not events or (events[-1]["event"] not in _TERMINAL_EVENTS),
+                # Deadline expiry (or a hard recv_event TimeoutError) is the only
+                # thing this reports -- not "no events collected" and not "the
+                # max_events cap was reached", both of which are simply the
+                # loop's other, non-terminal exit path and say nothing about
+                # whether more events were still coming.
+                "timed_out": timed_out,
             }
         finally:
             await client.close()

--- a/tests/test_mcp_server/test_bridge.py
+++ b/tests/test_mcp_server/test_bridge.py
@@ -411,3 +411,36 @@ async def test_events_wait_preserves_max_events_below_the_cap() -> None:
     result = await bridge.events_wait("agent:main:main", timeout_ms=200, max_events=2)
 
     assert len(result["events"]) == 2
+    # Regression for #1798: hitting the max_events cap is a successful call,
+    # not a timeout -- the collected events arrived well within the budget.
+    assert result["timed_out"] is False
+
+
+class TimeoutRaisingEventClient(FakeGatewayClient):
+    """Fake client whose recv_event always raises TimeoutError immediately."""
+
+    async def recv_event(self, timeout: float | None = None) -> dict[str, Any]:
+        raise TimeoutError
+
+
+@pytest.mark.asyncio
+async def test_events_wait_reports_timed_out_on_genuine_deadline_expiry() -> None:
+    """A real timeout -- recv_event exhausting its deadline with no terminal
+    event seen -- must still report timed_out: True."""
+    client = TimeoutRaisingEventClient()
+    bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)
+
+    result = await bridge.events_wait("agent:main:main", timeout_ms=50, max_events=5)
+
+    assert result["events"] == []
+    assert result["timed_out"] is True
+
+
+@pytest.mark.asyncio
+async def test_events_wait_terminal_event_is_not_a_timeout() -> None:
+    client = RecordingEventClient()
+    bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)
+
+    result = await bridge.events_wait("agent:main:main", timeout_ms=2_000)
+
+    assert result["timed_out"] is False


### PR DESCRIPTION
Summary

events_wait derived timed_out purely from whether the last collected event happened to be terminal (events[-1]["event"] not in _TERMINAL_EVENTS). That conflates three distinct loop exits — genuine deadline expiry, a terminal event seen, and the max_events cap being reached — and only the terminal-event path produces a terminal last event. A perfectly successful call that simply collected max_events non-terminal events before the deadline was misreported identically to a real timeout, which the default max_events=100 makes easy to hit on a long-running session, and easy for an MCP client to misdiagnose as stalled.
events_wait now tracks timed_out as an explicit flag, set only at the loop's two genuine timeout exits (deadline exhausted, or a recv_event TimeoutError) — never derived from the shape of the last collected event.
Test plan

Extended test_events_wait_preserves_max_events_below_the_cap to assert timed_out is False (the issue's exact reproduction).
Added test_events_wait_reports_timed_out_on_genuine_deadline_expiry and test_events_wait_terminal_event_is_not_a_timeout to guard the two paths that must still behave correctly.
Verified via stash that the extended test fails pre-fix (True vs expected False) and all pass post-fix.
ruff/mypy clean. Full tests/test_mcp_server/ suite: 32 passed, 1 unrelated pre-existing failure (test_protocol_smoke.py, a jsonschema_specifications package file corrupted during an unrelated .venv rebuild in this worktree — confirmed unrelated to bridge.py/events_wait).
Fixes #1798 