### PR TITLE
fix(sandbox): resolve a relative cwd against the workspace in gate_action

### DIFF
--- a/src/agentos/sandbox/integration.py
+++ b/src/agentos/sandbox/integration.py
@@ -257,10 +257,26 @@ def _resolve_session_id(runtime: SandboxRuntime, session_id: str | None) -> str:
 
 
 def _resolve_workspace(runtime: SandboxRuntime, cwd: str | None) -> Path:
+    """Directory the gated action runs in, always absolute.
+
+    A relative ``cwd`` is joined onto the workspace root, mirroring
+    ``shell._effective_workdir``. It used to be discarded outright, so every
+    relative ``workdir`` collapsed onto the root and -- because
+    :func:`action_fingerprint` hashes ``cwd`` -- two unrelated
+    subdirectories shared one fingerprint. For tools with a fixed
+    ``argv_factory`` that made a denial in one directory auto-deny the next
+    directory as ``REPEATED_SAME_INTENT`` (#1595).
+    """
+    root = _workspace_root(runtime)
     if cwd:
-        p = Path(cwd)
+        p = Path(cwd).expanduser()
         if p.is_absolute():
             return p
+        return root / p
+    return root
+
+
+def _workspace_root(runtime: SandboxRuntime) -> Path:
     try:
         from agentos.tools.types import current_tool_context
 

