### PR TITLE
fix(tools): keep CJK punctuation and fullwidth symbols in create_pdf_report

### DIFF
--- a/src/agentos/tools/builtin/file_authoring.py
+++ b/src/agentos/tools/builtin/file_authoring.py
@@ -153,6 +153,23 @@ def _is_cjk(char: str) -> bool:
     )
 
 
+def _is_cjk_symbol(char: str) -> bool:
+    """Punctuation and symbol blocks that CJK text is written with.
+
+    Not ideographs, so the base font keeps them when it can render them; when
+    it cannot (Helvetica stops at U+00FF) they go to the CJK font rather than
+    being dropped, which used to silently delete every ``，。：！《》`` and
+    ``“ ” — …`` from a report on hosts without a local TTF.
+    """
+    codepoint = ord(char)
+    return (
+        0x2000 <= codepoint <= 0x206F  # General Punctuation
+        or 0x3000 <= codepoint <= 0x303F  # CJK Symbols and Punctuation
+        or 0xFE30 <= codepoint <= 0xFE4F  # CJK Compatibility Forms
+        or 0xFF00 <= codepoint <= 0xFFEF  # Halfwidth and Fullwidth Forms
+    )
+
+
 def _font_supports_char(font_name: str, char: str) -> bool:
     from reportlab.pdfbase import pdfmetrics  # type: ignore[import-untyped]
 
@@ -186,7 +203,11 @@ def _pdf_markup_text(value: Any, *, base_font: str, cjk_font: str | None) -> str
         run_font = None
 
     for char in text:
-        target_font = cjk_font if cjk_font is not None and _is_cjk(char) else None
+        target_font: str | None = None
+        if cjk_font is not None and (
+            _is_cjk(char) or (_is_cjk_symbol(char) and not _font_supports_char(base_font, char))
+        ):
+            target_font = cjk_font
         if target_font is None and not _font_supports_char(base_font, char):
             continue
         if target_font != run_font:

