### PR TITLE
fix(channels): refuse email sends into an unknown thread instead of mailing the Message-ID

### DIFF
--- a/docs/channels.md
+++ b/docs/channels.md
@@ -143,7 +143,14 @@ from the same person starts a fresh session.
 
 The thread routing table (which address and subject a reply goes back to) is
 rebuilt from each inbound message and kept in memory only, so a gateway
-restart does not affect replying to live conversations.
+restart does not affect replying to live conversations. A reply into a thread
+the table no longer knows -- a scheduled job or artifact delivery that fires
+after a restart, before the correspondent has written again -- is refused with
+`email.send has no recipient for unknown thread` rather than guessed: the thread
+key is the inbound `Message-ID`, which looks like a mailbox but whose domain the
+original sender chose. Cron and heartbeat deliveries that are configured with an
+address (cron `channel_id: "alerts@example.com"`, heartbeat `to:`) do not depend
+on the table.
 
 Quoted history below a reply is stripped before the text reaches the model, and
 HTML-only mail is flattened to text. Replies are sent as plain text: mail

--- a/src/agentos/channels/email.py
+++ b/src/agentos/channels/email.py
@@ -187,19 +187,6 @@ def normalize_address(value: str) -> str:
     return address.strip().lower()
 
 
-def is_email_address(value: str) -> bool:
-    """Return True when ``value`` carries a usable mailbox address.
-
-    Outbound callers hand us ``reply_to`` values that are sometimes an address
-    and sometimes an opaque routing token (``cron``, a thread key), so the
-    address fallback has to be able to tell the two apart.
-    """
-
-    address = normalize_address(value)
-    local, at, domain = address.partition("@")
-    return bool(local and at and domain)
-
-
 def sender_allowed(sender: str, allowlist: list[str] | tuple[str, ...]) -> bool:
     """Return True when ``sender`` matches the fail-closed allowlist.
 
@@ -775,21 +762,39 @@ class EmailChannel:
         return OutgoingMessage(content=content, reply_to=inbound.channel_id, metadata=metadata)
 
     def _resolve_target(self, message: OutgoingMessage) -> tuple[str, str, str, str]:
-        """Return ``(to, subject, in_reply_to, references)`` for an outbound send."""
+        """Return ``(to, subject, in_reply_to, references)`` for an outbound send.
+
+        The mailbox comes from ``metadata["to"]`` (channel replies, scheduler
+        and heartbeat delivery), ``metadata["recipient"]`` (the message tool)
+        or the thread the ``reply_to`` key names. It is never read off
+        ``reply_to`` itself: that key is the inbound Message-ID, which has a
+        mailbox's ``local@domain`` shape but a domain chosen by whoever sent
+        the original mail. Once the thread has aged out of the cache -- any
+        restart empties it -- guessing would hand the reply to that domain.
+        Refusing is a loud failure instead of a silent misdelivery.
+        """
 
         reply_to = (message.reply_to or "").strip()
         thread = self._threads.get(reply_to)
         metadata = message.metadata or {}
-        # The message tool writes "recipient", channel replies write "to", and
-        # scheduler/heartbeat delivery sends the bare address as reply_to, so
-        # every producer has to be able to name the mailbox.
         to_address = str(
             metadata.get("to") or metadata.get("recipient") or (thread.to_address if thread else "")
         ).strip()
-        if not to_address and is_email_address(reply_to):
-            to_address = normalize_address(reply_to)
         if not to_address:
-            raise ValueError("email.send has no recipient for reply_to")
+            if not reply_to:
+                raise ValueError(
+                    "email.send has no recipient: the message names no metadata['to'] and no thread"
+                )
+            log.warning(
+                "email.send_unknown_thread",
+                name=self.config.name,
+                thread_id=reply_to,
+            )
+            raise ValueError(
+                f"email.send has no recipient for unknown thread {reply_to!r}: the thread "
+                "is not in the routing cache (evicted, or lost on restart) and the message "
+                "names no metadata['to']"
+            )
         subject = str(metadata.get("subject") or "").strip()
         if not subject:
             subject = reply_subject(thread.subject) if thread else _DEFAULT_OUTBOUND_SUBJECT

--- a/src/agentos/scheduler/delivery.py
+++ b/src/agentos/scheduler/delivery.py
@@ -339,6 +339,13 @@ class DeliveryChain:
             channel_id=channel_id,
             account_id=account_id,
             thread_id=thread_id,
+            # A rendezvous snapshot and ``origin`` mode both name the
+            # conversation the job came from; only a plain ``channel`` job
+            # carries a recipient someone typed in.
+            configured_recipient=(
+                job.delivery.originating_reply_target is None
+                and job.delivery.mode == DeliveryMode.CHANNEL
+            ),
         )
 
     async def _deliver_origin_webchat_to_session(
@@ -419,8 +426,16 @@ class DeliveryChain:
         channel_id: str,
         account_id: str = "",
         thread_id: str = "",
+        configured_recipient: bool = False,
     ) -> str:
-        """Send ``text`` via the registered channel adapter for ``channel_name``."""
+        """Send ``text`` via the registered channel adapter for ``channel_name``.
+
+        ``configured_recipient`` says ``channel_id`` is an address someone
+        configured rather than the key of the conversation the job came from.
+        The email adapter needs to know: a thread key is a Message-ID with a
+        mailbox's shape, so it refuses to read a recipient off ``reply_to``
+        and only mails an address it is handed as ``metadata["to"]``.
+        """
         text = strip_reply_directives(text) or ""
         if not self._channel_manager_ref:
             return "skipped"
@@ -472,6 +487,10 @@ class DeliveryChain:
                         reply_to="cron",
                         metadata={"channel": channel_id, "thread_ts": None},
                     )
+            elif channel_name == "email" and configured_recipient and channel_id:
+                msg = OutgoingMessage(
+                    content=text, reply_to=channel_id, metadata={"to": channel_id}
+                )
             else:
                 msg = OutgoingMessage(content=text, reply_to=channel_id or None)
             await asyncio.wait_for(adapter.send(msg), timeout=30.0)
@@ -588,6 +607,7 @@ class DeliveryChain:
                 channel_id=fd.channel_id,
                 account_id=fd.account_id or "",
                 thread_id=fd.thread_id,
+                configured_recipient=True,
             )
         return "skipped"
 

--- a/src/agentos/scheduler/handlers.py
+++ b/src/agentos/scheduler/handlers.py
@@ -205,6 +205,10 @@ def _delivery_override_from_fields(job: CronJob) -> dict[str, str] | None:
         "channel_id": delivery.channel_id,
         "account_id": delivery.account_id,
         "thread_id": delivery.thread_id,
+        # ``channel`` means the recipient was configured; ``origin`` means it
+        # is the key of the conversation the job came from. The email adapter
+        # only mails a configured address (see HeartbeatService).
+        "mode": str(delivery.mode),
     }
 
 

--- a/src/agentos/scheduler/heartbeat_loop.py
+++ b/src/agentos/scheduler/heartbeat_loop.py
@@ -209,6 +209,10 @@ class HeartbeatLoop:
                 "account_id": snap["account_id"],
                 "thread_id": snap["thread_id"],
             }
+            if snap["to"]:
+                # A configured ``to`` is a recipient, not the session's last
+                # conversation -- the email adapter treats the two differently.
+                delivery_override["mode"] = "channel"
 
         kwargs = {
             "reason": "heartbeat:loop",

--- a/src/agentos/scheduler/heartbeat_service.py
+++ b/src/agentos/scheduler/heartbeat_service.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from agentos.scheduler.delivery import infer_delivery
+from agentos.scheduler.types import DeliveryMode
 
 
 @dataclass
@@ -109,6 +110,12 @@ class HeartbeatService:
                 delivery.thread_id = override["thread_id"]
             elif not turn_source_thread_id:
                 delivery.thread_id = ""
+            if override.get("mode") == DeliveryMode.CHANNEL and override.get("channel_id"):
+                # The override carries a recipient someone configured, not
+                # the conversation the session last spoke to. Without an id
+                # the target is still the inferred conversation, whatever
+                # the override's mode says.
+                delivery.mode = DeliveryMode.CHANNEL
         elif isinstance(target, str) and target.strip():
             delivery = await infer_delivery(
                 self._session_storage,
@@ -273,6 +280,17 @@ class HeartbeatService:
                     reply_to=("cron" if channel_id else None),
                     metadata=metadata,
                 )
+        elif (
+            channel_name == "email"
+            and getattr(delivery, "mode", None) == DeliveryMode.CHANNEL
+            and channel_id
+        ):
+            # ``channel_id`` is a configured address. The email adapter only
+            # mails an address it is handed as ``metadata["to"]``: a thread
+            # key is a Message-ID with a mailbox's shape, so it refuses to
+            # read a recipient off ``reply_to``. In ``origin`` mode the id
+            # *is* the thread key and must stay ``reply_to`` alone.
+            msg = OutgoingMessage(content=text, reply_to=channel_id, metadata={"to": channel_id})
         else:
             msg = OutgoingMessage(content=text, reply_to=channel_id or None)
         try:

--- a/tests/test_channels/test_email_channel.py
+++ b/tests/test_channels/test_email_channel.py
@@ -21,7 +21,6 @@ from agentos.channels.email import (
     _quote_imap_mailbox,
     html_to_text,
     is_automated,
-    is_email_address,
     normalize_address,
     reply_subject,
     sender_allowed,
@@ -534,23 +533,99 @@ async def test_send_resolves_the_recipient_from_metadata_recipient(
     assert sent[0].get("In-Reply-To") is None
 
 
-async def test_send_resolves_the_recipient_from_reply_to_address(
+async def test_send_resolves_the_recipient_from_metadata_to(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Scheduler and heartbeat delivery pass the address as ``reply_to`` alone."""
+    """Scheduler and heartbeat delivery name the mailbox in ``metadata["to"]``."""
 
     channel = EmailChannel(config=_config())
     sent: list[EmailMessage] = []
     monkeypatch.setattr(channel, "_smtp_send", sent.append)
 
