### PR TITLE
fix(provider): guard Anthropic message_delta against missing usage and stop_reason

### DIFF
--- a/src/agentos/provider/anthropic.py
+++ b/src/agentos/provider/anthropic.py
@@ -542,29 +542,37 @@ class AnthropicProvider:
                                 )
 
                         elif etype == "message_delta":
-                            usage = event.get("usage", {})
-                            (
-                                iteration_input_tokens,
-                                iteration_output_tokens,
-                            ) = _anthropic_iteration_token_counts(usage)
-                            output_tokens = iteration_output_tokens
-                            cached_tokens = max(
-                                cached_tokens,
-                                usage.get("cache_read_input_tokens", 0),
-                            )
-                            cache_creation_tokens = max(
-                                cache_creation_tokens,
-                                _cache_creation_input_tokens(usage),
-                            )
-                            if "input_tokens" in usage:
-                                base_input_tokens = _coerce_int(usage.get("input_tokens"))
-                            if isinstance(usage.get("iterations"), list):
-                                input_tokens = iteration_input_tokens
-                            else:
-                                input_tokens = (
-                                    base_input_tokens + cached_tokens + cache_creation_tokens
+                            # Last-write-wins guards: a delta that omits
+                            # ``usage`` or ``delta.stop_reason`` (some
+                            # Anthropic-compatible proxies emit trailing or
+                            # empty deltas) must not zero the counts or reset
+                            # ``tool_use`` back to ``end_turn``.
+                            usage = event.get("usage") or {}
+                            if isinstance(usage, dict) and usage:
+                                (
+                                    iteration_input_tokens,
+                                    iteration_output_tokens,
+                                ) = _anthropic_iteration_token_counts(usage)
+                                output_tokens = iteration_output_tokens
+                                cached_tokens = max(
+                                    cached_tokens,
+                                    _coerce_int(usage.get("cache_read_input_tokens")),
                                 )
-                            stop_reason = event.get("delta", {}).get("stop_reason", "end_turn")
+                                cache_creation_tokens = max(
+                                    cache_creation_tokens,
+                                    _cache_creation_input_tokens(usage),
+                                )
+                                if "input_tokens" in usage:
+                                    base_input_tokens = _coerce_int(usage.get("input_tokens"))
+                                if isinstance(usage.get("iterations"), list):
+                                    input_tokens = iteration_input_tokens
+                                else:
+                                    input_tokens = (
+                                        base_input_tokens + cached_tokens + cache_creation_tokens
+                                    )
+                            delta_stop_reason = (event.get("delta") or {}).get("stop_reason")
+                            if delta_stop_reason:
+                                stop_reason = delta_stop_reason
 
                         elif etype == "message_stop":
                             reasoning_content = "".join(thinking_parts) or None

--- a/tests/test_provider_anthropic_message_delta.py
+++ b/tests/test_provider_anthropic_message_delta.py
@@ -1,0 +1,173 @@
+"""``message_delta`` handling in ``AnthropicProvider._stream`` (issue #1724).
+
+A ``message_delta`` that omits ``usage`` or ``delta.stop_reason`` must not
+regress state already accumulated from an earlier delta, and an explicit
+``null`` ``cache_read_input_tokens`` must not crash the stream.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import httpx
+import pytest
+
+from agentos.provider import ChatConfig, DoneEvent, ErrorEvent, Message
+from agentos.provider.anthropic import AnthropicProvider
+
+_MESSAGE_START = {
+    "type": "message_start",
+    "message": {
+        "id": "msg_1",
+        "model": "claude-opus-4-7",
+        "usage": {"input_tokens": 10, "cache_read_input_tokens": 100},
+    },
+}
+_TOOL_BLOCK = [
+    {
+        "type": "content_block_start",
+        "index": 0,
+        "content_block": {"type": "tool_use", "id": "toolu_1", "name": "read_file"},
+    },
+    {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {"type": "input_json_delta", "partial_json": '{"path": "a"}'},
+    },
+    {"type": "content_block_stop", "index": 0},
+]
+
+
+def _sse_body(events: list[dict]) -> bytes:
+    parts = []
+    for ev in events:
+        parts.append(f"event: {ev['type']}\n".encode())
+        parts.append(f"data: {json.dumps(ev)}\n\n".encode())
+    return b"".join(parts)
+
+
+def _run(monkeypatch: pytest.MonkeyPatch, events: list[dict]) -> DoneEvent:
+    body = _sse_body(events)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, headers={"content-type": "text/event-stream"}, content=body)
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def patched_async_client(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr("agentos.provider.anthropic.httpx.AsyncClient", patched_async_client)
+    provider = AnthropicProvider(api_key="test", model="claude-opus-4-7")
+
+    async def _collect() -> DoneEvent:
+        done: DoneEvent | None = None
+        async for ev in provider.chat([Message(role="user", content="hi")], config=ChatConfig()):
+            assert not isinstance(ev, ErrorEvent), ev.message
+            if isinstance(ev, DoneEvent):
+                done = ev
+        assert done is not None
+        return done
+
+    return asyncio.run(_collect())
+
+
+def test_trailing_empty_delta_keeps_tool_use_stop_reason_and_output_tokens(monkeypatch) -> None:
+    done = _run(
+        monkeypatch,
+        [
+            _MESSAGE_START,
+            *_TOOL_BLOCK,
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": "tool_use"},
+                "usage": {"output_tokens": 42},
+            },
+            {"type": "message_delta", "delta": {}},
+            {"type": "message_stop"},
+        ],
+    )
+    assert done.stop_reason == "tool_use"
+    assert done.output_tokens == 42
+    assert done.cached_tokens == 100
+    assert done.input_tokens == 110
+
+
+def test_trailing_usage_only_delta_updates_tokens_but_not_stop_reason(monkeypatch) -> None:
+    done = _run(
+        monkeypatch,
+        [
+            _MESSAGE_START,
+            *_TOOL_BLOCK,
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": "tool_use"},
+                "usage": {"output_tokens": 42},
+            },
+            {"type": "message_delta", "usage": {"output_tokens": 45}},
+            {"type": "message_stop"},
+        ],
+    )
+    assert done.stop_reason == "tool_use"
+    assert done.output_tokens == 45
+
+
+def test_explicit_null_stop_reason_and_null_usage_do_not_regress_state(monkeypatch) -> None:
+    done = _run(
+        monkeypatch,
+        [
+            _MESSAGE_START,
+            *_TOOL_BLOCK,
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": "tool_use"},
+                "usage": {"output_tokens": 42},
+            },
+            {"type": "message_delta", "delta": {"stop_reason": None}, "usage": None},
+            {"type": "message_stop"},
+        ],
+    )
+    assert done.stop_reason == "tool_use"
+    assert done.output_tokens == 42
+
+
+def test_null_cache_read_input_tokens_does_not_crash_the_stream(monkeypatch) -> None:
+    """The Messages API schema types ``cache_read_input_tokens`` as ``integer | null``."""
+    done = _run(
+        monkeypatch,
+        [
+            _MESSAGE_START,
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": "end_turn"},
+                "usage": {"output_tokens": 7, "cache_read_input_tokens": None},
+            },
+            {"type": "message_stop"},
+        ],
+    )
+    assert done.stop_reason == "end_turn"
+    assert done.output_tokens == 7
+    assert done.cached_tokens == 100
+
+
+def test_single_delta_last_write_wins_is_unchanged(monkeypatch) -> None:
+    """The normal one-delta stream keeps its exact previous behaviour."""
+    done = _run(
+        monkeypatch,
+        [
+            _MESSAGE_START,
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": "max_tokens"},
+                "usage": {"output_tokens": 9, "cache_read_input_tokens": 250},
+            },
+            {"type": "message_stop"},
+        ],
+    )
+    assert done.stop_reason == "max_tokens"
+    assert done.output_tokens == 9
+    assert done.cached_tokens == 250
+    assert done.input_tokens == 260


### PR DESCRIPTION
Closes #1724

## Problem

`AnthropicProvider._stream` treated every `message_delta` as a full rewrite of the accumulated state:

1. `stop_reason = event.get("delta", {}).get("stop_reason", "end_turn")` reset `tool_use` back to `end_turn` whenever a delta omitted `delta.stop_reason` — the engine then ended the turn without running the requested tools.
2. `output_tokens = iteration_output_tokens` zeroed the count whenever a delta omitted `usage` (`_anthropic_iteration_token_counts({})` → `(0, 0)`), corrupting billing / budget tracking.
3. `max(cached_tokens, usage.get("cache_read_input_tokens", 0))` raised `TypeError` on an explicit `null`, which the Messages API schema allows (`integer | null`) and which the non-streaming path already coerces through `_coerce_int` (`anthropic.py:280`).

## Fix

Per the accepted scope — plain last-write-wins guards, no accumulation or merging:

- token counts (`output_tokens`, cached / cache-creation, `input_tokens` recompute) update only when the delta carries a non-empty `usage` dict;
- `stop_reason` is overwritten only when `delta.stop_reason` is present and non-empty;
- `cache_read_input_tokens` goes through `_coerce_int`, matching the non-streaming path.

A normal single-delta stream behaves exactly as before (pinned by a test).

## Tests

New `tests/test_provider_anthropic_message_delta.py` (5 end-to-end SSE tests over `httpx.MockTransport`, same harness as `test_provider_anthropic_usage.py`):
- trailing empty delta keeps `stop_reason="tool_use"` and `output_tokens=42`
- trailing usage-only delta updates tokens (45) but not `stop_reason`
- explicit `"stop_reason": null` / `"usage": null` do not regress state
- `cache_read_input_tokens: null` no longer crashes the stream
- single-delta last-write-wins is unchanged

4 of 5 fail on `upstream/main`; all pass with the fix, as do the existing `test_provider_anthropic_usage.py` tests.

## Files

- `src/agentos/provider/anthropic.py`
- `tests/test_provider_anthropic_message_delta.py` (new)

## Merge safety

- Touches only the files listed above; the file set is disjoint from the other four PRs in this batch, and all 120 merge orderings of the batch were verified conflict-free against `upstream/main`.
- `CHANGELOG.md` is deliberately left out: five parallel PRs cannot each insert an `[Unreleased]` bullet without colliding. Happy to open one follow-up `docs(changelog)` PR recording the batch once these land — the ready-made entry is below.

<details><summary>Proposed CHANGELOG entry</summary>

- `AnthropicProvider` no longer lets a trailing or empty `message_delta`
  regress the stream's state: `stop_reason` is only overwritten when the delta
  carries one (so a `tool_use` turn is not turned into `end_turn` and its
  tools skipped), token counts are only overwritten when the delta carries
  `usage` (so `DoneEvent.output_tokens` is not zeroed), and an explicit
  `cache_read_input_tokens: null` — allowed by the Messages API schema — is
  coerced instead of raising `TypeError` and killing the stream.
  ([#1724](https://github.com/use-agent-os/agent-os/issues/1724))
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
