### PR TITLE
fix(tools): match grep_search's include glob against the relative path too

### DIFF
--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -1031,13 +1031,43 @@ async def glob_search(pattern: str, path: str | None = None) -> str:
     return "\n".join(matches)
 
 
+def _include_matches(fp: Path, base: Path, include: str) -> bool:
+    """Return True when ``include`` names ``fp`` by filename or by relative path.
+
+    A bare glob (``*.py``, ``test_*.py``) describes the filename, so it is
+    matched against ``fp.name`` at any depth exactly as before. A glob that
+    carries a directory (``tests/*.py``) can only be matched against the path
+    relative to the search base -- matched against the filename alone it never
+    fires, and the tool answers "no matches" for code that exists.
+
+    Matching is ``fnmatch``, so ``*`` also spans ``/``; ``**/`` additionally
+    matches zero directories (``src/**/*.py`` includes ``src/a.py``), which
+    ``fnmatch`` alone would not give it.
+    """
+    if fnmatch.fnmatch(fp.name, include):
+        return True
+    try:
+        relative = fp.relative_to(base).as_posix()
+    except ValueError:  # rglob yields base-prefixed paths; defensive only
+        return False
+    if fnmatch.fnmatch(relative, include):
+        return True
+    return "**/" in include and fnmatch.fnmatch(relative, include.replace("**/", ""))
+
+
 @tool(
     name="grep_search",
     description="Search file contents for a regex pattern.",
     params={
         "pattern": {"type": "string", "description": "Regex pattern to search for."},
         "path": {"type": "string", "description": "File or directory to search (default: cwd)."},
-        "include": {"type": "string", "description": "Glob pattern to filter files (e.g. '*.py')."},
+        "include": {
+            "type": "string",
+            "description": (
+                "Glob pattern to filter files, matched against the filename or the "
+                "path relative to the search directory (e.g. '*.py', 'tests/*.py')."
+            ),
+        },
         "max_results": {
             "type": "integer",
             "description": "Maximum number of matches to return (default 100).",
@@ -1099,7 +1129,7 @@ async def grep_search(
                     continue
                 if not fp.is_file():
                     continue
-                if include and not fnmatch.fnmatch(fp.name, include):
+                if include and not _include_matches(fp, base, include):
                     continue
                 search_file(fp)
 

--- a/tests/test_tools/test_grep_search_include.py
+++ b/tests/test_tools/test_grep_search_include.py
@@ -1,0 +1,108 @@
+"""``grep_search`` ``include`` globs match the path as well as the filename.
+
+The filter used to run ``fnmatch`` against ``fp.name`` alone, so a
+path-qualified glob such as ``tests/*.py`` could never match anything and the
+tool answered ``No matches for '<pattern>'`` -- indistinguishable, to the
+agent, from "this code does not exist". These tests pin the new contract
+(the glob may name directories relative to the search base) and the old one
+(a bare filename glob keeps matching at any depth).
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from agentos.tools.builtin import filesystem as fs
+from agentos.tools.types import CallerKind, ToolContext, current_tool_context
+
+
+@contextmanager
+def _tool_context(workspace: Path) -> Iterator[None]:
+    token = current_tool_context.set(
+        ToolContext(
+            caller_kind=CallerKind.CLI,
+            channel_kind="cli",
+            channel_id="cli:test",
+            workspace_dir=str(workspace),
+            workspace_strict=True,
+        )
+    )
+    try:
+        yield
+    finally:
+        current_tool_context.reset(token)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_basic.py").write_text("def test_one():\n    pass\n")
+    (tmp_path / "src" / "pkg").mkdir(parents=True)
+    (tmp_path / "src" / "utils.py").write_text("def test_helper():\n    pass\n")
+    (tmp_path / "src" / "pkg" / "mod.py").write_text("def test_nested():\n    pass\n")
+    (tmp_path / "README.md").write_text("def test_ not code\n")
+    return tmp_path
+
+
+# ``<absolute path>:<lineno>: <text>`` -- split on the line number, not the
+# first colon, which on Windows is the drive letter's.
+_RESULT_LINE = re.compile(r"^(?P<file>.+?):(?P<lineno>\d+): ")
+
+
+async def _hits(repo: Path, include: str, *, path: str | None = None) -> set[str]:
+    with _tool_context(repo):
+        out = await fs.grep_search("def test_", path=path or str(repo), include=include)
+    if out.startswith("No matches"):
+        return set()
+    paths: set[str] = set()
+    for line in out.splitlines():
+        match = _RESULT_LINE.match(line)
+        assert match is not None, line
+        paths.add(Path(match["file"]).relative_to(repo).as_posix())
+    return paths
+
+
+@pytest.mark.asyncio
+async def test_path_qualified_glob_matches_files_under_that_directory(repo: Path) -> None:
+    assert await _hits(repo, "tests/*.py") == {"tests/test_basic.py"}
+
+
+@pytest.mark.asyncio
+async def test_bare_filename_glob_still_matches_at_any_depth(repo: Path) -> None:
+    assert await _hits(repo, "*.py") == {
+        "tests/test_basic.py",
+        "src/utils.py",
+        "src/pkg/mod.py",
+    }
+
+
+@pytest.mark.asyncio
+async def test_bare_filename_glob_with_a_literal_prefix_still_matches_nested_files(
+    repo: Path,
+) -> None:
+    """``test_*.py`` names a filename shape, so it must not need the directory."""
+    assert await _hits(repo, "test_*.py") == {"tests/test_basic.py"}
+
+
+@pytest.mark.asyncio
+async def test_double_star_glob_matches_files_at_every_depth(repo: Path) -> None:
+    """``**/`` spans zero or more directories, as in every other glob dialect."""
+    assert await _hits(repo, "src/**/*.py") == {"src/utils.py", "src/pkg/mod.py"}
+
+
+@pytest.mark.asyncio
+async def test_glob_is_relative_to_the_search_path(repo: Path) -> None:
+    assert await _hits(repo, "pkg/*.py", path=str(repo / "src")) == {"src/pkg/mod.py"}
+
+
+@pytest.mark.asyncio
+async def test_path_qualified_glob_that_matches_nothing_reports_no_matches(repo: Path) -> None:
+    with _tool_context(repo):
+        out = await fs.grep_search("def test_", path=str(repo), include="docs/*.py")
+
+    assert out == "No matches for 'def test_'"


### PR DESCRIPTION
## Linked issue
Closes #1571

## Summary
`grep_search` ran `fnmatch.fnmatch(fp.name, include)` — filename only — so any path-qualified glob (`tests/*.py`, `src/**/*.py`) matched nothing and the tool answered `No matches for '<pattern>'`, indistinguishable to the agent from "this code does not exist".

## Fix
`_include_matches(fp, base, include)` matches the glob against the **filename first, then the path relative to the search base**.

Filename-first is deliberate: matching the relative path *only* (as #1610 and #1675 do) keeps `*.py` working because fnmatch's `*` spans `/`, but silently breaks any bare pattern with a literal prefix — `test_*.py` matches `tests/test_basic.py` by filename today and would not match the relative path, since fnmatch anchors the pattern. There is a regression test for exactly that case.

A `**/` segment additionally matches zero directories (`src/**/*.py` includes `src/a.py`), which plain fnmatch would not give it, so the issue's own example behaves like every other glob dialect. The `include` parameter description now documents the path form (triage ask).

## Tests
`tests/test_tools/test_grep_search_include.py` (new, 6): the issue's `tests/*.py` repro; `*.py` still matches at any depth (the requested non-regression); `test_*.py` still matches nested files; `src/**/*.py` matches at every depth under `src/`; the glob is relative to `path=`; a path-qualified glob that matches nothing still reports "No matches". Result lines are parsed on the `:<lineno>:` separator so the helper is Windows-safe (drive-letter colon).

## Quality gate
ruff, mypy, full pytest green (one `test_pilot_benchmark` latency flake under parallel load; passes alone). `filesystem.py` has pre-existing `ruff format` drift that this PR deliberately does not touch.

---

No `CHANGELOG.md` entry on purpose: this PR is one of five opened together (#1570 #1571 #1573 #1575 #1577), each on disjoint files, and the changelog is the one file they would all collide on. All 120 merge orderings were verified conflict-free against `upstream/main`, and the fully merged tree passes the complete gate. Happy to add the bullet in a follow-up `docs(changelog)` once the batch lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfPC1g1hsFx5Tw7LefvgDN