-    await channel.send(OutgoingMessage(content="alert", reply_to="alerts@example.com"))
+    await channel.send(
+        OutgoingMessage(
+            content="alert",
+            reply_to="alerts@example.com",
+            metadata={"to": "alerts@example.com"},
+        )
+    )
 
     assert sent[0]["To"] == "alerts@example.com"
     assert sent[0].get_content().strip() == "alert"
 
 
+@pytest.mark.parametrize(
+    "reply_to",
+    [
+        # The thread key an inbound Message-ID produces -- the value every
+        # channel reply, message-tool send and artifact delivery carries.
+        "CAGr5Gg=xyz@mail.gmail.com",
+        # ...and one whose domain the original sender chose for themselves.
+        "anything@attacker.example",
+        # A bare mailbox is no different: after a restart the channel cannot
+        # tell it from a Message-ID, so neither may be guessed at.
+        "alerts@example.com",
+    ],
+)
+async def test_send_never_treats_an_unknown_thread_key_as_the_recipient(
+    monkeypatch: pytest.MonkeyPatch, reply_to: str
+) -> None:
+    """A Message-ID has a mailbox's shape; an evicted thread must fail loudly."""
+
+    channel = EmailChannel(config=_config())
+    sent: list[EmailMessage] = []
+    monkeypatch.setattr(channel, "_smtp_send", sent.append)
+
+    with pytest.raises(ValueError, match="unknown thread"):
+        await channel.send(OutgoingMessage(content="secret reply", reply_to=reply_to))
+
+    assert sent == []
+
+
+async def test_send_with_no_target_at_all_says_so() -> None:
+    channel = EmailChannel(config=_config())
+
+    with pytest.raises(ValueError, match="no metadata\\['to'\\] and no thread"):
+        await channel.send(OutgoingMessage(content="ping", reply_to=None))
+
+
+async def test_send_after_thread_eviction_is_refused_not_misdelivered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    channel = EmailChannel(config=_config())
+    sent: list[EmailMessage] = []
+    monkeypatch.setattr(channel, "_smtp_send", sent.append)
+    inbound = channel._to_incoming(_raw())
+    assert inbound is not None
+    await channel.send(OutgoingMessage(content="first", reply_to=inbound.channel_id))
+    assert sent[0]["To"] == "owner@example.com"
+
+    channel._threads.clear()  # what a restart or LRU eviction does
+
+    with pytest.raises(ValueError, match="unknown thread"):
+        await channel.send(OutgoingMessage(content="second", reply_to=inbound.channel_id))
+    assert len(sent) == 1
+
+
+async def test_send_file_into_an_evicted_thread_fails_instead_of_misdelivering(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    channel = EmailChannel(config=_config())
+    sent: list[EmailMessage] = []
+    monkeypatch.setattr(channel, "_smtp_send", sent.append)
+    artifact = tmp_path / "report.csv"
+    artifact.write_bytes(b"a,b\n")
+
+    result = await channel.send_file("CAGr5Gg=xyz@mail.gmail.com", str(artifact))
+
+    assert result.status == ChannelSendStatus.FAILED
+    assert result.retryable is False
+    assert "unknown thread" in (result.reason or "")
+    assert sent == []
+
+
 async def test_send_recipient_resolution_precedence(monkeypatch: pytest.MonkeyPatch) -> None:
-    """``to`` beats ``recipient`` beats the thread cache beats ``reply_to``."""
+    """``to`` beats ``recipient`` beats the thread cache; ``reply_to`` is never a mailbox."""
 
     channel = EmailChannel(config=_config())
     assert channel._to_incoming(_raw()) is not None
@@ -572,29 +647,12 @@ async def test_send_recipient_resolution_precedence(monkeypatch: pytest.MonkeyPa
         )
     )
     await channel.send(OutgoingMessage(content="x", reply_to="m1@example.com"))
