### PR TITLE
fix(cli): exit non-zero when `cron run` reports the job did not run

### DIFF
--- a/src/agentos/cli/cron_cmd.py
+++ b/src/agentos/cli/cron_cmd.py
@@ -11,8 +11,8 @@ from typing import Annotated, Any
 import typer
 from rich.table import Table
 
-from agentos.cli.gateway_rpc import confirm_or_exit, run_gateway_sync
-from agentos.cli.output import print_json
+from agentos.cli.gateway_rpc import confirm_or_exit, rpc_error_exit_code, run_gateway_sync
+from agentos.cli.output import emit_error, print_json
 from agentos.cli.ui import ACCENT_HEADER, console
 
 cron_app = typer.Typer(help="Inspect and manage scheduled AgentOS runs.")
@@ -1148,6 +1148,40 @@ def cron_run(
 
     payload = run_gateway_sync(_run, json_output=json_output)
     _emit_success(payload, json_output=json_output, title="Cron run result")
+    _exit_on_manual_run_failure(payload, json_output=json_output)
+
+
+def _exit_on_manual_run_failure(payload: Any, *, json_output: bool) -> None:
+    """Turn a ``success: false`` ``cron.run`` payload into a non-zero exit.
+
+    ``cron.run`` reports a missing / disabled / busy job (and a run whose
+    handler failed) as a *successful* RPC carrying ``success: false`` so the
+    Control UI can render it; the CLI has to map that onto ``$?`` itself or a
+    script would treat a job that never ran as a success. ``not_found`` exits
+    2 like ``cron status`` / ``cron update`` on the same id; every other
+    failure exits 1. The wire payload has already been printed above, so
+    ``--json`` consumers keep the full body on stdout.
+    """
+
+    if not isinstance(payload, dict) or payload.get("success") is not False:
+        return
+    status = str(payload.get("status") or "").strip().lower()
+    error = payload.get("error")
+    reason = payload.get("reason")
+    if error:
+        message = str(error)
+    elif status == "accepted":
+        message = "cron run failed"
+    else:
+        message = f"cron run rejected: {reason or status or 'unknown'}"
+    if status == "not_found":
+        code = "NOT_FOUND"
+    elif status and status != "accepted":
+        code = f"RUN_{status.upper()}"
+    else:
+        code = "RUN_FAILED"
+    emit_error(message, json_output=json_output, code=code)
+    raise typer.Exit(rpc_error_exit_code(code))
 
 
 @cron_app.command("runs")

--- a/tests/test_cli/test_cron_run_exit_code.py
+++ b/tests/test_cli/test_cron_run_exit_code.py
@@ -1,0 +1,124 @@
+"""``agentos cron run`` must exit non-zero when the job did not actually run.
+
+``cron.run`` reports a missing / disabled / busy job as a *successful* RPC whose
+payload carries ``success: false`` (so the Control UI can render it). The CLI
+has to translate that into ``$?`` itself; before the fix ``_emit_success``
+printed the honest payload and returned 0 (#1684).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+import typer
+
+from agentos.cli import cron_cmd
+
+
+@pytest.fixture
+def run_payload(monkeypatch):
+    """Drive ``cron_run`` against a canned ``cron.run`` reply, skipping confirmation."""
+
+    def _install(payload: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
+        calls: list[tuple[str, dict[str, Any]]] = []
+
+        class _Client:
+            async def call(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+                calls.append((method, params))
+                return payload
+
+        def _runner(fn, *, json_output: bool = False):  # noqa: ARG001
+            return asyncio.run(fn(_Client()))
+
+        monkeypatch.setattr(cron_cmd, "run_gateway_sync", _runner)
+        monkeypatch.setattr(cron_cmd, "confirm_or_exit", lambda *a, **kw: None)
+        return calls
+
+    return _install
+
+
+def _invoke(job_id: str = "missing-job-xyz", *, json_output: bool) -> int:
+    try:
+        cron_cmd.cron_run(job_id=job_id, yes=True, json_output=json_output)
+    except typer.Exit as exc:
+        return int(exc.exit_code)
+    return 0
+
+
+def test_missing_job_exits_2_and_keeps_the_payload_on_stdout(run_payload, capsys) -> None:
+    payload = {
+        "success": False,
+        "status": "not_found",
+        "reason": "not_found",
+        "error": "Cron job not found",
+    }
+    calls = run_payload(payload)
+
+    assert _invoke(json_output=True) == 2
+
+    captured = capsys.readouterr()
+    assert calls == [("cron.run", {"id": "missing-job-xyz"})]
+    # stdout is still exactly the wire payload, so ``--json`` consumers keep it.
+    assert json.loads(captured.out) == payload
+    # the diagnostic goes to stderr with the same code ``cron status`` uses.
+    err = json.loads(captured.err)
+    assert err["error"]["code"] == "NOT_FOUND"
+    assert "Cron job not found" in err["error"]["message"]
+
+
+def test_missing_job_exits_2_in_human_mode(run_payload, capsys) -> None:
+    run_payload({"success": False, "status": "not_found", "reason": "not_found", "error": None})
+
+    assert _invoke(json_output=False) == 2
+
+    captured = capsys.readouterr()
+    assert "not_found" in captured.err
+
+
+@pytest.mark.parametrize("status", ["disabled", "busy", "blocked", "no_handler"])
+def test_rejected_run_exits_1(run_payload, status: str, capsys) -> None:
+    run_payload({"success": False, "status": status, "reason": status, "error": None})
+
+    assert _invoke("job-1", json_output=True) == 1
+
+    err = json.loads(capsys.readouterr().err)
+    assert err["error"]["code"] == f"RUN_{status.upper()}"
+    assert status in err["error"]["message"]
+
+
+def test_accepted_run_that_failed_exits_1(run_payload, capsys) -> None:
+    run_payload(
+        {
+            "success": False,
+            "status": "accepted",
+            "reply": "",
+            "error": "handler exploded",
+            "duration_ms": 12,
+        }
+    )
+
+    assert _invoke("job-1", json_output=True) == 1
+
+    err = json.loads(capsys.readouterr().err)
+    assert err["error"]["code"] == "RUN_FAILED"
+    assert err["error"]["message"] == "handler exploded"
+
+
+def test_successful_run_still_exits_0(run_payload, capsys) -> None:
+    payload = {"success": True, "status": "accepted", "reply": "done", "error": None}
+    run_payload(payload)
+
+    assert _invoke("job-1", json_output=True) == 0
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == payload
+    assert captured.err == ""
+
+
+def test_non_dict_payload_is_left_alone(run_payload) -> None:
+    run_payload("ok")  # type: ignore[arg-type]
+
+    assert _invoke("job-1", json_output=False) == 0


### PR DESCRIPTION
Fixes #1684

## Problem

`cron.run` reports a missing / disabled / busy job (and an accepted run whose handler failed) as a *successful* RPC whose payload carries `success: false`, so the Control UI can render it. `cron_run` handed that payload straight to `_emit_success` and returned normally:

```console
$ agentos cron run missing-job-xyz --yes --json
{"success": false, "status": "not_found", "reason": "not_found", "error": "Cron job not found"}
# exit 0
```

The payload is honest; `$?` is not. `cron status` / `cron update` on the same id exit 2.

## Fix (CLI-side only, as preferred in triage)

After printing the payload, `cron_run` maps a `success: false` body onto the existing CLI exit-code convention via `rpc_error_exit_code`:

| payload | stderr code | exit |
|---|---|---|
| `status: not_found` | `NOT_FOUND` | 2 |
| `status: disabled / busy / blocked / no_handler` | `RUN_<STATUS>` | 1 |
| `status: accepted`, `success: false` (handler failed) | `RUN_FAILED` | 1 |
| `success: true` | — | 0 |

The wire payload still goes to stdout first, so `--json` consumers keep the full body; the diagnostic goes to stderr through `emit_error` like every other CLI failure. The `cron.run` RPC contract for Control UI consumers is untouched.

## Tests

`tests/test_cli/test_cron_run_exit_code.py` drives `cron_run` against canned `cron.run` replies (7 of 9 fail on `main`): not-found exits 2 in both `--json` and human mode with the payload intact on stdout and `NOT_FOUND` on stderr; each rejection status exits 1 with `RUN_<STATUS>`; a failed accepted run exits 1 with the handler error as the message; a successful run still exits 0 with a clean stderr; a non-dict payload is left alone.

`docs/cli.md` and the bundled `agentos` SKILL.md do not document `cron run` exit codes today, so nothing there needed updating.

## Merge safety

This PR is one of five opened together (#1684, #1689, #1691, #1705, #1707). Each touches a disjoint set of files and none touches `CHANGELOG.md`, so they can be merged one by one in any order; all 120 orderings were verified conflict-free against `upstream/main`, and the fully merged tree passes the complete gate (ruff, mypy, full pytest). Happy to follow up with a single `docs(changelog)` PR recording the batch once they land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
