### PR TITLE
fix(security): treat newlines and grouping parens as separators in is_env_dump_command

### DIFF
--- a/src/agentos/redact.py
+++ b/src/agentos/redact.py
@@ -664,13 +664,16 @@ _ENV_DUMP_COMMANDS = frozenset({"env", "printenv", "set", "export", "declare"})
 def is_env_dump_command(command: str | None) -> bool:
     """Return whether *command* prints the environment to stdout.
 
-    Checks the first token of every pipeline or sequence segment. Conservative:
+    Checks the first token of every pipeline or sequence segment. A newline
+    separates commands exactly like ``;`` does (``exec_command`` hands the
+    whole string to the shell, so multi-line scripts are routine), and
+    grouping parentheses are stripped so ``(printenv)`` is seen. Conservative:
     anything it cannot parse is reported as not-a-dump, and the caller falls
     back to the pass that has fewer false positives.
     """
     if not command or not isinstance(command, str):
         return False
-    for segment in re.split(r"[|;&]+", command):
+    for segment in re.split(r"[|;&\r\n]+", command):
         segment = segment.strip()
         if not segment:
             continue
@@ -678,7 +681,10 @@ def is_env_dump_command(command: str | None) -> bool:
             tokens = shlex.split(segment)
         except ValueError:
             tokens = segment.split()
-        if tokens and tokens[0] in _ENV_DUMP_COMMANDS:
+        # ``(printenv)`` / ``( printenv )`` keep the grouping parens glued to
+        # (or in front of) the command; a paren-only token is skipped.
+        first = next((t.strip("()") for t in tokens if t.strip("()")), "")
+        if first in _ENV_DUMP_COMMANDS:
             return True
     return False
 

--- a/tests/test_security/test_redact.py
+++ b/tests/test_security/test_redact.py
@@ -211,10 +211,36 @@ class TestTerminalOutput:
             ("cat notes.txt", False),
             ("echo env", False),
             ("", False),
+            # A newline is a sequence separator, exactly like ``;``.
+            ("cd /srv/app\nprintenv", True),
+            ("cd /srv\r\nprintenv", True),
+            ("set -a\nsource .env\nenv", True),
+            ("cat a.txt\nenv\ncat b.txt", True),
+            # Grouping parentheses must not hide the command inside them.
+            ("(printenv)", True),
+            ("( printenv )", True),
+            ("(cd /srv; printenv)", True),
+            # Ordinary multi-line / parenthesised commands stay out.
+            ("git log --oneline\ngit status", False),
+            ("cat a.txt\ncat b.txt", False),
+            ('grep "(env)" notes.txt', False),
+            ("echo 'set'\nls", False),
+            ("node --env-file=.env app.js", False),
+            ("()", False),
         ],
     )
     def test_env_dump_detection(self, command: str, expected: bool) -> None:
         assert redact.is_env_dump_command(command) is expected
+
+    def test_a_multi_line_env_dump_is_masked_like_its_chained_twin(self) -> None:
+        """Opaque (non-vendor-prefixed) secrets are only caught by the assignment pass."""
+        output = "DEPLOY_API_KEY=9f2b7c41ae55d0e3bb84\nDB_PASSWORD=hunter2hunter2hunter2\n"
+        chained = redact.redact_terminal_output(output, "cd /srv/app && printenv")
+        multi_line = redact.redact_terminal_output(output, "cd /srv/app\nprintenv")
+        grouped = redact.redact_terminal_output(output, "(printenv)")
+        assert "9f2b7c41ae55d0e3bb84" not in chained
+        assert multi_line == chained
+        assert grouped == chained
 
 
 def test_the_disable_switch_is_read_once_at_import(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Closes #1721

## Problem

`redact_terminal_output` only runs the assignment pass (the one that masks opaque `NAME=secret` values) when `is_env_dump_command` says the command dumps the environment. That helper split the command on `[|;&]+` only, so a **newline was not a segment boundary** — and a newline is exactly how an agent writes a two-line `exec_command` script (`create_subprocess_shell` runs them routinely).

`cd /srv/app\nprintenv` → `False` → assignment pass skipped → `DB_PASSWORD=hunter2…` reaches the model in cleartext, while the semantically identical `cd /srv/app && printenv` is masked. `(printenv)` and `(cd /srv; printenv)` were missed the same way because the grouping paren stayed glued to the first token.

Vendor-prefixed keys and JWTs are still caught by `_redact_value_shapes`; the leak is specifically the opaque secrets (DB passwords, internal API keys) the assignment pass exists for. Both call sites — `exec_command` on every backend, and `background_process` polling — are affected.

## Fix

Two small changes inside `is_env_dump_command`:
1. Split on `[|;&\r\n]+` so `\n` / `\r\n` separate segments like `;`.
2. Strip grouping parentheses from the first token before the membership test; a paren-only token (`( printenv )`) is skipped so the real command is examined.

Shell keyword prefixes (`do`, `then`, `{`) stay out of scope, as agreed on the issue. The helper remains conservative — anything unparsable is still reported as not-a-dump.

## Tests

`tests/test_security/test_redact.py`:
- 13 new cases in `test_env_dump_detection` — newline, CRLF, inner-line dump, `set -a\nsource .env\nenv`, `(printenv)`, `( printenv )`, `(cd /srv; printenv)`, plus the false-positive matrix from the issue (`git log\ngit status`, `grep "(env)" notes.txt`, `echo 'set'\nls`, `node --env-file=.env app.js`, `()`).
- `test_a_multi_line_env_dump_is_masked_like_its_chained_twin` — end-to-end: opaque secrets in `printenv` output are masked identically for the chained, multi-line and grouped forms.

7 of the new cases fail on `upstream/main`; all 79 tests in the file pass with the fix.

## Files

- `src/agentos/redact.py`
- `tests/test_security/test_redact.py`

## Merge safety

- Touches only the files listed above; the file set is disjoint from the other four PRs in this batch, and all 120 merge orderings of the batch were verified conflict-free against `upstream/main`.
- `CHANGELOG.md` is deliberately left out: five parallel PRs cannot each insert an `[Unreleased]` bullet without colliding. Happy to open one follow-up `docs(changelog)` PR recording the batch once these land — the ready-made entry is below.

<details><summary>Proposed CHANGELOG entry</summary>

- `is_env_dump_command` now treats a newline (and `\r\n`) as a command
  separator and looks through grouping parentheses, so the output of
  `cd /srv\nprintenv` and `(printenv)` gets the same `NAME=secret` masking as
  `cd /srv && printenv`. Multi-line `exec_command` scripts previously skipped
  the assignment pass and let opaque, non-vendor-prefixed secrets (database
  passwords, internal API keys) reach the model unredacted.
  ([#1721](https://github.com/use-agent-os/agent-os/issues/1721))
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