-    await channel.send(OutgoingMessage(content="x", reply_to="fourth@example.com"))
 
     assert [m["To"] for m in sent] == [
         "first@example.com",
         "second@example.com",
         "owner@example.com",
-        "fourth@example.com",
     ]
-
-
-@pytest.mark.parametrize(
-    ("value", "expected"),
-    [
-        ("owner@example.com", True),
-        ("Owner Name <owner@example.com>", True),
-        ("unknown", False),
-        ("cron", False),
-        ("", False),
-        ("m1@example.com", True),
-    ],
-)
-def test_is_email_address_accepts_only_addressable_values(value: str, expected: bool) -> None:
-    assert is_email_address(value) is expected
 
 
 async def test_send_without_a_known_thread_is_refused() -> None:

--- a/tests/test_scheduler/test_heartbeat_email_delivery.py
+++ b/tests/test_scheduler/test_heartbeat_email_delivery.py
@@ -1,0 +1,205 @@
+"""Heartbeat delivery tells the email adapter when ``channel_id`` is a mailbox.
+
+``EmailChannel`` never reads a recipient off ``reply_to``: an inbound thread
+key is a Message-ID with the same ``local@domain`` shape, and its domain is
+chosen by whoever sent the original mail. A heartbeat that delivers to an
+operator-configured address therefore has to name it in ``metadata["to"]``,
+while one that delivers back into the session's last email thread must not --
+there ``channel_id`` *is* the thread key.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from agentos.channels.manager import ChannelManager
+from agentos.channels.types import OutgoingMessage
+from agentos.scheduler.heartbeat_loop import HeartbeatLoop
+from agentos.scheduler.heartbeat_service import HeartbeatService
+from agentos.scheduler.types import DeliveryConfig, DeliveryMode
+
+_THREAD_KEY = "CAGr5Gg=xyz@mail.gmail.com"
+_MAILBOX = "alerts@example.com"
+
+
+class _FakeAdapter:
+    def __init__(self) -> None:
+        self.messages: list[OutgoingMessage] = []
+
+    async def send(self, message: OutgoingMessage) -> None:
+        self.messages.append(message)
+
+
+class _FakeTurnRunner:
+    async def run(self, **_: Any):  # noqa: ANN202
+        yield SimpleNamespace(kind="done", text="heartbeat text")
+
+
+class _FakeSessionStorage:
+    """A session whose last inbound message came from an email thread."""
+
+    async def get_session(self, session_key: str) -> Any:
+        return SimpleNamespace(
+            last_channel="email", last_to=_THREAD_KEY, last_account_id="", last_thread_id=""
+        )
+
+
+def _service(adapter: _FakeAdapter) -> HeartbeatService:
+    manager = ChannelManager(
+        _channels={"mail": adapter},  # type: ignore[dict-item]
+        _turn_runner=None,
+        _session_manager=None,
+        _channel_types={"mail": "email"},
+    )
+    return HeartbeatService(
+        turn_runner=_FakeTurnRunner(),
+        session_storage=_FakeSessionStorage(),
+        channel_manager_ref=lambda: manager,
+    )
+
+
+async def test_send_delivery_names_the_mailbox_for_a_configured_email_target() -> None:
+    adapter = _FakeAdapter()
+    delivery = DeliveryConfig(mode=DeliveryMode.CHANNEL, channel_name="email", channel_id=_MAILBOX)
+
+    assert await _service(adapter)._send_delivery(delivery, "hi") is None
+
+    (msg,) = adapter.messages
+    assert msg.reply_to == _MAILBOX
+    assert msg.metadata == {"to": _MAILBOX}
+
+
+async def test_send_delivery_keeps_an_inferred_email_thread_as_reply_to_only() -> None:
+    adapter = _FakeAdapter()
+    delivery = DeliveryConfig(
+        mode=DeliveryMode.ORIGIN, channel_name="email", channel_id=_THREAD_KEY
+    )
+
+    assert await _service(adapter)._send_delivery(delivery, "hi") is None
+
+    (msg,) = adapter.messages
+    assert msg.reply_to == _THREAD_KEY
+    assert msg.metadata == {}
+
+
+async def _run_last(adapter: _FakeAdapter, override: dict[str, str] | None) -> OutgoingMessage:
+    result = await _service(adapter).run_once(
+        reason="test",
+        agent_id="main",
+        session_key="agent:main:main",
+        prompt="ping",
+        target="last",
+        delivery_override=override,
+    )
+    assert result.status == "delivered", result
+    (msg,) = adapter.messages
+    return msg
+
+
+async def test_target_last_without_override_replies_into_the_email_thread() -> None:
+    msg = await _run_last(_FakeAdapter(), None)
+
+    assert msg.reply_to == _THREAD_KEY
+    assert msg.metadata == {}
+
+
+async def test_target_last_with_a_configured_recipient_override_names_the_mailbox() -> None:
+    """A ``mode: channel`` override is an operator-chosen address, not a thread."""
+    msg = await _run_last(_FakeAdapter(), {"channel_id": _MAILBOX, "mode": "channel"})
+
+    assert msg.reply_to == _MAILBOX
+    assert msg.metadata == {"to": _MAILBOX}
+
+
+async def test_target_last_with_a_snapshot_override_keeps_the_thread_key_as_reply_to() -> None:
+    """A snapshot override carries the originating conversation's key."""
+    msg = await _run_last(
+        _FakeAdapter(), {"channel_name": "email", "channel_id": "other-thread@mail.example"}
+    )
+
+    assert msg.reply_to == "other-thread@mail.example"
+    assert msg.metadata == {}
+
+
+async def test_target_last_with_a_channel_mode_override_but_no_id_stays_a_thread_reply() -> None:
+    """``mode: channel`` without an id still delivers to the inferred thread."""
+    msg = await _run_last(_FakeAdapter(), {"channel_name": "email", "mode": "channel"})
+
+    assert msg.reply_to == _THREAD_KEY
+    assert msg.metadata == {}
+
+
+async def test_explicit_email_target_names_the_configured_mailbox() -> None:
+    adapter = _FakeAdapter()
+    result = await _service(adapter).run_once(
+        reason="test",
+        agent_id="main",
+        session_key="agent:main:main",
+        prompt="ping",
+        target="email",
+        delivery_override={"channel_id": _MAILBOX},
+    )
+
+    assert result.status == "delivered", result
+    (msg,) = adapter.messages
+    assert msg.metadata == {"to": _MAILBOX}
+
+
+class _CapturingService:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def run_once(self, **kwargs: Any) -> None:
+        self.calls.append(kwargs)
+
+
+@pytest.mark.parametrize(
+    ("to", "expected_override"),
+    [
+        (
+            _MAILBOX,
+            {
+                "channel_name": "",
+                "channel_id": _MAILBOX,
+                "account_id": "",
+                "thread_id": "th-1",
+                "mode": "channel",
+            },
+        ),
+        # No configured recipient: the thread comes from the session, so it
+        # must not be promoted to a mailbox.
+        ("", {"channel_name": "", "channel_id": "", "account_id": "", "thread_id": "th-1"}),
+    ],
+)
+async def test_loop_marks_an_operator_configured_recipient_as_channel_mode(
+    tmp_path: Path, to: str, expected_override: dict[str, str]
+) -> None:
+    heartbeat_md = tmp_path / "HEARTBEAT.md"
+    heartbeat_md.write_text("Check the inbox and report anything urgent.\n", encoding="utf-8")
+    config = SimpleNamespace(
+        workspace_dir=str(tmp_path),
+        heartbeat=SimpleNamespace(
+            enabled=True,
+            interval_ms=60_000,
+            target="last",
+            prompt=None,
+            ack_max_chars=300,
+            light_context=False,
+            to=to,
+            account_id="",
+            thread_id="th-1",
+            config_path=str(heartbeat_md),
+        ),
+    )
+    service = _CapturingService()
+    loop = HeartbeatLoop(config=config, heartbeat_service=service)
+
+    await loop._tick()
+
+    (call,) = service.calls
+    assert call["target"] == "last"
+    assert call["delivery_override"] == expected_override

