### PR TITLE
fix(scheduler): fail cron.remove for a missing job instead of reporting success

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -706,7 +706,13 @@ agentos cron add --every 1h --text "Summarize important updates" --name hourly-s
 agentos cron status <job-id>
 agentos cron runs <job-id>
 agentos cron output <job-id>
+agentos cron remove <job-id> --yes
 ```
+
+`cron status`, `cron update` and `cron remove` all fail the same way for an
+unknown id: exit code 2 and a `Cron job not found: <job-id>` error (`NOT_FOUND`
+under `--json`). `cron remove` never reports `removed: true` for a job that was
+not there.
 
 `--job-kind` picks what fires: `reminder` (delivers `--text` verbatim, no LLM),
 `script` (runs a file, no LLM), `agent_turn` (the agent runs `--text` as a

--- a/src/agentos/cli/cron_cmd.py
+++ b/src/agentos/cli/cron_cmd.py
@@ -1122,7 +1122,12 @@ def cron_remove(
     confirm_or_exit(f"Remove cron job {job_id!r}?", yes=yes, json_output=json_output)
 
     async def _run(client):
-        await client.call("cron.remove", {"id": job_id})
+        # A missing id surfaces as a NOT_FOUND RPC error and never reaches
+        # here; the payload is whatever the gateway actually did rather than
+        # a hardcoded ``removed: True``. Older gateways answer ``null``.
+        payload = await client.call("cron.remove", {"id": job_id})
+        if isinstance(payload, dict) and payload:
+            return payload
         return {"id": job_id, "removed": True}
 
     payload = run_gateway_sync(_run, json_output=json_output)

--- a/src/agentos/gateway/rpc_cron.py
+++ b/src/agentos/gateway/rpc_cron.py
@@ -1057,12 +1057,17 @@ async def _handle_cron_update(params: dict | None, ctx: RpcContext) -> dict[str,
 
 
 @_d.method("cron.remove")
-async def _handle_cron_remove(params: dict | None, ctx: RpcContext) -> None:
+async def _handle_cron_remove(params: dict | None, ctx: RpcContext) -> dict[str, Any]:
     if not isinstance(params, dict) or "id" not in params:
         raise ValueError("params.id is required")
     scheduler = _require_scheduler(ctx)
-    await scheduler.remove_job(params["id"])
-    return None
+    # ``remove_job`` answers False for an unknown id. Discarding that bool
+    # turned "nothing was deleted" into an RPC success; fail the way
+    # ``cron.status`` / ``cron.update`` already do for a missing job.
+    removed = await scheduler.remove_job(params["id"])
+    if not removed:
+        raise KeyError(f"Cron job not found: {params['id']}")
+    return {"id": params["id"], "removed": True}
 
 
 @_d.method("cron.run")

--- a/tests/test_cli/test_cron_remove_missing.py
+++ b/tests/test_cli/test_cron_remove_missing.py
@@ -1,0 +1,85 @@
+"""Issue #1598: ``agentos cron remove`` must not print a success payload for a
+job the gateway says does not exist, and must not invent ``removed: true``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from typer.testing import CliRunner
+
+from agentos.cli.main import app
+
+runner = CliRunner()
+
+
+class _Gateway:
+    calls: list[tuple[str, Any]] = []
+    present: set[str] = set()
+
+    async def connect(self, url: str, *, token=None) -> None:
+        pass
+
+    async def close(self) -> None:
+        pass
+
+    async def call(self, method: str, params: dict | None = None) -> Any:
+        from agentos.cli.gateway_client import GatewayRPCError
+
+        type(self).calls.append((method, params or {}))
+        assert method == "cron.remove"
+        job_id = (params or {})["id"]
+        if job_id not in type(self).present:
+            raise GatewayRPCError(
+                method, code="NOT_FOUND", message=f"'Cron job not found: {job_id}'"
+            )
+        type(self).present.discard(job_id)
+        return {"id": job_id, "removed": True}
+
+
+def _install(monkeypatch, *, present: set[str]) -> type[_Gateway]:
+    from agentos.cli import gateway_client, gateway_rpc
+
+    _Gateway.calls = []
+    _Gateway.present = set(present)
+    monkeypatch.setattr(gateway_client, "GatewayClient", _Gateway)
+    monkeypatch.setattr(gateway_rpc, "_apply_version_skew_policy", lambda *a, **kw: None)
+    monkeypatch.setattr(gateway_rpc, "_maybe_emit_update_notice", lambda *a, **kw: None)
+    monkeypatch.setattr(gateway_rpc, "_target_gateway_url", lambda **kw: "ws://test")
+    monkeypatch.setattr(gateway_rpc, "default_gateway_token", lambda *a, **kw: None)
+    return _Gateway
+
+
+def test_remove_missing_job_fails_like_status_does(monkeypatch) -> None:
+    _install(monkeypatch, present={"real-job"})
+
+    result = runner.invoke(app, ["cron", "remove", "missing-job-xyz", "--yes", "--json"])
+
+    assert result.exit_code == 2, result.output
+    assert result.stdout.strip() == "", result.stdout
+    error = json.loads(result.stderr)["error"]
+    assert error["code"] == "NOT_FOUND"
+    assert "Cron job not found: missing-job-xyz" in error["message"]
+
+
+def test_remove_missing_job_human_mode_prints_no_success_table(monkeypatch) -> None:
+    _install(monkeypatch, present=set())
+
+    result = runner.invoke(app, ["cron", "remove", "missing-job-xyz", "--yes"])
+
+    assert result.exit_code == 2, result.output
+    assert "Cron job removed" not in result.output
+    assert "removed" not in result.stdout.lower()
+    assert "Cron job not found: missing-job-xyz" in result.output
+
+
+def test_remove_existing_job_still_succeeds(monkeypatch) -> None:
+    gw = _install(monkeypatch, present={"real-job"})
+
+    result = runner.invoke(app, ["cron", "remove", "real-job", "--yes", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {"id": "real-job", "removed": True}
+    assert gw.calls == [("cron.remove", {"id": "real-job"})]
+    assert gw.present == set()

--- a/tests/test_gateway/test_rpc_cron_remove_missing.py
+++ b/tests/test_gateway/test_rpc_cron_remove_missing.py
@@ -1,0 +1,73 @@
+"""Issue #1598: ``cron.remove`` must not report success for a missing job.
+
+``scheduler.remove_job`` already returns ``False`` when nothing was deleted;
+the handler used to discard that bool and answer with a plain RPC success.
+It now raises ``KeyError`` like its ``cron.status`` / ``cron.update``
+siblings (which the dispatcher maps to ``NOT_FOUND``) and returns the real
+outcome on the happy path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from agentos.gateway.rpc import RpcContext
+from agentos.gateway.rpc_cron import _d, _handle_cron_remove
+
+
+class _FakeScheduler:
+    def __init__(self, *, present: set[str]) -> None:
+        self.present = set(present)
+        self.removed: list[str] = []
+
+    async def remove_job(self, job_id: str) -> bool:
+        self.removed.append(job_id)
+        if job_id in self.present:
+            self.present.discard(job_id)
+            return True
+        return False
+
+
+def test_remove_missing_job_raises_not_found() -> None:
+    scheduler = _FakeScheduler(present={"real-job"})
+
+    with pytest.raises(KeyError, match="Cron job not found: missing-job-xyz"):
+        asyncio.run(
+            _handle_cron_remove(
+                {"id": "missing-job-xyz"},
+                RpcContext(conn_id="test", cron_scheduler=scheduler),
+            )
+        )
+
+    assert scheduler.removed == ["missing-job-xyz"]
+    assert scheduler.present == {"real-job"}
+
+
+def test_remove_existing_job_reports_the_real_outcome() -> None:
+    scheduler = _FakeScheduler(present={"real-job"})
+
+    result = asyncio.run(
+        _handle_cron_remove(
+            {"id": "real-job"},
+            RpcContext(conn_id="test", cron_scheduler=scheduler),
+        )
+    )
+
+    assert result == {"id": "real-job", "removed": True}
+    assert scheduler.present == set()
+
+
+def test_remove_missing_job_surfaces_as_not_found_over_the_wire() -> None:
+    """Through the dispatcher, so the CLI and web UI see the same shape as
+    ``cron.status`` / ``cron.update`` already produce for a missing id."""
+    scheduler = _FakeScheduler(present=set())
+    ctx = RpcContext(conn_id="test", cron_scheduler=scheduler)
+
+    frame = asyncio.run(_d.dispatch("req-1", "cron.remove", {"id": "missing-job-xyz"}, ctx))
+
+    assert frame.ok is False
+    assert frame.error is not None
+    assert frame.error.code == "NOT_FOUND"
+    assert "Cron job not found: missing-job-xyz" in frame.error.message


### PR DESCRIPTION
## Summary

Fixes #1598.

All three links in the reported chain: `scheduler.remove_job` returns `False` for a missing job, `_handle_cron_remove` discarded that bool and returned an RPC success, and `cron_remove` in the CLI printed a hardcoded `{"id": ..., "removed": true}`. So `agentos cron remove missing-job --yes --json` exited 0 with a success payload while `cron status` / `cron update` and the agent's Control `cron` tool all report `Cron job not found`.

## Change

- `gateway/rpc_cron.py`: `_handle_cron_remove` raises `KeyError("Cron job not found: <id>")` like its siblings (the dispatcher maps it to `NOT_FOUND`; exit code 2 in the CLI) and returns `{"id", "removed": true}` on the happy path.
- `cli/cron_cmd.py`: passes the gateway's payload through instead of inventing one; keeps the old shape only for older gateways that still answer `null` (the RPC error is what stops the false success in every case).
- `docs/cli.md`: lists `cron remove` and documents the not-found behaviour shared by `status` / `update` / `remove`.

The web UI's delete mutation ignores the RPC result, so the richer return value is compatible. The separately reported `cron run <missing>` exit-0 case is #1684 and is deliberately not folded in.

## Tests

- `tests/test_gateway/test_rpc_cron_remove_missing.py`: missing id raises `KeyError` (scheduler consulted, nothing else touched); existing id reports the real outcome; through `_d.dispatch` the wire frame is `ok=False` with code `NOT_FOUND`.
- `tests/test_cli/test_cron_remove_missing.py`: `cron remove <missing> --yes --json` exits 2 with a `NOT_FOUND` error and nothing on stdout; human mode prints no "Cron job removed" table; an existing id still removes with exit 0.

## Merge safety

This PR is one of five opened together (#1579, #1580, #1595, #1598, #1600). Each touches a disjoint set of files and none touches `CHANGELOG.md`, so they can be merged one by one in any order; all 120 orderings were verified conflict-free against `upstream/main`, and the fully merged tree passes the complete gate (ruff, mypy, full pytest). Happy to follow up with a single `docs(changelog)` PR recording the batch once they land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrT2hZdMcL98BWVTX8oZB1
