### PR TITLE
fix(tools): keep blank lines in apply_patch `*** Add File:` blocks

### DIFF
--- a/src/agentos/tools/builtin/patch.py
+++ b/src/agentos/tools/builtin/patch.py
@@ -87,11 +87,28 @@ def _parse_patch(patch_text: str) -> list[PatchOp]:
             path = line[len("*** Add File: ") :].strip()
             i += 1
             content_lines: list[str] = []
+            trailing_bare_blanks = 0
             while i < len(body) and not body[i].startswith("*** "):
                 raw = body[i]
                 if raw.startswith("+"):
                     content_lines.append(raw[1:])
+                    trailing_bare_blanks = 0
+                elif raw.strip() == "":
+                    # Editors, log pipelines and most model output strip the
+                    # lone "+" from an empty line, so a bare blank inside the
+                    # block is an empty content line, not a line to skip.
+                    content_lines.append("")
+                    trailing_bare_blanks += 1
+                else:
+                    raise ValueError(
+                        f"Invalid line in '*** Add File: {path}' block "
+                        f"(expected a '+' prefix): {raw!r}"
+                    )
                 i += 1
+            # Bare blanks that only separate the block from the next marker
+            # are formatting, not content; an explicit "+" line is kept.
+            if trailing_bare_blanks:
+                del content_lines[-trailing_bare_blanks:]
             ops.append(AddFile(path=path, content="\n".join(content_lines)))
 
         elif line.startswith("*** Update File: "):