--- a/tests/test_sandbox/test_gate_action_relative_cwd.py
+++ b/tests/test_sandbox/test_gate_action_relative_cwd.py
@@ -1,0 +1,131 @@
+"""Issue #1595: a relative ``cwd`` must resolve against the workspace root.
+
+``_resolve_workspace`` used to accept ``cwd`` only when it was already
+absolute and otherwise fell through to the workspace root, so every relative
+``workdir`` collapsed onto one path. ``action_fingerprint`` hashes ``cwd``, and
+for tools with a fixed ``argv_factory`` (``git_status``) it is the *only*
+discriminator -- so a human denial in ``repoA`` made ``post_denial_guard``
+auto-deny a never-reviewed call in ``repoB`` as ``REPEATED_SAME_INTENT``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agentos.sandbox.config import SandboxSettings
+from agentos.sandbox.governance import DenialReason, DenialResult, action_fingerprint
+from agentos.sandbox.integration import (
+    _resolve_workspace,
+    configure_runtime,
+    gate_action,
+    reset_runtime,
+)
+from agentos.tools.types import ToolContext, current_tool_context
+
+_ARGV = ("git", "status", "--short", "--branch")
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    reset_runtime()
+    configure_runtime(SandboxSettings(sandbox=False, denial_threshold=10), workspace=ws)
+    token = current_tool_context.set(
+        ToolContext(workspace_dir=str(ws), session_key="agent:main:test")
+    )
+    yield ws
+    current_tool_context.reset(token)
+    reset_runtime()
+
+
+def test_relative_cwd_is_joined_onto_the_workspace(workspace: Path) -> None:
+    from agentos.sandbox.integration import get_runtime
+
+    rt = get_runtime()
+    assert rt is not None
+
+    assert _resolve_workspace(rt, "repoA") == workspace / "repoA"
+    assert _resolve_workspace(rt, "repoB") == workspace / "repoB"
+    assert _resolve_workspace(rt, "nested/deeper") == workspace / "nested" / "deeper"
+    # The pre-existing contracts are untouched.
+    assert _resolve_workspace(rt, None) == workspace
+    assert _resolve_workspace(rt, "") == workspace
+    assert _resolve_workspace(rt, str(workspace / "abs")) == workspace / "abs"
+
+
+def test_relative_cwd_prefers_the_tool_context_over_the_runtime(
+    workspace: Path, tmp_path: Path
+) -> None:
+    """The context's workspace is what ``shell._effective_workdir`` anchors
+    on; the runtime workspace is only the fallback when no context is set."""
+    from agentos.sandbox.integration import get_runtime
+
+    rt = get_runtime()
+    assert rt is not None
+    other = tmp_path / "other"
+    token = current_tool_context.set(ToolContext(workspace_dir=str(other)))
+    try:
+        assert _resolve_workspace(rt, "repoA") == other / "repoA"
+    finally:
+        current_tool_context.reset(token)
+
+    token = current_tool_context.set(ToolContext(workspace_dir=None))
+    try:
+        assert _resolve_workspace(rt, "repoA") == workspace / "repoA"
+    finally:
+        current_tool_context.reset(token)
+
+
+def test_tilde_cwd_is_expanded(workspace: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from agentos.sandbox.integration import get_runtime
+
+    home = workspace.parent / "home"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    rt = get_runtime()
+    assert rt is not None
+
+    assert _resolve_workspace(rt, "~/repo") == home / "repo"
+
+
+@pytest.mark.asyncio
+async def test_different_relative_workdirs_produce_different_fingerprints(
+    workspace: Path,
+) -> None:
+    _, _, req_a = await gate_action(action_kind="git_status", argv=_ARGV, cwd=Path("repoA"))
+    _, _, req_b = await gate_action(action_kind="git_status", argv=_ARGV, cwd=Path("repoB"))
+
+    assert req_a.cwd == workspace / "repoA"
+    assert req_b.cwd == workspace / "repoB"
+    assert action_fingerprint(req_a) != action_fingerprint(req_b)
+
+
+@pytest.mark.asyncio
+async def test_denial_in_one_relative_workdir_does_not_block_another(workspace: Path) -> None:
+    """The reported false positive: deny ``repoA``, and the never-reviewed
+    ``repoB`` call must reach the gate as a fresh intent. A genuine blind
+    retry of ``repoA`` is still caught."""
+    from agentos.sandbox.integration import get_runtime
+
+    rt = get_runtime()
+    assert rt is not None
+    session = "agent:main:test"
+
+    _, _, req_a = await gate_action(
+        action_kind="git_status", argv=_ARGV, cwd=Path("repoA"), session_id=session
+    )
+    await rt.ledger.record_denial(session, action_fingerprint(req_a), DenialReason.HUMAN_REJECTED)
+
+    decision_b, _, _ = await gate_action(
+        action_kind="git_status", argv=_ARGV, cwd=Path("repoB"), session_id=session
+    )
+    assert not isinstance(decision_b, DenialResult)
+
+    decision_a, _, _ = await gate_action(
+        action_kind="git_status", argv=_ARGV, cwd=Path("repoA"), session_id=session
+    )
+    assert isinstance(decision_a, DenialResult)
+    assert decision_a.reason is DenialReason.REPEATED_SAME_INTENT


### PR DESCRIPTION
## Summary

Fixes #1595.

`_resolve_workspace` accepted `cwd` only when it was already absolute and otherwise discarded it, falling through to the workspace root. `gate_action` passes that value into `build_request(cwd=...)` and `action_fingerprint` hashes `cwd` ("a different working directory is a different action"), so every relative `workdir` collapsed onto one fingerprint. For `@sandboxed` tools whose `argv_factory` is fixed or path-only (`git_status`), `cwd` is the only discriminator — which made `post_denial_guard` auto-deny a `repoB` call as `REPEATED_SAME_INTENT` right after the human denied `repoA`, a request the human never saw.

## Change

A relative `cwd` is now joined onto the workspace root (tool-context workspace first, then the runtime workspace, then the process cwd — the same precedence the function already used for its fallback), mirroring `shell._effective_workdir`. Absolute paths and the no-`cwd` fallback are unchanged. The join is lexical: an absolute cwd is already passed through without `resolve()`, and `build_policy` deliberately avoids symlink expansion.

As the triage note says, #1510 (`_sandbox_request_for`) and #1566 (`git._effective_workdir`) already landed on `main`; this is the remaining call site.

## Tests

`tests/test_sandbox/test_gate_action_relative_cwd.py`: `_resolve_workspace` for relative / nested / absolute / empty / `~` cwds and the context-vs-runtime precedence; two `gate_action` calls with the fixed `git status` argv in `repoA` and `repoB` producing distinct `request.cwd` and fingerprints; and the reported scenario end to end through the runtime ledger — deny `repoA`, `repoB` is allowed, a blind retry of `repoA` is still `REPEATED_SAME_INTENT`.

## Merge safety

This PR is one of five opened together (#1579, #1580, #1595, #1598, #1600). Each touches a disjoint set of files and none touches `CHANGELOG.md`, so they can be merged one by one in any order; all 120 orderings were verified conflict-free against `upstream/main`, and the fully merged tree passes the complete gate (ruff, mypy, full pytest). Happy to follow up with a single `docs(changelog)` PR recording the batch once they land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrT2hZdMcL98BWVTX8oZB1