--- a/tests/test_scheduler/test_multi_account_delivery.py
+++ b/tests/test_scheduler/test_multi_account_delivery.py
@@ -14,6 +14,7 @@ from agentos.scheduler.types import (
     DeliveryConfig,
     DeliveryMode,
     FailureDestination,
+    ReplyTargetSnapshot,
     SessionTarget,
 )
 
@@ -317,6 +318,131 @@ async def test_slack_resolved_thread_metadata() -> None:
     assert msg.content == "hello thread"
     assert msg.reply_to == "thread-456"
     assert msg.metadata == {"channel": "C0123ABCDEF"}
+
+
+def _email_chain() -> tuple[_FakeAdapter, DeliveryChain]:
+    adapter = _FakeAdapter("mail")
+    manager = ChannelManager(
+        _channels={"mail": adapter},  # type: ignore
+        _turn_runner=None,
+        _session_manager=None,
+        _channel_types={"mail": "email"},
+    )
+    return adapter, DeliveryChain(channel_manager_ref=lambda: manager)
+
+
+def _email_job(delivery: DeliveryConfig) -> CronJob:
+    return CronJob(
+        id="job-1",
+        name="mail-test",
+        handler_key="script_run",
+        payload=make_script_payload("test.sh"),
+        session_target=SessionTarget.ISOLATED,
+        delivery=delivery,
+    )
+
+
+# The email adapter never reads a mailbox off ``reply_to``: an inbound thread
+# key is a Message-ID with the same ``local@domain`` shape. So a delivery to an
+# operator-chosen address has to carry it in ``metadata["to"]``, while a
+# delivery back into the originating conversation must not -- there
+# ``channel_id`` *is* the thread key, and naming it as the recipient would
+# mail the Message-ID.
+
+
+@pytest.mark.asyncio
+async def test_channel_mode_email_delivery_names_the_configured_mailbox() -> None:
+    adapter, chain = _email_chain()
+    job = _email_job(
+        DeliveryConfig(
+            mode=DeliveryMode.CHANNEL, channel_name="email", channel_id="alerts@example.com"
+        )
+    )
+
+    report = await chain.deliver(job, "report", True, "report", "cron:job-1:run:deadbeef")
+
+    assert report.channel_status == "delivered"
+    (msg,) = adapter.messages
+    assert msg.reply_to == "alerts@example.com"
+    assert msg.metadata == {"to": "alerts@example.com"}
+
+
+@pytest.mark.asyncio
+async def test_origin_mode_email_delivery_keeps_the_thread_key_as_reply_to_only() -> None:
+    adapter, chain = _email_chain()
+    job = _email_job(
+        DeliveryConfig(
+            mode=DeliveryMode.ORIGIN, channel_name="email", channel_id="CAGr5Gg=xyz@mail.gmail.com"
+        )
+    )
+
+    await chain.deliver(job, "report", True, "report", "cron:job-1:run:deadbeef")
+
+    (msg,) = adapter.messages
+    assert msg.reply_to == "CAGr5Gg=xyz@mail.gmail.com"
+    assert msg.metadata == {}
+
+
+@pytest.mark.asyncio
+async def test_snapshot_rendezvous_email_delivery_keeps_the_thread_key_as_reply_to_only() -> None:
+    adapter, chain = _email_chain()
+    job = _email_job(
+        DeliveryConfig(
+            mode=DeliveryMode.CHANNEL,
+            channel_name="email",
+            channel_id="alerts@example.com",
+            originating_reply_target=ReplyTargetSnapshot(
+                channel_name="email", channel_type="email", to="CAGr5Gg=xyz@mail.gmail.com"
+            ),
+        )
+    )
+
+    await chain.deliver(job, "report", True, "report", "cron:job-1:run:deadbeef")
+
+    (msg,) = adapter.messages
+    assert msg.reply_to == "CAGr5Gg=xyz@mail.gmail.com"
+    assert msg.metadata == {}
+
+
+@pytest.mark.asyncio
+async def test_failure_destination_email_delivery_names_the_configured_mailbox() -> None:
+    adapter, chain = _email_chain()
+    job = _email_job(
+        DeliveryConfig(
+            mode=DeliveryMode.NONE,
+            failure_destination=FailureDestination(
+                mode=DeliveryMode.CHANNEL, channel_name="email", channel_id="oncall@example.com"
+            ),
+        )
+    )
+
+    status = await chain.dispatch_failure_alert(job, "boom")
+
+    assert status == "delivered"
+    (msg,) = adapter.messages
+    assert msg.reply_to == "oncall@example.com"
+    assert msg.metadata == {"to": "oncall@example.com"}
+
+
+@pytest.mark.asyncio
+async def test_channel_mode_delivery_to_other_adapters_carries_no_metadata() -> None:
+    adapter = _FakeAdapter("tg")
+    manager = ChannelManager(
+        _channels={"tg": adapter},  # type: ignore
+        _turn_runner=None,
+        _session_manager=None,
+        _channel_types={"tg": "telegram"},
+    )
+    chain = DeliveryChain(channel_manager_ref=lambda: manager)
+    job = _email_job(
+        DeliveryConfig(mode=DeliveryMode.CHANNEL, channel_name="telegram", channel_id="12345")
+    )
+
+    await chain.deliver(job, "report", True, "report", "cron:job-1:run:deadbeef")
+
+    (msg,) = adapter.messages
+    assert msg.reply_to == "12345"
+    assert msg.metadata == {}
 
 
 @pytest.mark.asyncio