--- a/tests/test_tools/test_apply_patch_add_file_blank_lines.py
+++ b/tests/test_tools/test_apply_patch_add_file_blank_lines.py
@@ -1,0 +1,123 @@
+"""``*** Add File:`` blocks must keep their blank lines (#1691).
+
+The strict format prefixes every content line with ``+``, but editors, log
+pipelines and most model output strip a lone ``+`` down to ``""``. Skipping
+such a line silently rewrote the file the model asked for; treating it as an
+empty content line is the only outcome that does not lose data.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+
+import pytest
+
+from agentos.tools.builtin import patch as patch_tool
+from agentos.tools.builtin.patch import AddFile, _parse_patch
+from agentos.tools.types import ToolContext, current_tool_context
+
+
+def _original_async(fn: Callable[..., Awaitable[str]]) -> Callable[..., Awaitable[str]]:
+    return fn.__wrapped__.__wrapped__  # type: ignore[attr-defined, no-any-return]
+
+
+def _add_file_content(patch_text: str) -> str:
+    ops = _parse_patch(patch_text)
+    assert len(ops) == 1
+    assert isinstance(ops[0], AddFile)
+    return ops[0].content
+
+
+def test_bare_blank_line_between_functions_is_kept() -> None:
+    patch_text = """*** Begin Patch
+*** Add File: sample.py
++def foo():
++    pass
+
++def bar():
++    pass
+*** End Patch"""
+
+    assert _add_file_content(patch_text) == "def foo():\n    pass\n\ndef bar():\n    pass"
+
+
+def test_bare_and_prefixed_blank_lines_are_equivalent() -> None:
+    bare = """*** Begin Patch
+*** Add File: a.txt
++one
+
++two
+
+
++three
+*** End Patch"""
+    prefixed = bare.replace("\n\n+two", "\n+\n+two").replace("\n\n\n+three", "\n+\n+\n+three")
+    assert "\n\n" not in prefixed.split("*** Add File")[1]
+
+    assert _add_file_content(bare) == "one\n\ntwo\n\n\nthree"
+    assert _add_file_content(bare) == _add_file_content(prefixed)
+
+
+def test_whitespace_only_line_is_a_blank_line() -> None:
+    patch_text = "*** Begin Patch\n*** Add File: a.txt\n+one\n   \n+two\n*** End Patch"
+
+    assert _add_file_content(patch_text) == "one\n\ntwo"
+
+
+def test_trailing_bare_blanks_before_the_next_marker_are_separators() -> None:
+    """A blank that only pads the block off the next marker is formatting."""
+    patch_text = """*** Begin Patch
+*** Add File: a.txt
++alpha
+
+*** Add File: b.txt
++beta
+
+
+*** End Patch"""
+
+    ops = _parse_patch(patch_text)
+    assert [op.content for op in ops if isinstance(op, AddFile)] == ["alpha", "beta"]
+
+
+def test_explicit_trailing_plus_line_is_content() -> None:
+    """``+`` on its own is an explicit empty line and survives even at the end."""
+    patch_text = "*** Begin Patch\n*** Add File: a.txt\n+alpha\n+\n\n*** End Patch"
+
+    assert _add_file_content(patch_text) == "alpha\n"
+
+
+def test_unprefixed_text_line_is_rejected_not_dropped() -> None:
+    patch_text = """*** Begin Patch
+*** Add File: sample.py
++def foo():
+    pass
+*** End Patch"""
+
+    with pytest.raises(ValueError, match=r"Add File: sample\.py.*'\+' prefix.*'    pass'"):
+        _parse_patch(patch_text)
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_writes_the_blank_line(tmp_path: Path) -> None:
+    token = current_tool_context.set(ToolContext(workspace_dir=str(tmp_path)))
+    apply_patch = _original_async(patch_tool.apply_patch)
+    try:
+        result = await apply_patch(
+            """*** Begin Patch
+*** Add File: sample.py
++def foo():
++    pass
+
++def bar():
++    pass
+*** End Patch"""
+        )
+    finally:
+        current_tool_context.reset(token)
+
+    assert result == "Applied patch: 1 file(s) added"
+    assert (tmp_path / "sample.py").read_text(encoding="utf-8") == (
+        "def foo():\n    pass\n\ndef bar():\n    pass"
+    )


### PR DESCRIPTION
Fixes #1691

## Problem

`_parse_patch` only collected lines that start with `+` inside an `*** Add File:` block. A bare `""` — which is what editors, log pipelines and most model output turn a lone `+` into — was skipped without an error, so every blank line separating functions or paragraphs vanished from the file the model asked for:

```pycon
>>> _parse_patch(patch_text)[0].content
'def foo():\n    pass\ndef bar():\n    pass'
```

## Fix (Add File branch only)

- A bare blank (or whitespace-only) line inside the block is an empty content line.
- Bare blanks that only pad the block off the next `***` marker are formatting and are trimmed, so `*** Add File: a\n+alpha\n\n*** Add File: b` still yields `"alpha"`. An explicit `+` line is always content, even at the end.
- Any other un-prefixed line is now `ValueError: Invalid line in '*** Add File: <path>' block (expected a '+' prefix): <line>` instead of being dropped silently, per triage ("keep any other un-prefixed line an error rather than widening what the parser accepts").

This is the Add-File sibling of #1577 and touches only the Add File branch of `_parse_patch`, so it composes with whichever #1577 fix lands (those all modify the hunk branch / `_apply_hunk`).

## Tests

`tests/test_tools/test_apply_patch_add_file_blank_lines.py` (5 of 7 fail on `main`): the issue's repro; bare vs `+`-prefixed blanks are equivalent; whitespace-only lines; trailing separators before the next marker are dropped while an explicit trailing `+` survives; an un-prefixed text line is rejected with the file and line in the message; and an end-to-end `apply_patch` writes the blank line to disk. The existing 225 patch tests still pass.

## Merge safety

This PR is one of five opened together (#1684, #1689, #1691, #1705, #1707). Each touches a disjoint set of files and none touches `CHANGELOG.md`, so they can be merged one by one in any order; all 120 orderings were verified conflict-free against `upstream/main`, and the fully merged tree passes the complete gate (ruff, mypy, full pytest). Happy to follow up with a single `docs(changelog)` PR recording the batch once they land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
