### PR TITLE
fix(tools): match inline artifact markers on CRLF line endings

### DIFF
--- a/src/agentos/tools/builtin/artifacts.py
+++ b/src/agentos/tools/builtin/artifacts.py
@@ -315,8 +315,12 @@ async def publish_artifact(
 # charge of whether the UI draws.
 
 #: The marker a skill script prints, alone on its own line.
+# A trailing ``\r`` is tolerated but not captured: subprocess output is decoded
+# without newline normalisation and Python's text stdout ends lines with
+# ``\r\n`` on Windows, so ``[ \t]*$`` alone never matched there. Keeping the
+# ``\r`` out of the match means replacing the marker preserves the line ending.
 INLINE_ARTIFACT_MARKER_RE = re.compile(
-    r"^publish_artifact[ \t]+path=(?P<path>\S+)[ \t]+mime=(?P<mime>\S+)[ \t]*$",
+    r"^publish_artifact[ \t]+path=(?P<path>\S+)[ \t]+mime=(?P<mime>\S+)[ \t]*(?=\r?$)",
     re.MULTILINE,
 )
 

--- a/tests/test_tools/test_inline_artifacts.py
+++ b/tests/test_tools/test_inline_artifacts.py
@@ -90,6 +90,35 @@ async def test_several_markers_each_publish(ctx: Any, published: list[dict[str, 
     assert "publish_artifact path=" not in out
 
 
+@pytest.mark.asyncio
+async def test_crlf_terminated_marker_publishes_and_keeps_its_line_ending(
+    ctx: Any, published: list[dict[str, str]]
+) -> None:
+    """Python's text stdout ends lines with ``\\r\\n`` on Windows (issue #1732)."""
+    out = await publish_inline_artifacts(f"looked up 683 tokens\r\n{marker()}\r\ndone\r\n")
+    assert published == [{"path": "apple.cards.json", "mime": CARDS_MIME}]
+    assert "publish_artifact path=" not in out
+    assert out.startswith("looked up 683 tokens\r\n")
+    assert out.endswith("Do not call publish_artifact for it.]\r\ndone\r\n")
+
+
+@pytest.mark.asyncio
+async def test_crlf_marker_with_trailing_whitespace_publishes(
+    ctx: Any, published: list[dict[str, str]]
+) -> None:
+    out = await publish_inline_artifacts(f"{marker()} \t\r\n")
+    assert [c["path"] for c in published] == ["apple.cards.json"]
+    assert out.endswith("\r\n")
+
+
+@pytest.mark.asyncio
+async def test_several_crlf_markers_each_publish(ctx: Any, published: list[dict[str, str]]) -> None:
+    out = await publish_inline_artifacts(f"{marker('a.json')}\r\n{marker('b.json')}\r\n")
+    assert [c["path"] for c in published] == ["a.json", "b.json"]
+    assert "publish_artifact path=" not in out
+    assert out.count("\r\n") == 2
+
+
 # ── Guards ──────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #1732

## Problem

`INLINE_ARTIFACT_MARKER_RE` ended in `[ \t]*$` (MULTILINE). `$` only matches before `\n`, and `\r` is neither a space nor a tab, so a marker line terminated by `\r\n` never matched. The shell tool decodes subprocess output without newline normalisation and Python's text stdout emits `\r\n` on Windows even through a pipe, so `publish_inline_artifacts` — added in 192e8531 — never fired on Windows: the cards/charts written by bundled skills stayed in the workspace and were never rendered.

## Fix

The regex now ends in `[ \t]*(?=\r?$)`. The optional `\r` is matched but **not captured** (lookahead), so `match.group(0)` — the string that gets replaced with the "already rendered" note — excludes it and the line keeps its original ending. Nothing else about shell output is normalised, per the accepted scope.

## Tests

`tests/test_tools/test_inline_artifacts.py`, three new tests:
- CRLF-terminated marker publishes, and the surrounding `\r\n` line endings are preserved byte-for-byte
- CRLF marker with trailing whitespace publishes
- several CRLF markers each publish and the output keeps exactly two `\r\n`

All three fail on `upstream/main`; all 13 tests in the file pass with the fix.

## Files

- `src/agentos/tools/builtin/artifacts.py`
- `tests/test_tools/test_inline_artifacts.py`

## Merge safety

- Touches only the files listed above; the file set is disjoint from the other four PRs in this batch, and all 120 merge orderings of the batch were verified conflict-free against `upstream/main`.
- `CHANGELOG.md` is deliberately left out: five parallel PRs cannot each insert an `[Unreleased]` bullet without colliding. Happy to open one follow-up `docs(changelog)` PR recording the batch once these land — the ready-made entry is below.

<details><summary>Proposed CHANGELOG entry</summary>

- Inline artifact markers (`publish_artifact path=… mime=…`) printed by a
  command are now recognised on CRLF-terminated lines. The marker regex ended
  in `[ \t]*$`, which never matched the `\r\n` Python's text stdout emits on
  Windows, so the auto-publish added in 192e8531 never fired there and the
  cards/charts written by bundled skills were left unrendered. The `\r` is
  tolerated but not captured, so replacing the marker keeps the line's
  original ending.
  ([#1732](https://github.com/use-agent-os/agent-os/issues/1732))
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