--- a/tests/test_scheduler/test_system_event_pinned_delivery.py
+++ b/tests/test_scheduler/test_system_event_pinned_delivery.py
@@ -51,6 +51,9 @@ def test_resolver_uses_explicit_channel_fields_when_channel_mode() -> None:
         "channel_id": "C123",
         "account_id": "T1",
         "thread_id": "th-1",
+        # The recipient was configured, not inferred from a conversation --
+        # the email adapter needs to know which (see HeartbeatService).
+        "mode": "channel",
     }
 
 
@@ -116,6 +119,7 @@ def test_resolver_uses_origin_fields_when_origin_without_snapshot() -> None:
         "channel_id": "dis-1",
         "account_id": "",
         "thread_id": "",
+        "mode": "origin",
     }
 
 


### PR DESCRIPTION
## Linked issue
Closes #1570

## Summary
`EmailChannel._resolve_target` fell back to `is_email_address(reply_to)` whenever the thread named by `reply_to` was not in the in-memory `_threads` cache. But `reply_to` is the inbound thread key — an RFC 5322 Message-ID, which has a mailbox's `local@domain` shape and a domain chosen by whoever sent the original mail. After a restart or LRU eviction the agent's reply was silently mailed to that address.

## Fix
- **`channels/email.py`** — the fallback (and the `is_email_address` helper that existed for it) is gone. An unknown thread with no `metadata["to"]`/`["recipient"]` raises `email.send has no recipient for unknown thread '<key>': ...` and logs `email.send_unknown_thread` (two producers swallow send exceptions, so the log line is what makes the refusal visible). `send_file` reports a non-retryable failure. A message with no target at all gets its own message.
- **Scheduler / heartbeat** used to rely on the fallback to deliver to operator-configured addresses. They now pass `metadata["to"]` — **but only when `channel_id` is a configured recipient.** The same field is the *thread key* when a job was created from an email conversation (`mode=origin`, or an `originating_reply_target` rendezvous snapshot); naming that as the recipient would mail the Message-ID even on a cache hit, and re-open the exact hole on a miss.
  - `scheduler/delivery.py`: `configured_recipient = job.delivery.originating_reply_target is None and mode == CHANNEL`; failure destinations are always configured. This proxy holds because the cron tool refuses `mode=channel` from chat callers, so a snapshot-less channel job can only come from an operator (CLI/RPC/Web).
  - `scheduler/heartbeat_service.py`: uses `delivery.mode == CHANNEL`. In the `target: last` branch an override is promoted to channel mode only when it says `"mode": "channel"` **and** supplies a `channel_id` (a channel-mode override without an id still targets the inferred conversation).
  - `scheduler/handlers.py` / `heartbeat_loop.py`: overrides now say which mode they represent (`_delivery_override_from_fields` includes `mode`; the loop marks a configured `to` as channel mode; snapshot overrides carry nothing and stay thread replies).
