### PR TITLE
fix(sandbox): resolve relative destructive targets against cwd, not the workspace

### DIFF
--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -493,17 +493,39 @@ def sensitive_target_in_command(
         return None
     from agentos.sandbox.intent_cache import _extract_intents
 
-    effective_workspace = workspace
-    if effective_workspace is None:
-        effective_workspace = cwd if cwd is not None else Path.cwd()
+    # Two different notions: ``cwd`` is what a relative target resolves
+    # against (the directory the command executes in), ``workspace`` is what
+    # "inside the workspace" is measured against. Collapsing them made ``rm
+    # -rf config`` in ``~/.aws`` look like ``<workspace>/config``.
+    base_dir = _resolve_command_cwd(cwd, workspace)
+    # With no configured workspace, the execution directory is the only
+    # boundary there is -- the ``/root`` container exception hangs off it.
+    effective_workspace = workspace if workspace is not None else base_dir
 
-    for _kind, target in _extract_intents(command, base_dir=effective_workspace):
+    for _kind, target in _extract_intents(command, base_dir=base_dir):
         if _is_root_target(target):
             return _ROOT_TARGET_MARKER
         marker = sensitive_path_marker(target, workspace=effective_workspace)
         if marker is not None:
             return marker
     return None
+
+
+def _resolve_command_cwd(cwd: str | Path | None, workspace: str | Path | None) -> Path:
+    """Directory a command's relative targets resolve against.
+
+    Mirrors ``shell._effective_workdir``: an absolute ``cwd`` is taken as
+    given, a relative one is anchored to the workspace, and with neither the
+    workspace itself (or, failing that, the process cwd) is the anchor.
+    """
+    if cwd is not None:
+        raw = Path(cwd).expanduser()
+        if raw.is_absolute() or workspace is None:
+            return raw
+        return Path(workspace).expanduser() / raw
+    if workspace is not None:
+        return Path(workspace).expanduser()
+    return Path.cwd()
 
 
 def build_block_envelope(

--- a/tests/test_sandbox/test_sensitive_paths.py
+++ b/tests/test_sandbox/test_sensitive_paths.py
@@ -494,3 +494,155 @@ def test_env_var_and_tilde_spellings_report_the_same_marker(
 
     assert tilde == f"~/{name}"
     assert expanded == tilde
+
+
+# --- Issue #1579: relative destructive targets resolve against cwd ------------
+#
+# ``workspace`` is the boundary "inside the workspace" is measured against;
+# ``cwd`` is the directory the command actually executes in. A relative
+# ``rm`` target must resolve against the latter, otherwise a command running
+# in ``~/.aws`` looks like it is deleting ``<workspace>/config``.
+
+
+def test_relative_target_resolves_against_cwd_not_workspace(fixed_home: Path) -> None:
+    workspace = Path("/tmp/workspace")
+
+    assert (
+        sensitive_target_in_command(
+            "rm -rf config",
+            workspace=workspace,
+            cwd=fixed_home / ".aws",
+        )
+        == "~/.aws"
+    )
+    assert (
+        sensitive_target_in_command(
+            "rm -rf .aws/config",
+            workspace=workspace,
+            cwd=fixed_home,
+        )
+        == "~/.aws"
+    )
+    assert (
+        sensitive_target_in_command(
+            "shutil.rmtree('config')",
+            workspace=workspace,
+            cwd=fixed_home / ".aws",
+        )
+        == "~/.aws"
+    )
+
+
+def test_parent_traversal_from_cwd_reaches_sensitive_paths(fixed_home: Path) -> None:
+    workspace = Path("/tmp/workspace")
+
+    assert (
+        sensitive_target_in_command(
+            "rm -rf ../.ssh",
+            workspace=workspace,
+            cwd=fixed_home / "project",
+        )
+        == "~/.ssh"
+    )
+    assert (
+        sensitive_target_in_command(
+            "rm -rf ../../../etc/ssl",
+            workspace=workspace,
+            cwd=workspace / "nested",
+        )
+        == "/etc"
+    )
+
+
+def test_tilde_cwd_is_expanded_before_resolving_targets(fixed_home: Path) -> None:
+    assert (
+        sensitive_target_in_command(
+            "rm -rf credentials",
+            workspace="/tmp/workspace",
+            cwd="~/.aws",
+        )
+        == "~/.aws"
+    )
+
+
+def test_relative_cwd_resolves_against_workspace(fixed_home: Path) -> None:
+    """A relative ``cwd`` is itself relative to the workspace, mirroring
+    ``shell._effective_workdir``; it must not be joined onto the process cwd."""
+    workspace = Path("/tmp/workspace")
+
+    assert (
+        sensitive_target_in_command("rm -rf build", workspace=workspace, cwd="packages/app") is None
+    )
+    assert sensitive_target_in_command("rm -rf .env", workspace=workspace, cwd="packages/app") in {
+        "/.env",
+        "/.env*",
+    }
+
+
+def test_in_workspace_cwd_keeps_ordinary_work_allowed(fixed_home: Path) -> None:
+    """Regression guard: the fix must not start blocking benign in-workspace
+    deletes just because the command runs in a subdirectory."""
+    workspace = Path("/tmp/workspace")
+
+    for command in (
+        "rm -rf build",
+        "rm -rf ./dist node_modules",
+        "rm -f ../scratch.txt",
+        "shutil.rmtree('build')",
+    ):
+        assert (
+            sensitive_target_in_command(
+                command,
+                workspace=workspace,
+                cwd=workspace / "packages" / "app",
+            )
+            is None
+        ), command
+
+
+def test_workspace_exception_is_measured_against_workspace_not_cwd() -> None:
+    """The ``/root`` exception for a container workspace still applies when the
+    command runs in a subdirectory of that workspace, and still does *not*
+    apply when cwd escapes it."""
+    workspace = Path("/root/.agentos/workspace")
+
+    assert (
+        sensitive_target_in_command(
+            "rm scratch.txt",
+            workspace=workspace,
+            cwd=workspace / "sub",
+        )
+        is None
+    )
+    assert (
+        sensitive_target_in_command(
+            "rm -rf ../../.bashrc",
+            workspace=workspace,
+            cwd=workspace / "sub",
+        )
+        == "/root"
+    )
+    assert (
+        sensitive_target_in_command(
+            "rm -rf .agentos",
+            workspace=workspace,
+            cwd=Path("/root"),
+        )
+        == "/root"
+    )
+
+
+def test_relative_targets_resolve_against_workspace_when_cwd_is_absent() -> None:
+    workspace = Path("/root/.agentos/workspace")
+
+    assert sensitive_target_in_command("rm scratch.txt", workspace=workspace) is None
+    assert sensitive_target_in_command("rm -rf ../../.bashrc", workspace=workspace) == "/root"
+
+
+def test_cwd_alone_still_anchors_relative_targets(fixed_home: Path) -> None:
+    """With no workspace configured the execution directory is the only
+    anchor we have, for both the target and the boundary."""
+    assert sensitive_target_in_command("rm -rf config", cwd=fixed_home / ".aws") == "~/.aws"
+    assert (
+        sensitive_target_in_command("rm scratch.txt", cwd=Path("/root/.agentos/workspace")) is None
+    )

--- a/tests/test_tools/test_shell_approval_policy.py
+++ b/tests/test_tools/test_shell_approval_policy.py
@@ -1013,6 +1013,49 @@ async def test_root_wipe_is_hard_blocked_at_the_exec_approval_boundary() -> None
         assert result["sensitive_path"] == "/"
 
 
+@pytest.mark.asyncio
+async def test_relative_delete_target_resolves_against_workdir_at_the_exec_boundary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Issue #1579 at the real entry point: ``exec_command`` passes both the
+    workspace and the resolved workdir, which was exactly the case where the
+    workdir got discarded. ``rm -rf .aws/config`` run from ``$HOME`` must be
+    hard-blocked, and the same command run inside the workspace must not be."""
+    home = tmp_path / "home"
+    (home / ".aws").mkdir(parents=True)
+    workspace = tmp_path / "workspace"
+    (workspace / "packages" / "app").mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.workspace_dir = str(workspace)
+    ctx.elevated = "bypass"
+
+    blocked = await shell._check_exec_approval(
+        "exec_command",
+        "rm -rf .aws/config",
+        str(home),
+        "command requires approval",
+        None,
+        False,
+    )
+    assert blocked is not None
+    assert blocked["status"] == "blocked"
+    assert blocked["reason"] == "sensitive_path"
+    assert blocked["sensitive_path"] == "~/.aws"
+
+    allowed = await shell._check_exec_approval(
+        "exec_command",
+        "rm -rf build",
+        str(workspace / "packages" / "app"),
+        "command requires approval",
+        None,
+        False,
+    )
+    assert allowed is None
+
+
 def test_sandbox_request_for_resolves_relative_workdir(tmp_path: Path) -> None:
     """Relative workdir in _sandbox_request_for must resolve against workspace (#1562)."""
     ws = tmp_path / "ws"


### PR DESCRIPTION
## Summary

Fixes #1579.

`sensitive_target_in_command` conflated the workspace boundary with the command's execution directory: whenever `workspace` was passed, `cwd` was discarded and `_extract_intents` normalised relative targets against the workspace root. `exec_command` passes both (`shell.py` `_check_exec_approval`), which is exactly the case where `cwd` was ignored, so `rm -rf config` run with `workdir=~/.aws` resolved to `<workspace>/config`, matched no sensitive basename, and the hard block that "ordinary approval cannot override" never fired.

Reproduced at the real tool boundary before the change. The reported case (`workdir=~/.aws`) is caught by the whole-text scan in `_sensitive_shell_block`, which prepends the workdir literal — but these two are not:

| command | workdir | intent scan | text scan |
|---|---|---|---|
| `rm -rf config` | `~/.aws` | None | `~/.aws` (workdir literal) |
| `rm -rf .aws/config` | `~` | None | None |
| `rm -rf ../.ssh` | `~/project` | None | None |

## Change

Per the triage note, the two notions are kept separate:

- `cwd` is what a relative target resolves against. A relative `cwd` is itself anchored to the workspace, mirroring `shell._effective_workdir`.
- `workspace` is what "inside the workspace" is measured against, and that comparison is **not** tightened.
- With no workspace configured the execution directory remains the only boundary there is, so the `/root` container exception keeps working for that case exactly as before.

## Tests

- New cases in `tests/test_sandbox/test_sensitive_paths.py`: the three rows above, tilde expansion of `cwd`, a relative `cwd` anchored to the workspace, the `/root` exception measured against the workspace rather than the cwd, and the pre-existing `cwd=None` / `workspace=None` contracts.
- Benign regression guards that must stay **allowed**: `rm -rf build`, `rm -rf ./dist node_modules`, `rm -f ../scratch.txt`, `shutil.rmtree('build')` under an in-workspace workdir.
- A boundary test in `tests/test_tools/test_shell_approval_policy.py` through `_check_exec_approval` with both `workspace` and `workdir` set: `rm -rf .aws/config` from `$HOME` is blocked with `~/.aws`; `rm -rf build` inside the workspace is not.

Note: `sensitive_paths.py` and the test module are not `ruff format`-clean on `main`; the added hunks are format-clean on their own and the surrounding code was deliberately left untouched to keep the diff reviewable.

## Merge safety

This PR is one of five opened together (#1579, #1580, #1595, #1598, #1600). Each touches a disjoint set of files and none touches `CHANGELOG.md`, so they can be merged one by one in any order; all 120 orderings were verified conflict-free against `upstream/main`, and the fully merged tree passes the complete gate (ruff, mypy, full pytest). Happy to follow up with a single `docs(changelog)` PR recording the batch once they land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrT2hZdMcL98BWVTX8oZB1
