### PR TITLE
fix(tools): treat a bare empty hunk line as blank context in apply_patch

### DIFF
--- a/src/agentos/tools/builtin/patch.py
+++ b/src/agentos/tools/builtin/patch.py
@@ -110,6 +110,7 @@ def _parse_patch(patch_text: str) -> list[PatchOp]:
                     ):
                         hunk.lines.append(body[i])
                         i += 1
+                    _trim_trailing_separators(hunk)
                     hunks.append(hunk)
                 else:
                     i += 1
@@ -124,6 +125,37 @@ def _parse_patch(patch_text: str) -> list[PatchOp]:
             i += 1
 
     return ops
+
+
+def _split_hunk_line(raw: str) -> tuple[str, str]:
+    """Return ``(prefix, content)`` for one hunk line.
+
+    Unified diffs write an empty context line as a bare ``""`` at least as
+    often as ``" "`` -- editors, terminals, CI log pipelines and most model
+    output strip the trailing space -- so an empty line is a context line
+    whose content is empty, not a line to skip.
+    """
+    if not raw:
+        return " ", ""
+    return raw[0], raw[1:]
+
+
+def _old_side_line_count(lines: list[str]) -> int:
+    """Number of hunk lines that consume a line of the original file."""
+    return sum(1 for raw in lines if _split_hunk_line(raw)[0] in (" ", "-"))
+
+
+def _trim_trailing_separators(hunk: Hunk) -> None:
+    """Drop blank lines that trail the hunk body but are not part of it.
+
+    A bare ``""`` inside a hunk is a blank context line (see
+    ``_split_hunk_line``), but a blank line that merely separates the hunk
+    from the next ``@@@`` / ``***`` marker is formatting, not context. The
+    header's old-side count tells the two apart: a trailing blank the count
+    does not account for is a separator.
+    """
+    while hunk.lines and hunk.lines[-1] == "" and _old_side_line_count(hunk.lines) > hunk.old_count:
+        hunk.lines.pop()
 
 
 def _parse_hunk_header(header: str) -> Hunk:
@@ -470,10 +502,7 @@ def _apply_hunk(file_lines: list[str], hunk: Hunk) -> list[str]:
     # Verify context and deleted lines match
     check_pos = pos
     for raw in hunk.lines:
-        if not raw:
-            continue
-        prefix = raw[0]
-        content = raw[1:]
+        prefix, content = _split_hunk_line(raw)
         if prefix in (" ", "-"):
             if check_pos >= len(result):
                 raise ValueError(f"Hunk context/delete at line {check_pos + 1} exceeds file length")
@@ -490,10 +519,7 @@ def _apply_hunk(file_lines: list[str], hunk: Hunk) -> list[str]:
     new_lines: list[str] = []
     src_pos = pos
     for raw in hunk.lines:
-        if not raw:
-            continue
-        prefix = raw[0]
-        content = raw[1:]
+        prefix, content = _split_hunk_line(raw)
         if prefix == " ":
             new_lines.append(result[src_pos])
             src_pos += 1

--- a/tests/test_tools/test_apply_patch_hunks.py
+++ b/tests/test_tools/test_apply_patch_hunks.py
@@ -178,3 +178,195 @@ def test_apply_hunk_zero_start_with_explicit_old_count_replaces_the_first_line()
     hunk.lines = ["-line1", "+LINE1"]
 
     assert patch_tool._apply_hunk(["line1\n", "line2\n"], hunk) == ["LINE1\n", "line2\n"]