- **`docs/channels.md`**: "Threads and Sessions" describes the refusal and which deliveries do not depend on the routing table.

### Compared with the other open PRs on this issue
#1644 removes the fallback but leaves scheduler/heartbeat sending the bare address, which turns every configured cron/heartbeat email delivery into a hard failure. #1827 additionally sets `metadata["to"] = channel_id` unconditionally in `delivery.py`, which mails the Message-ID for jobs created from an email conversation — even when the thread is still cached — and does not touch the heartbeat producer at all. This PR threads the provenance through so both classes keep working and no path can populate `to` from a thread key.

## Tests
- `test_email_channel.py`: the issue's Message-ID key, an attacker-domain key and a bare mailbox are all refused with nothing sent; a reply works before `_threads.clear()` and is refused after; `send_file` into an evicted thread reports `FAILED` (not retryable); the empty-target message; scheduler-style `metadata["to"]` still resolves; precedence test updated (`to` > `recipient` > cache; `reply_to` is never a mailbox). The test that encoded the vulnerable contract is replaced.
- `test_multi_account_delivery.py`: channel-mode email → `{"to": addr}`; origin-mode email → `{}`; snapshot rendezvous → `{}` with the snapshot key as `reply_to`; failure destination → `{"to": addr}`; telegram channel-mode → `{}` (untouched).
- `test_heartbeat_email_delivery.py` (new): `_send_delivery` for channel vs origin mode; `run_once(target="last")` end-to-end with no override / configured override / snapshot override / channel-mode override without an id; explicit `target="email"`; and `HeartbeatLoop._tick` override construction with and without a configured `to`.
- `test_system_event_pinned_delivery.py`: override dicts now carry `mode`.

## Follow-up (out of scope, same shape)
The `message` tool writes `metadata["recipient"] = target` unconditionally and `recipient` outranks the thread cache, so `message(channel="email", target="<Message-ID>")` would still mail the key. That is an explicit-address contract rather than this bug; worth its own issue.

## Quality gate
`uv run ruff check src tests`, `uv run mypy src/agentos`, full `uv run pytest -q` — all green (one `test_pilot_benchmark` latency assertion flaked under load with five suites in parallel; passes alone).

---

No `CHANGELOG.md` entry on purpose: this PR is one of five opened together (#1570 #1571 #1573 #1575 #1577), each on disjoint files, and the changelog is the one file they would all collide on. All 120 merge orderings were verified conflict-free against `upstream/main`, and the fully merged tree passes the complete gate. Happy to add the bullet in a follow-up `docs(changelog)` once the batch lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfPC1g1hsFx5Tw7LefvgDN