--- a/tests/test_tools/test_pdf_report_cjk_punctuation.py
+++ b/tests/test_tools/test_pdf_report_cjk_punctuation.py
@@ -1,0 +1,130 @@
+"""``create_pdf_report`` must not drop CJK punctuation and fullwidth symbols (issue #1739).
+
+On hosts without a local TTF the base font is Helvetica, which only renders
+U+0000-U+00FF. Ideographs were already routed to ``STSong-Light``; the
+punctuation written between them was silently deleted.
+"""
+
+from __future__ import annotations
+
+import json
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from pypdf import PdfReader
+
+from agentos.artifacts import ArtifactStore
+from agentos.tools.builtin import file_authoring
+from agentos.tools.builtin.file_authoring import (
+    _is_cjk_symbol,
+    _pdf_markup_text,
+    _register_pdf_fonts,
+    create_pdf_report,
+)
+from agentos.tools.types import CallerKind, ToolContext, current_tool_context
+
+CJK_FONT = "STSong-Light"
+
+
+def _markup(text: str) -> str:
+    _register_pdf_fonts()
+    return _pdf_markup_text(text, base_font="Helvetica", cjk_font=CJK_FONT)
+
+
+@pytest.mark.parametrize(
+    "char",
+    ["，", "。", "：", "！", "《", "》", "“", "”", "—", "…", "／", "Ａ"],
+)
+def test_cjk_symbol_blocks_are_classified(char: str) -> None:
+    assert _is_cjk_symbol(char)
+
+
+@pytest.mark.parametrize("char", ["a", ",", "é", "中", "✅"])
+def test_ordinary_and_ideographic_chars_are_not_cjk_symbols(char: str) -> None:
+    assert not _is_cjk_symbol(char)
+
+
+def test_helvetica_base_routes_cjk_punctuation_to_the_cjk_font() -> None:
+    markup = _markup("测试报告：重要通知！")
+    assert markup == f'<font name="{CJK_FONT}">测试报告：重要通知！</font>'
+
+
+def test_helvetica_base_keeps_quotes_dashes_and_ellipsis() -> None:
+    text = "你好，世界！这是“测试”——破折号……省略号。"
+    markup = _markup(text)
+    for char in "，！“”—…。":
+        assert char in markup
+    assert markup == f'<font name="{CJK_FONT}">{text}</font>'
+
+
+def test_latin_text_stays_on_the_base_font_and_unsupported_symbols_are_still_dropped() -> None:
+    markup = _markup("Title: ok ✅ — done")
+    assert markup.startswith("Title: ok ")
+    assert "✅" not in markup
+    assert f'<font name="{CJK_FONT}">—</font>' in markup
+
+
+def test_without_a_cjk_font_the_punctuation_is_dropped_not_crashed() -> None:
+    _register_pdf_fonts()
+    assert _pdf_markup_text("a，b", base_font="Helvetica", cjk_font=None) == "ab"
+
+
+def _channel_artifact_context(tmp_path: Path) -> ToolContext:
+    root = tmp_path / "artifacts"
+    root.mkdir()
+    return ToolContext(
+        workspace_dir=str(tmp_path),
+        session_key="agent:main:main",
+        artifact_session_id="sess-1",
+        artifact_media_root=str(root),
+        caller_kind=CallerKind.CHANNEL,
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_pdf_report_preserves_cjk_punctuation_on_helvetica_hosts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Simulate a host with no local TTF (Docker, CI, minimal Linux): the real
+    # registration still runs (so STSong-Light exists) but the report is built
+    # on Helvetica, exactly as ``_register_pdf_fonts`` resolves it there.
+    _register_pdf_fonts()
+    monkeypatch.setattr(
+        file_authoring,
+        "_register_pdf_fonts",
+        lambda: ("Helvetica", "Helvetica-Bold", CJK_FONT),
+    )
+
+    ctx = _channel_artifact_context(tmp_path)
+    token = current_tool_context.set(ctx)
+    try:
+        result = await create_pdf_report(
+            name="cjk-report.pdf",
+            title="测试报告：重要通知！",
+            sections=[
+                {
+                    "heading": "第一节：说明《细节》",
+                    "body": "你好，世界！这是“测试”——破折号……省略号。",
+                }
+            ],
+        )
+    finally:
+        current_tool_context.reset(token)
+
+    payload = json.loads(result)
+    store = ArtifactStore(ctx.artifact_media_root or "")
+    _, path = store.resolve_for_download(
+        str(payload["artifact"]["id"]),
+        session_id=str(payload["artifact"]["session_id"]),
+    )
+    material = Path(path).read_bytes()
+    text = "".join(page.extract_text() for page in PdfReader(BytesIO(material)).pages)
+    for needle in (
+        "测试报告：重要通知！",
+        "第一节：说明《细节》",
+        "你好，世界！",
+        "“测试”",
+        "……省略号。",
+    ):
+        assert needle in text, f"{needle!r} missing from {text!r}"


### PR DESCRIPTION
Closes #1739

## Problem

`_pdf_markup_text` routed only CJK **ideographs** (`_is_cjk`) to the registered `STSong-Light` font and dropped any other character the base font could not render. On hosts without a local TTF (Docker, CI, minimal Linux) the base font is Helvetica, for which `_font_supports_char` is `ord(char) < 256`, so every `，。：！《》`, fullwidth form and `“ ” — …` between the ideographs was silently deleted:

```
测试报告：重要通知！  →  测试报告重要通知
你好，世界！这是“测试”——破折号……省略号。  →  你好世界这是测试破折号省略号
```

## Fix

A new `_is_cjk_symbol(char)` covers the four blocks named in the issue — CJK Symbols and Punctuation (U+3000–303F), CJK Compatibility Forms (U+FE30–FE4F), Halfwidth and Fullwidth Forms (U+FF00–FFEF) and General Punctuation (U+2000–206F). In `_pdf_markup_text` those characters:

- keep the **base** font when it can render them (a DejaVu / Arial TTF host — no visual change there), and
- fall back to the **CJK** font when it cannot (Helvetica), instead of being dropped.

Ideographs are routed exactly as before. No font-loading changes.

## Tests

New `tests/test_tools/test_pdf_report_cjk_punctuation.py`:
- block classification for the 12 characters from the issue + negatives (`a`, `,`, `é`, `中`, `✅`)
- `_pdf_markup_text` on Helvetica keeps `：！`, quotes, em-dash and ellipsis inside the `STSong-Light` run
- Latin text stays on the base font; a genuinely unsupported symbol (`✅`) is still dropped rather than crashing
- with no CJK font registered, punctuation is dropped (unchanged behaviour), not crashed
- end-to-end `create_pdf_report` on a simulated Helvetica host: `pypdf` extracts `测试报告：重要通知！`, `第一节：说明《细节》`, `“测试”`, `……省略号。`

Before/after on `upstream/main`: `_pdf_markup_text('测试报告：重要通知！', base_font='Helvetica', cjk_font='STSong-Light')` → `测试报告重要通知` before, `测试报告：重要通知！` after. Existing `test_file_authoring_tools.py` passes unchanged.

## Files

- `src/agentos/tools/builtin/file_authoring.py`
- `tests/test_tools/test_pdf_report_cjk_punctuation.py` (new)

## Merge safety

- Touches only the files listed above; the file set is disjoint from the other four PRs in this batch, and all 120 merge orderings of the batch were verified conflict-free against `upstream/main`.
- `CHANGELOG.md` is deliberately left out: five parallel PRs cannot each insert an `[Unreleased]` bullet without colliding. Happy to open one follow-up `docs(changelog)` PR recording the batch once these land — the ready-made entry is below.

<details><summary>Proposed CHANGELOG entry</summary>

- `create_pdf_report` no longer drops CJK punctuation and fullwidth symbols on
  hosts whose base font is Helvetica (Docker, CI, minimal Linux). Only
  ideographs were routed to the `STSong-Light` CID font; `，。：！《》`,
  fullwidth forms and `“ ” — …` were deleted because Helvetica cannot render
  them. Those blocks now fall back to the CJK font when the base font lacks
  them, and keep the base font when a local TTF has them.
  ([#1739](https://github.com/use-agent-os/agent-os/issues/1739))
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