+
+
+# ---------------------------------------------------------------------------
+# Blank context lines (#1577)
+#
+# In unified diff format an empty context line is legitimately written as a
+# bare ``""`` rather than ``" "`` -- editors, terminals, CI log pipelines and
+# most model output strip the trailing space. ``_apply_hunk`` used to skip
+# such lines outright, so every later line was checked against the wrong file
+# line (a spurious "Context mismatch") and, had verification passed, the
+# blank would have been dropped from the output.
+# ---------------------------------------------------------------------------
+
+
+def _hunk(old_start: int, old_count: int, new_count: int, lines: list[str]) -> patch_tool.Hunk:
+    hunk = patch_tool.Hunk(
+        old_start=old_start, old_count=old_count, new_start=old_start, new_count=new_count
+    )
+    hunk.lines = lines
+    return hunk
+
+
+def test_bare_empty_hunk_line_is_a_blank_context_line() -> None:
+    hunk = _hunk(1, 3, 3, [" foo", "", "-bar", "+baz"])
+
+    assert patch_tool._apply_hunk(["foo\n", "\n", "bar\n"], hunk) == ["foo\n", "\n", "baz\n"]
+
+
+def test_space_prefixed_blank_context_line_still_works() -> None:
+    hunk = _hunk(1, 3, 3, [" foo", " ", "-bar", "+baz"])
+
+    assert patch_tool._apply_hunk(["foo\n", "\n", "bar\n"], hunk) == ["foo\n", "\n", "baz\n"]
+
+
+def test_consecutive_blank_context_lines_are_all_kept() -> None:
+    hunk = _hunk(1, 4, 4, [" foo", "", "", "-bar", "+baz"])
+
+    assert patch_tool._apply_hunk(["foo\n", "\n", "\n", "bar\n"], hunk) == [
+        "foo\n",
+        "\n",
+        "\n",
+        "baz\n",
+    ]
+
+
+def test_blank_context_line_as_the_first_hunk_line() -> None:
+    hunk = _hunk(1, 2, 2, ["", "-bar", "+baz"])
+
+    assert patch_tool._apply_hunk(["\n", "bar\n"], hunk) == ["\n", "baz\n"]
+
+
+def test_blank_context_line_as_the_last_hunk_line() -> None:
+    hunk = _hunk(1, 2, 2, ["-bar", "+baz", ""])
+
+    assert patch_tool._apply_hunk(["bar\n", "\n", "tail\n"], hunk) == ["baz\n", "\n", "tail\n"]
+
+
+def test_blank_context_line_must_match_a_blank_file_line() -> None:
+    hunk = _hunk(1, 3, 3, [" foo", "", "-bar", "+baz"])
+
+    with pytest.raises(ValueError, match=r"line 2: expected '', got 'not blank'"):
+        patch_tool._apply_hunk(["foo\n", "not blank\n", "bar\n"], hunk)
+
+
+def test_added_and_deleted_blank_lines_keep_their_prefix_semantics() -> None:
+    hunk = _hunk(1, 3, 3, [" foo", "-", "+", "+added", "-bar"])
+
+    assert patch_tool._apply_hunk(["foo\n", "\n", "bar\n"], hunk) == ["foo\n", "\n", "added\n"]
+
+
+def test_blank_context_line_reuses_the_original_file_line() -> None:
+    """A blank context line is copied through, not re-synthesised."""
+    hunk = _hunk(1, 2, 3, [" foo", "", "+"])
+    original_blank = "\n"
+
+    out = patch_tool._apply_hunk(["foo\n", original_blank], hunk)
+
+    assert out == ["foo\n", "\n", "\n"]
+    assert out[1] is original_blank
+
+
+@pytest.mark.asyncio
+async def test_issue_repro_blank_context_line_without_leading_space(tmp_path: Path) -> None:
+    target = tmp_path / "test.txt"
+    target.write_text("foo\n\nbar\n", encoding="utf-8")
+
+    result = await _apply(
+        tmp_path,
+        "*** Begin Patch\n"
+        "*** Update File: test.txt\n"
+        "@@@ -1,3 +1,3 @@@\n"
+        " foo\n"
+        "\n"
+        "-bar\n"
+        "+baz\n"
+        "*** End Patch",
+    )
+
+    assert "1 file(s) modified" in result
+    assert target.read_text(encoding="utf-8") == "foo\n\nbaz\n"
+
+
+@pytest.mark.asyncio
+async def test_blank_line_before_end_marker_is_not_hunk_context(tmp_path: Path) -> None:
+    """A blank separator after the hunk body must not be read as context."""
+    target = tmp_path / "test.txt"
+    target.write_text("foo\nbar\n", encoding="utf-8")
+
+    await _apply(
+        tmp_path,
+        "*** Begin Patch\n"
+        "*** Update File: test.txt\n"
+        "@@@ -1,2 +1,2 @@@\n"
+        " foo\n"
+        "-bar\n"
+        "+baz\n"
+        "\n"
+        "*** End Patch",
+    )
+
+    assert target.read_text(encoding="utf-8") == "foo\nbaz\n"
+
+
+@pytest.mark.asyncio
+async def test_blank_line_between_hunks_and_files_is_not_hunk_context(tmp_path: Path) -> None:
+    first = tmp_path / "a.txt"
+    second = tmp_path / "b.txt"
+    first.write_text("one\ntwo\nthree\nfour\n", encoding="utf-8")
+    second.write_text("x\n", encoding="utf-8")
+
+    await _apply(
+        tmp_path,
+        "*** Begin Patch\n"
+        "*** Update File: a.txt\n"
+        "@@@ -1,1 +1,1 @@@\n"
+        "-one\n"
+        "+ONE\n"
+        "\n"
+        "@@@ -4,1 +4,1 @@@\n"
+        "-four\n"
+        "+FOUR\n"
+        "\n"
+        "*** Update File: b.txt\n"
+        "@@@ -1,1 +1,1 @@@\n"
+        "-x\n"
+        "+y\n"
+        "*** End Patch",
+    )
+
+    assert first.read_text(encoding="utf-8") == "ONE\ntwo\nthree\nFOUR\n"
+    assert second.read_text(encoding="utf-8") == "y\n"
+
+
+@pytest.mark.asyncio
+async def test_trailing_blank_context_counted_by_the_header_is_kept(tmp_path: Path) -> None:
+    """A trailing ``""`` the header accounts for is real context, not a separator."""
+    target = tmp_path / "test.txt"
+    target.write_text("bar\n\ntail\n", encoding="utf-8")
+
+    await _apply(
+        tmp_path,
+        "*** Begin Patch\n"
+        "*** Update File: test.txt\n"
+        "@@@ -1,2 +1,2 @@@\n"
+        "-bar\n"
+        "+baz\n"
+        "\n"
+        "*** End Patch",
+    )
+
+    assert target.read_text(encoding="utf-8") == "baz\n\ntail\n"
+
+
+def _parsed_hunk_lines(body: str) -> list[str]:
+    ops = patch_tool._parse_patch(f"*** Begin Patch\n*** Update File: t.txt\n{body}\n*** End Patch")
+    (op,) = ops
+    assert isinstance(op, patch_tool.UpdateFile)
+    (hunk,) = op.hunks
+    return hunk.lines
+
+
+def test_separator_after_an_omitted_count_header_is_trimmed() -> None:
+    """``-3 +3`` means one old line; the trailing blank is not a second one."""
+    assert _parsed_hunk_lines("@@@ -3 +3 @@@\n-old\n+new\n") == ["-old", "+new"]
+
+
+def test_separator_after_a_prepend_hunk_is_trimmed() -> None:
+    assert _parsed_hunk_lines("@@@ -0,0 +1,2 @@@\n+one\n+two\n") == ["+one", "+two"]
+
+
+def test_counted_trailing_blank_is_kept_and_only_the_separator_is_trimmed() -> None:
+    assert _parsed_hunk_lines("@@@ -1,2 +1,2 @@@\n-bar\n+baz\n\n\n") == ["-bar", "+baz", ""]


