### PR TITLE
fix(channels): read stdin through a thread on Windows in TerminalChannel

### DIFF
--- a/src/agentos/channels/terminal.py
+++ b/src/agentos/channels/terminal.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import sys
 from dataclasses import dataclass, field
 
@@ -11,6 +12,16 @@ import structlog
 from agentos.channels.types import IncomingMessage, OutgoingMessage
 
 log = structlog.get_logger(__name__)
+
+# ``loop.connect_read_pipe(sys.stdin)`` cannot work on Windows: the default
+# ProactorEventLoop hands ``sys.stdin.fileno()`` -- a CRT fd, not a Win32
+# handle -- to IOCP registration, which fails with ``OSError: [WinError 6]
+# The handle is invalid`` (and a console handle would not be overlapped
+# anyway). The failure surfaces from the first ``readline()``, not from
+# ``connect_read_pipe`` itself, so it cannot be caught and retried there; a
+# SelectorEventLoop raises NotImplementedError instead. Reads go through a
+# thread on Windows, the same way ``send``/``edit`` already write.
+_ON_WINDOWS = os.name == "nt"
 
 
 @dataclass
@@ -32,11 +43,27 @@ class TerminalChannel:
                 self._reader = reader
             return self._reader
 
+    async def _read_line(self) -> bytes:
+        """Return one raw line from stdin, ``b""`` at EOF.
+
+        On Windows the read runs in the default executor under
+        ``_reader_lock`` so overlapping ``receive()`` calls take turns
+        instead of racing for lines. Cancelling the awaiting task does not
+        unblock the worker thread: it keeps waiting for the next line and
+        discards it, and interpreter exit joins it, so wrap ``receive()`` in
+        a timeout only with that in mind.
+        """
+        if _ON_WINDOWS:
+            loop = asyncio.get_running_loop()
+            async with self._reader_lock:
+                return await loop.run_in_executor(None, self._blocking_readline)
+        reader = await self._get_reader()
+        return await reader.readline()
+
     async def receive(self) -> IncomingMessage:
         """Read one line from stdin and return as IncomingMessage."""
