### PR TITLE
fix(tools): record workspace file writes in edit_file

### DIFF
--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -916,6 +916,9 @@ async def edit_file(
         p.write_text(updated, encoding="utf-8")
 
     await loop.run_in_executor(None, _write)
+    # Same bookkeeping as write_file / apply_patch: an edited deliverable is
+    # still a workspace write, and artifact delivery only sees the ones recorded.
+    record_workspace_file_write(p)
     _notify_memory_source_write(p)
     _notify_bootstrap_source_write(p)
     summary = f"replaced {len(old_text)} chars with {len(new_text)} chars"

--- a/tests/test_engine/test_runtime_artifacts.py
+++ b/tests/test_engine/test_runtime_artifacts.py
@@ -895,7 +895,8 @@ async def test_turn_runner_auto_publishes_overwritten_deliverable_file(tmp_path)
 
 
 @pytest.mark.asyncio
-async def test_turn_runner_does_not_auto_publish_edited_config_json(tmp_path) -> None:
+async def test_turn_runner_auto_publishes_deliverable_file_edited_in_place(tmp_path) -> None:
+    """``edit_file`` is a tracked workspace write like ``write_file`` / ``apply_patch`` (#1689)."""
     storage = SessionStorage(":memory:")
     await storage.connect()
     manager = SessionManager(storage)
@@ -933,11 +934,15 @@ async def test_turn_runner_does_not_auto_publish_edited_config_json(tmp_path) ->
         ]
 
         artifact_events = [event for event in events if isinstance(event, ArtifactEvent)]
-        assert artifact_events == []
+        assert [event.name for event in artifact_events] == ["config.json"]
+        assert (workspace / "config.json").read_text(encoding="utf-8") == '{"enabled": true}\n'
 
         transcript = await manager.get_transcript(session_key)
         assistant = [entry for entry in transcript if entry.role == "assistant"][-1]
-        assert assistant.content == "Updated config.json."
+        payload = json.loads(assistant.content)
+        assert payload["text"] == "Updated config.json."
+        assert payload["artifacts"][0]["name"] == "config.json"
+        assert payload["artifacts"][0]["source"] == "auto_publish_omitted"
     finally:
         await storage.close()
 

--- a/tests/test_tools/test_filesystem_read_workspace.py
+++ b/tests/test_tools/test_filesystem_read_workspace.py
@@ -435,3 +435,49 @@ async def test_write_file_records_workspace_write_on_both_create_and_overwrite(
         current_tool_context.reset(token)
 
 
+@pytest.mark.asyncio
+async def test_edit_file_records_workspace_write(tmp_path: Path) -> None:
+    """An in-place edit is a workspace write too (#1689).
+
+    ``auto_publish_omitted_workspace_artifacts`` reads ``ctx.workspace_file_writes``
+    to find deliverables the turn touched; ``edit_file`` used to skip the record,
+    so a report edited in place was never auto-published.
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    target = workspace / "report.md"
+    target.write_text("initial report draft", encoding="utf-8")
+    ctx = ToolContext(workspace_dir=str(workspace))
+    token = current_tool_context.set(ctx)
+    raw_edit_file = fs.edit_file.__wrapped__.__wrapped__
+    try:
+        result = await raw_edit_file(str(target), "draft", "final")
+        assert result.startswith("Edited ")
+        assert target.read_text(encoding="utf-8") == "initial report final"
+        assert len(ctx.workspace_file_writes) == 1
+        record = ctx.workspace_file_writes[0]
+        assert record["name"] == "report.md"
+        assert record["relative_path"] == "report.md"
+        assert record["suffix"] == ".md"
+        assert Path(record["path"]) == target.resolve()
+    finally:
+        current_tool_context.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_edit_file_gated_outside_workspace_records_nothing(tmp_path: Path) -> None:
+    """An edit that never wrote (out-of-workspace approval gate) leaves no record."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "elsewhere.txt"
+    outside.write_text("alpha beta", encoding="utf-8")
+    ctx = ToolContext(workspace_dir=str(workspace))
+    token = current_tool_context.set(ctx)
+    raw_edit_file = fs.edit_file.__wrapped__.__wrapped__
+    try:
+        result = await raw_edit_file(str(outside), "beta", "gamma")
+        assert not result.startswith("Edited ")
+        assert outside.read_text(encoding="utf-8") == "alpha beta"
+        assert ctx.workspace_file_writes == []
+    finally:
+        current_tool_context.reset(token)


### PR DESCRIPTION
Fixes #1689

## Problem

`write_file` (`filesystem.py`) and `apply_patch` (`patch.py`) call `record_workspace_file_write` after landing a file, and `auto_publish_omitted_workspace_artifacts` (`engine/artifact_delivery.py`) reads exactly `ctx.workspace_file_writes` to find deliverables the turn touched. `edit_file` only fired the memory / bootstrap notifiers, so a report or asset edited in place was never auto-published even when the final text named it.

## Fix

`record_workspace_file_write(p)` next to the two notifier calls in `edit_file` — the one-line omission called out in triage.

## Tests

- `test_edit_file_records_workspace_write` (`tests/test_tools/test_filesystem_read_workspace.py`): drives the tool (not the helper) and asserts the record lands in `ctx.workspace_file_writes` with the right `name` / `relative_path` / `suffix` / `path`. Fails on `main`.
- `test_edit_file_gated_outside_workspace_records_nothing`: an edit stopped by the out-of-workspace approval gate leaves no record (nothing was written).
- `tests/test_engine/test_runtime_artifacts.py`: the existing `test_turn_runner_does_not_auto_publish_edited_config_json` pinned the old behaviour (an `edit_file` on a deliverable `config.json` named in the final text publishes nothing). Since that is exactly the bug this issue accepts as a defect, it is renamed to `test_turn_runner_auto_publishes_deliverable_file_edited_in_place` and now asserts the edited file is auto-published, mirroring the sibling `apply_patch` test. Flagging this explicitly in case that test was intended as a deliberate exclusion rather than a snapshot of the omission.

## Merge safety

This PR is one of five opened together (#1684, #1689, #1691, #1705, #1707). Each touches a disjoint set of files and none touches `CHANGELOG.md`, so they can be merged one by one in any order; all 120 orderings were verified conflict-free against `upstream/main`, and the fully merged tree passes the complete gate (ruff, mypy, full pytest). Happy to follow up with a single `docs(changelog)` PR recording the batch once they land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
