### PR TITLE
fix(tools): collapse nullable unions spelled with type: ["null"], const: null or enum: [null]

### DIFF
--- a/src/agentos/tools/schema_sanitize.py
+++ b/src/agentos/tools/schema_sanitize.py
@@ -45,8 +45,31 @@ _SCHEMA_VALUED_KEYS = ("items", "additionalProperties", "contains", "not")
 _SCHEMA_LIST_KEYS = ("allOf", "anyOf", "oneOf", "prefixItems")
 
 
+# The spellings a JSON ``type`` uses for "null": the keyword itself, and the
+# JSON literal some non-Python servers emit in its place.
+_NULL_TYPE_ENTRIES = ("null", None)
+
+
 def _is_null_schema(node: Any) -> bool:
-    return isinstance(node, Mapping) and node.get("type") == "null"
+    """Return True when *node* is a schema that admits ``null`` and nothing else.
+
+    Pydantic spells it ``{"type": "null"}``, but the same branch also arrives
+    as ``{"type": ["null"]}``, ``{"type": null}``, ``{"const": null}`` and
+    ``{"enum": [null]}`` from other generators. Every spelling has to collapse, because the whole
+    point of removing the union is a provider that rejects ``anyOf`` outright.
+    """
+
+    if not isinstance(node, Mapping):
+        return False
+    if "type" in node:
+        declared = node["type"]
+        if isinstance(declared, list):
+            return bool(declared) and all(entry in _NULL_TYPE_ENTRIES for entry in declared)
+        return declared in _NULL_TYPE_ENTRIES
+    if "const" in node:
+        return node["const"] is None
+    enum = node.get("enum")
+    return isinstance(enum, list) and bool(enum) and all(entry is None for entry in enum)
 
 
 def _collect_defs(schema: Mapping[str, Any]) -> dict[str, Any]:
@@ -132,7 +155,7 @@ def _sanitize_node(
             continue
 
         if key == "type" and isinstance(value, list):
-            concrete = [entry for entry in value if entry != "null"]
+            concrete = [entry for entry in value if entry not in _NULL_TYPE_ENTRIES]
             out["type"] = concrete[0] if concrete else "string"
             fixes.append("collapsed_type_array")
             continue

--- a/tests/test_tools/test_schema_sanitize.py
+++ b/tests/test_tools/test_schema_sanitize.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from typing import Any
+
+import pytest
+
 from agentos.tools.schema_sanitize import sanitize_input_schema
 
 
@@ -51,6 +55,70 @@ def test_union_with_two_real_branches_is_left_alone() -> None:
 
     assert cleaned["properties"]["value"]["anyOf"] == [{"type": "integer"}, {"type": "string"}]
     assert "collapsed_nullable_union" not in fixes
+
+
+# Every spelling of "this branch only admits null" that JSON Schema allows.
+# Pydantic emits ``{"type": "null"}``; hand-written and non-Python servers
+# emit the rest, and each one used to survive as an uncollapsed ``anyOf``.
+_NULL_SPELLINGS: list[dict[str, Any]] = [
+    {"type": "null"},
+    {"type": ["null"]},
+    {"type": None},
+    {"type": [None]},
+    {"const": None},
+    {"enum": [None]},
+    {"type": "null", "description": "Nothing."},
+]
+
+
+@pytest.mark.parametrize("null_branch", _NULL_SPELLINGS)
+@pytest.mark.parametrize("union_key", ["anyOf", "oneOf"])
+def test_every_null_spelling_collapses_the_nullable_union(
+    union_key: str, null_branch: dict[str, Any]
+) -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "filter": {union_key: [{"type": "string"}, null_branch], "description": "Which."}
+        },
+    }
+
+    cleaned, fixes = sanitize_input_schema(schema)
+
+    assert cleaned["properties"]["filter"] == {"type": "string", "description": "Which."}
+    assert "collapsed_nullable_union" in fixes
+
+
+@pytest.mark.parametrize(
+    "branch",
+    [
+        {"enum": [None, "a"]},
+        {"enum": []},
+        {"enum": ["null"]},
+        {"const": "null"},
+        {"const": 0},
+        {"type": []},
+        {"type": ["null", "integer"]},
+        {"type": "string"},
+        {"description": "no type at all"},
+    ],
+)
+def test_branches_that_admit_a_real_value_are_not_treated_as_null(branch: dict[str, Any]) -> None:
+    schema = {"type": "object", "properties": {"value": {"anyOf": [{"type": "string"}, branch]}}}
+
+    cleaned, fixes = sanitize_input_schema(schema)
+
+    assert "collapsed_nullable_union" not in fixes
+    assert "anyOf" in cleaned["properties"]["value"]
+
+
+def test_type_array_with_a_none_entry_collapses_to_the_concrete_entry() -> None:
+    schema = {"type": "object", "properties": {"name": {"type": [None, "string"]}}}
+
+    cleaned, fixes = sanitize_input_schema(schema)
+
+    assert cleaned["properties"]["name"]["type"] == "string"
+    assert "collapsed_type_array" in fixes
 
 
 def test_type_array_collapses_to_the_non_null_entry() -> None:


### PR DESCRIPTION
## Linked issue
Closes #1573

## Summary
`_is_null_schema` was a single equality test against `"null"`, so a nullable `anyOf`/`oneOf` whose null branch was spelled `{"type": ["null"]}`, `{"type": null}`, `{"const": null}` or `{"enum": [null]}` survived as an uncollapsed union — the construct this module exists to remove before the schema reaches a provider that rejects it. The type-array case was worse: `collapsed_type_array` rewrote the branch to `{"type": "string"}`, leaving an `anyOf` of two identical branches.

## Fix
`_is_null_schema` recognises every spelling. Precedence is conservative: a `type` key decides if present (a list must be non-empty and all-null; a scalar must be `"null"`/`null`), then `const` must be `null`, then `enum` must be a non-empty list of only `null`. A branch that admits any real value (`enum: [null, "a"]`, `type: ["null", "integer"]`, `const: 0`, `type: "string", enum: [null]`) is never treated as null, so the union is left intact rather than a legal input being dropped. `collapsed_type_array` drops `null` literals alongside `"null"` so `["null","string"]` and `[null,"string"]` behave identically — which is also what keeps the collapse idempotent.

`{"type": null}` is invalid JSON Schema; treating it as null follows the module's "a tool the model can still call beats a discovery that aborted" contract and the triage's explicit ask. A standalone (non-union) `{"type": null}` is passed through unchanged, as a standalone `{"type": "null"}` already is.

## Tests
Parametrised positive matrix (anyOf/oneOf × 7 spellings, one carrying its own `description` to prove sibling precedence), a negative matrix of 9 branches that admit a real value (asserting the union survives), and an order-sensitive `type: [null, "string"]` case. Existing idempotence test still passes; the module never raises on any malformed shape probed (unhashable entries, non-list `enum`, etc.).

## Quality gate
ruff, mypy, full pytest green.

---

No `CHANGELOG.md` entry on purpose: this PR is one of five opened together (#1570 #1571 #1573 #1575 #1577), each on disjoint files, and the changelog is the one file they would all collide on. All 120 merge orderings were verified conflict-free against `upstream/main`, and the fully merged tree passes the complete gate. Happy to add the bullet in a follow-up `docs(changelog)` once the batch lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfPC1g1hsFx5Tw7LefvgDN