### PR DESCRIPTION
## Linked issue
Closes #1577

## Summary
Both loops in `_apply_hunk` opened with `if not raw: continue`. In unified diff format a blank context line is written as a bare `""` at least as often as `" "` — editors, terminals, CI pipelines and most model output strip the trailing space — so the verification loop skipped it **without advancing `check_pos`** (every later line compared against the wrong file line → spurious `Context mismatch at line N` pointing at the wrong line) and the construction loop would have dropped the blank from the output.

## Fix
- `_split_hunk_line(raw)` maps `""` to `(" ", "")`; both loops use it. A blank context line is verified against the file, advances the cursor, and is copied through from the original line (not re-synthesised).
- A blank line that merely **separates** a hunk from the next `@@@` / `*** Update File:` / `*** End Patch` marker used to be harmlessly skipped; with `""` now meaning context it would be checked against the file and fail. `_trim_trailing_separators` (parser) pops trailing `""` lines only while the hunk's old-side line count exceeds the header's `old_count` — the count `_apply_hunk` already trusts for its splice — so a counted trailing blank stays context and a separator does not become one. Where the header count is wrong, this turns what was silent data loss via the splice into a loud context error; it never makes a previously-correct patch fail.
- Known consequence: a stray blank placed **directly after the `@@@` header** is now a context line (the matrix's "blank as the first line of a hunk"); the count rule cannot tell a leading surplus blank from a trailing one, and the maintainer's spec says leading blanks are context.

## Tests (`test_apply_patch_hunks.py`, +16)
The triage matrix: blank as `""`, as `" "`, several in a row, first line of a hunk, last line of a hunk, `+`/`-` blank lines, mismatch against a non-blank file line reports the right line number, the blank context line reuses the original line object (newline style preserved), the issue's end-to-end repro. Separator handling: blank before `*** End Patch`, between hunks and between files, a counted trailing blank kept, and parser-level cases for an omitted-count header (`-3 +3`), a `-0,0` prepend hunk, and a counted blank followed by a separator.

Follow-up (out of scope): `*** Add File:` bodies keep only `+`-prefixed lines, so a bare `""` there is still dropped.

## Quality gate
ruff, mypy, full pytest green (one `test_pilot_benchmark` latency flake under parallel load; passes alone).

---

No `CHANGELOG.md` entry on purpose: this PR is one of five opened together (#1570 #1571 #1573 #1575 #1577), each on disjoint files, and the changelog is the one file they would all collide on. All 120 merge orderings were verified conflict-free against `upstream/main`, and the fully merged tree passes the complete gate. Happy to add the bullet in a follow-up `docs(changelog)` once the batch lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfPC1g1hsFx5Tw7LefvgDN