-        reader = await self._get_reader()
-        line_bytes = await reader.readline()
-        content = line_bytes.decode(errors="replace").rstrip("\n")
+        line_bytes = await self._read_line()
+        content = line_bytes.decode(errors="replace").removesuffix("\n").removesuffix("\r")
         log.debug("terminal.receive", content=content[:80])
         return IncomingMessage(
             sender_id=self.sender_id,
@@ -67,6 +94,22 @@ class TerminalChannel:
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _blocking_readline() -> bytes:
+        """Read one raw line from stdin; ``b""`` at EOF.
+
+        Reads the underlying byte stream so both platform branches decode
+        with the same UTF-8 ``errors="replace"`` policy (a Windows console
+        yields UTF-8 bytes; redirected input is assumed UTF-8, as on POSIX).
+        A replaced ``sys.stdin`` (a ``StringIO`` in tests or an embedder) has
+        no ``buffer``; its text is re-encoded so the caller sees bytes either
+        way.
+        """
+        buffer = getattr(sys.stdin, "buffer", None)
+        if buffer is not None:
+            return bytes(buffer.readline())
+        return sys.stdin.readline().encode("utf-8", errors="replace")
 
     @staticmethod
     def _write_stdout(text: str) -> None:

--- a/tests/test_channels/test_terminal_channel.py
+++ b/tests/test_channels/test_terminal_channel.py
@@ -1,0 +1,115 @@
+"""``TerminalChannel`` stdin reads on Windows.
+
+``_get_reader`` hands ``sys.stdin`` to ``loop.connect_read_pipe``. On the
+default Windows ``ProactorEventLoop`` that registers the handle with IOCP,
+which only accepts overlapped handles -- a console handle is not one, so the
+transport dies with ``OSError: [WinError 6] The handle is invalid`` and every
+``receive()`` fails. ``send``/``edit`` already run blocking stdio in a thread;
+these tests pin ``receive`` to the same approach on Windows and leave the
+POSIX ``StreamReader`` path untouched.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+
+import pytest
+
+from agentos.channels import terminal as terminal_module
+from agentos.channels.terminal import TerminalChannel
+
+
+def _binary_stdin(data: bytes) -> io.TextIOWrapper:
+    return io.TextIOWrapper(io.BytesIO(data), encoding="utf-8")
+
+
+@pytest.fixture
+def windows(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(terminal_module, "_ON_WINDOWS", True)
+
+    async def _never(self: TerminalChannel) -> asyncio.StreamReader:
+        raise AssertionError("connect_read_pipe path must not be used on Windows")
+
+    monkeypatch.setattr(TerminalChannel, "_get_reader", _never)
+
+
+@pytest.mark.asyncio
+async def test_windows_receive_reads_a_line_without_connect_read_pipe(
+    windows: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("sys.stdin", _binary_stdin(b"hello\nworld\n"))
+    channel = TerminalChannel()
+
+    first = await channel.receive()
+    second = await channel.receive()
+
+    assert (first.content, second.content) == ("hello", "world")
+    assert first.sender_id == "user"
+    assert first.channel_id == "terminal"
+
+
+@pytest.mark.asyncio
+async def test_windows_receive_reports_eof_as_empty_content(
+    windows: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("sys.stdin", _binary_stdin(b""))
+
+    message = await TerminalChannel().receive()
+
+    assert message.content == ""
+
+
+@pytest.mark.asyncio
+async def test_windows_receive_strips_a_console_crlf_terminator(
+    windows: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("sys.stdin", _binary_stdin(b"hello\r\n"))
+
+    message = await TerminalChannel().receive()
+
+    assert message.content == "hello"
+
+
+@pytest.mark.asyncio
+async def test_windows_receive_replaces_undecodable_bytes_like_posix(
+    windows: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Both platform branches share one decoding policy."""
+    monkeypatch.setattr("sys.stdin", _binary_stdin(b"caf\xff\n"))
+
+    message = await TerminalChannel().receive()
+
+    assert message.content == "caf�"
+
+
+@pytest.mark.asyncio
+async def test_windows_receive_copes_with_a_text_only_stdin(
+    windows: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A replaced ``sys.stdin`` (tests, embedders) may have no ``.buffer``."""
+    monkeypatch.setattr("sys.stdin", io.StringIO("typed\n"))
+
+    message = await TerminalChannel().receive()
+
+    assert message.content == "typed"
+
+
+@pytest.mark.asyncio
+async def test_posix_receive_still_uses_the_stream_reader(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(terminal_module, "_ON_WINDOWS", False)
+    monkeypatch.setattr("sys.stdin", _binary_stdin(b"must not be read\n"))
+    reader = asyncio.StreamReader()
+    reader.feed_data(b"from reader\n")
+    reader.feed_eof()
+
+    async def _reader(self: TerminalChannel) -> asyncio.StreamReader:
+        return reader
+
+    monkeypatch.setattr(TerminalChannel, "_get_reader", _reader)
+
+    message = await TerminalChannel().receive()
+
+    assert message.content == "from reader"


### PR DESCRIPTION
## Linked issue
Closes #1575

## Summary
`TerminalChannel._get_reader` hands `sys.stdin` to `loop.connect_read_pipe`. On Windows the default `ProactorEventLoop` passes `sys.stdin.fileno()` — a CRT fd, not a Win32 handle — to IOCP registration, which fails with `OSError: [WinError 6] The handle is invalid`. The failure surfaces from the **first `readline()`**, not from `connect_read_pipe` itself (the transport schedules its first read via `call_soon` and reports through `_fatal_error`), by which point the dead transport is already cached — so a try/except around `connect_read_pipe` would not help, and a `SelectorEventLoop` raises `NotImplementedError` instead. `receive()` never worked on Windows.

Per triage, whether this consumer-less adapter should exist at all is a maintainer question; this PR only fixes the reported crash.

## Fix
Branch on the platform (`_ON_WINDOWS = os.name == "nt"`, the pattern `upgrade_cmd.py` uses). On Windows, `_read_line` runs `_blocking_readline` in the default executor — the same approach `send`/`edit` already take for stdout — serialised under the existing `_reader_lock` so overlapping `receive()` calls take turns rather than racing for lines. POSIX keeps the `StreamReader` path.

Both branches read **bytes** (`sys.stdin.buffer`, with a fallback for a replaced text-only stdin) and share one `errors="replace"` decode, so malformed input behaves the same on both platforms (#1642 reads text-mode `sys.stdin.readline()`, which raises `UnicodeDecodeError` where POSIX substitutes). A trailing CRLF is stripped as one terminator — needed because bypassing `TextIOWrapper` on a Windows console yields `\r\n`; on POSIX this only changes piped CRLF input, which previously kept a stray `\r`.

Documented caveat: cancelling a Windows `receive()` does not unblock the worker thread (it keeps waiting for the next line and discards it, and interpreter exit joins it). Fixing that needs a dedicated daemon thread and is out of scope for the issue's explicit ask.

## Tests
`tests/test_channels/test_terminal_channel.py` (new, 6; the class had none): the Windows path never touches `_get_reader`/`connect_read_pipe` (the fixture makes it raise), reads consecutive lines, reports EOF as empty content, strips a console CRLF, replaces undecodable bytes like POSIX, copes with a `StringIO` stdin; and the POSIX path still uses the `StreamReader`. The real `_blocking_readline` runs in the real executor; offline and deterministic.

## Quality gate
ruff, mypy, full pytest green (one `test_pilot_benchmark` latency flake under parallel load; passes alone).

---

No `CHANGELOG.md` entry on purpose: this PR is one of five opened together (#1570 #1571 #1573 #1575 #1577), each on disjoint files, and the changelog is the one file they would all collide on. All 120 merge orderings were verified conflict-free against `upstream/main`, and the fully merged tree passes the complete gate. Happy to add the bullet in a follow-up `docs(changelog)` once the batch lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfPC1g1hsFx5Tw7LefvgDN
