### PR TITLE
fix(tools): parse CSV cells over the 128 KB field limit in read_spreadsheet

### DIFF
--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -11,6 +11,7 @@ import json
 import os
 import posixpath
 import re
+import threading
 import zipfile
 from pathlib import Path
 from xml.etree import ElementTree as ET
@@ -594,9 +595,43 @@ def _read_delimited_rows(path: Path, delimiter: str) -> list[tuple[str, dict[int
         text = path.read_text(encoding="utf-8-sig")
     except UnicodeDecodeError as exc:
         raise ToolError(f"Cannot read spreadsheet as UTF-8 text: {path}") from exc
-    parsed = [list(row) for row in csv.reader(io.StringIO(text), delimiter=delimiter)]
+    try:
+        parsed = _parse_delimited_text(text, delimiter)
+    except csv.Error as exc:
+        raise ToolError(f"Cannot parse {path.name} as delimited text: {exc}") from exc
     rows = dict(enumerate(parsed, start=1))
     return [(path.name, rows, len(parsed))]
+
+
+# ``csv.field_size_limit`` is process-global and spreadsheet reads run on
+# executor threads. Every parse takes this lock, not just the ones that raise
+# the limit: a small read that checked the limit outside it could see a
+# neighbour's temporary raise, skip the lock, and then fail when that
+# neighbour restores the default mid-parse.
+_CSV_FIELD_LIMIT_LOCK = threading.Lock()
+
+
+def _parse_delimited_text(text: str, delimiter: str) -> list[list[str]]:
+    """Parse *text* with the field limit raised just far enough for it.
+
+    ``csv.reader`` refuses any single cell over ``csv.field_size_limit()``
+    (128 KB by default), which one embedded JSON blob or base64 column trips.
+    A cell can never be longer than the text it lives in, so the limit is
+    raised to the text's own length rather than ``sys.maxsize`` -- a
+    malformed quote can then absorb at most this file, which is already in
+    memory -- and it is restored as soon as the parse ends.
+    """
+    needed = len(text) + 1
+    with _CSV_FIELD_LIMIT_LOCK:
+        previous = csv.field_size_limit()
+        raised = needed > previous
+        if raised:
+            csv.field_size_limit(needed)
+        try:
+            return [list(row) for row in csv.reader(io.StringIO(text), delimiter=delimiter)]
+        finally:
+            if raised:
+                csv.field_size_limit(previous)
 
 
 def _read_xlsx_sheets(path: Path) -> list[tuple[str, dict[int, list[str]], int]]:

--- a/tests/test_tools/test_csv_large_fields.py
+++ b/tests/test_tools/test_csv_large_fields.py
@@ -1,0 +1,171 @@
+"""Issue #1580: a CSV cell over ``csv.field_size_limit()`` must not escape
+``read_spreadsheet`` as a raw ``_csv.Error``.
+
+The limit is process-global, so the fix raises it only as far as the file's
+own length, only for the duration of the parse, and puts it back afterwards
+-- another CSV consumer in the same process must never observe a changed
+default once the read is over.
+"""
+
+from __future__ import annotations
+
+import csv
+import threading
+from pathlib import Path
+
+import pytest
+
+from agentos.tools.builtin.filesystem import _read_delimited_rows, read_spreadsheet
+from agentos.tools.types import ToolError
+
+_DEFAULT_LIMIT = 131072
+
+
+@pytest.fixture(autouse=True)
+def _default_field_limit():
+    """Pin the process-wide limit so the restore assertions are meaningful."""
+    previous = csv.field_size_limit(_DEFAULT_LIMIT)
+    yield
+    csv.field_size_limit(previous)
+
+
+def _write_large_field_csv(path: Path, cell_len: int) -> str:
+    payload = "A" * cell_len
+    path.write_text("id,payload\n1," + payload + "\n", encoding="utf-8")
+    return payload
+
+
+def test_field_over_the_default_limit_is_parsed(tmp_path: Path) -> None:
+    csv_file = tmp_path / "large_field.csv"
+    payload = _write_large_field_csv(csv_file, _DEFAULT_LIMIT + 1)
+
+    [(_, rows, total)] = _read_delimited_rows(csv_file, ",")
+
+    assert total == 2
+    assert rows[1] == ["id", "payload"]
+    assert rows[2] == ["1", payload]
+
+
+def test_quoted_multiline_field_over_the_limit_is_parsed(tmp_path: Path) -> None:
+    """Embedded JSON / log blobs are the realistic trigger: quoted, with
+    newlines and delimiters inside."""
+    csv_file = tmp_path / "blob.csv"
+    body = ('{"k": "v",\n' * ((_DEFAULT_LIMIT // 10) + 1)) + "}"
+    quoted = body.replace('"', '""')
+    csv_file.write_text('id,blob\n1,"' + quoted + '"\n', encoding="utf-8")
+
+    [(_, rows, total)] = _read_delimited_rows(csv_file, ",")
+
+    assert total == 2
+    assert rows[2] == ["1", body]
+
+
+@pytest.mark.asyncio
+async def test_read_spreadsheet_tool_returns_the_large_cell(tmp_path: Path) -> None:
+    """The exact reproduction from the report, through the tool boundary."""
+    csv_file = tmp_path / "large_field.csv"
+    payload = _write_large_field_csv(csv_file, _DEFAULT_LIMIT + 1)
+
+    out = await read_spreadsheet(str(csv_file))
+
+    assert "Sheet: large_field.csv (2 rows x 2 columns)" in out
+    assert f"2\t1\t{payload}" in out
+
+
+def test_process_wide_limit_is_restored_after_the_read(tmp_path: Path) -> None:
+    csv_file = tmp_path / "large_field.csv"
+    _write_large_field_csv(csv_file, _DEFAULT_LIMIT + 1)
+
+    _read_delimited_rows(csv_file, ",")
+
+    assert csv.field_size_limit() == _DEFAULT_LIMIT
+
+
+def test_process_wide_limit_is_restored_after_a_parse_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    csv_file = tmp_path / "large_field.csv"
+    _write_large_field_csv(csv_file, _DEFAULT_LIMIT + 1)
+
+    def _boom(*_args: object, **_kwargs: object):
+        raise csv.Error("boom")
+
+    monkeypatch.setattr(csv, "reader", _boom)
+
+    with pytest.raises(ToolError, match="Cannot parse large_field.csv"):
+        _read_delimited_rows(csv_file, ",")
+    assert csv.field_size_limit() == _DEFAULT_LIMIT
+
+
+def test_small_files_never_touch_the_process_wide_limit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Below the default there is nothing to raise; the common path never
+    mutates the process-wide value."""
+    csv_file = tmp_path / "small.csv"
+    csv_file.write_text("a,b\n1,2\n", encoding="utf-8")
+    calls: list[int] = []
+    real = csv.field_size_limit
+
+    def _spy(*args: int) -> int:
+        if args:
+            calls.append(args[0])
+        return real(*args)
+
+    monkeypatch.setattr(csv, "field_size_limit", _spy)
+
+    [(_, rows, _)] = _read_delimited_rows(csv_file, ",")
+
+    assert rows[2] == ["1", "2"]
+    assert calls == []
+
+
+def test_limit_is_capped_at_the_file_length_not_sys_maxsize(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    csv_file = tmp_path / "large_field.csv"
+    _write_large_field_csv(csv_file, _DEFAULT_LIMIT + 1)
+    size = len(csv_file.read_text(encoding="utf-8-sig"))
+    seen: list[int] = []
+    real = csv.field_size_limit
+
+    def _spy(*args: int) -> int:
+        if args:
+            seen.append(args[0])
+        return real(*args)
+
+    monkeypatch.setattr(csv, "field_size_limit", _spy)
+
+    _read_delimited_rows(csv_file, ",")
+
+    assert seen, "expected the limit to be raised for an over-limit field"
+    assert max(seen) <= size + 1
+
+
+def test_concurrent_large_reads_restore_the_default(tmp_path: Path) -> None:
+    """Executor threads read spreadsheets concurrently; two raise/restore
+    pairs racing each other must not leave the limit raised or drop it
+    under a parse still in flight."""
+    files = []
+    for i in range(4):
+        f = tmp_path / f"large_{i}.csv"
+        _write_large_field_csv(f, _DEFAULT_LIMIT + 1 + i)
+        files.append(f)
+    errors: list[BaseException] = []
+
+    def _worker(path: Path) -> None:
+        try:
+            for _ in range(5):
+                [(_, rows, _)] = _read_delimited_rows(path, ",")
+                assert len(rows[2][1]) > _DEFAULT_LIMIT
+        except BaseException as exc:  # surfaced below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_worker, args=(f,)) for f in files]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == []
+    assert csv.field_size_limit() == _DEFAULT_LIMIT


### PR DESCRIPTION
## Summary

Fixes #1580.

`_read_delimited_rows` handed the text to `csv.reader` with Python's default `field_size_limit` (131072) and caught only `UnicodeDecodeError`, so a single cell over 128 KB — an embedded JSON blob, log line or base64 column — escaped `read_spreadsheet` as a raw `_csv.Error` traceback instead of a `ToolError`.

## Change

Following the triage guidance (`csv.field_size_limit()` is process-global; don't raise it at import or to `sys.maxsize`; cap against the file):

- The parse runs with the limit raised to `len(text) + 1` — a cell can never be longer than the text it lives in, so a malformed quote can absorb at most this file, which is already in memory — and the previous value is restored in a `finally` as soon as the parse ends.
- Every parse takes one lock. Spreadsheet reads run on executor threads, and a small read that checked the limit *outside* the lock could observe a neighbour's temporary raise, skip the lock, and then fail when that neighbour restored the default mid-parse. Reads that don't need a raise never mutate the global at all.
- Any other `csv.Error` is surfaced as `ToolError("Cannot parse <file> as delimited text: ...")`.

## Tests

`tests/test_tools/test_csv_large_fields.py`: the exact reproduction (131073-char cell) through both `_read_delimited_rows` and the `read_spreadsheet` tool; a quoted multiline blob over the limit; the process-wide limit restored after a successful read and after a parse error; small files never touching the global; the raised value capped at the file length; and four threads doing over-limit reads concurrently with the default intact afterwards.

## Merge safety

This PR is one of five opened together (#1579, #1580, #1595, #1598, #1600). Each touches a disjoint set of files and none touches `CHANGELOG.md`, so they can be merged one by one in any order; all 120 orderings were verified conflict-free against `upstream/main`, and the fully merged tree passes the complete gate (ruff, mypy, full pytest). Happy to follow up with a single `docs(changelog)` PR recording the batch once they land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrT2hZdMcL98BWVTX8oZB1
