### PR TITLE
fix(skills): reject bare value-taking flags in senior-unilp-manager

### DIFF
--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/lp_read.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/lp_read.py
@@ -47,6 +47,9 @@ from unilp.fmt import (  # noqa: E402
     fmt_usd,
     heading,
     json_safe,
+    opt_float,
+    opt_int,
+    opt_str,
     parse_args,
     render_kv,
     render_table,
@@ -235,7 +238,8 @@ def pool_key_from_args(args: dict) -> dict | None:
     silently address the wrong pool. ``--hooks`` defaults to the zero address, which is
     the whole point: a hook-less pool is exactly the case registries cannot describe.
     """
-    present = [name for name in _POOL_KEY_ARGS if args.get(name) is not None]
+    given = {name: opt_str(args, name) for name in _POOL_KEY_ARGS}
+    present = [name for name, value in given.items() if value is not None]
     if not present:
         return None
     if len(present) != len(_POOL_KEY_ARGS):
@@ -247,19 +251,19 @@ def pool_key_from_args(args: dict) -> dict | None:
         )
     # base 0 so a dynamic-fee pool can be given as 0x800000 as well as 8388608.
     try:
-        fee = int(str(args["fee"]), 0)
-        tick_spacing = int(str(args["tick-spacing"]), 0)
+        fee = int(given["fee"], 0)
+        tick_spacing = int(given["tick-spacing"], 0)
     except ValueError as exc:
         raise RuntimeError(
             f"--fee and --tick-spacing must be integers (hex accepted with an 0x "
             f"prefix): {exc}"
         ) from exc
     return normalize_pool_key({
-        "currency0": args["currency0"],
-        "currency1": args["currency1"],
+        "currency0": given["currency0"],
+        "currency1": given["currency1"],
         "fee": fee,
         "tickSpacing": tick_spacing,
-        "hooks": args.get("hooks") or NATIVE,
+        "hooks": opt_str(args, "hooks") or NATIVE,
     })
 
 
@@ -297,8 +301,9 @@ def pool_key_for_id(client, chain: dict, pool_id: str, args: dict | None = None)
         init = get_pool_init(client, chain, pool_id)
         return init["poolKey"] if init else None
 
-    if args.get("token"):
-        token = checksum_address(args["token"])
+    raw_token = opt_str(args, "token")
+    if raw_token:
+        token = checksum_address(raw_token)
         found = resolve_launcher(client, chain, token)
         if found:
             hit = next(
@@ -506,8 +511,9 @@ def discover_vanilla_pools(client, chain: dict, token: str,
 
 def cmd_pools(client, chain: dict, args: dict) -> None:
     token = checksum_address(require_arg(args, "token", "token address"))
-    min_tvl = -1.0 if args.get("all-pools") else float(args.get("min-tvl", 1))
-    mode = args.get("mode") or chain.get("rangeMode") or "logs"
+    min_tvl = -1.0 if args.get("all-pools") else opt_float(args, "min-tvl", 1.0)
+    mode = opt_str(args, "mode") or chain.get("rangeMode") or "logs"
+    raw_quote = opt_str(args, "quote")
 
     inits: list = []
     launcher = None
@@ -515,7 +521,7 @@ def cmd_pools(client, chain: dict, args: dict) -> None:
     used_vanilla = False
     # --quote lets the hook-less probe reach a pairing currency this chain's registry
     # does not list; without it every known quote is tried.
-    vanilla_quotes = [checksum_address(args["quote"])] if args.get("quote") else None
+    vanilla_quotes = [checksum_address(raw_quote)] if raw_quote else None
 
     if no_hook_only:
         # Deliberately skips both the registry and the log scan: this asks one narrow
@@ -581,19 +587,19 @@ def cmd_pools(client, chain: dict, args: dict) -> None:
         return
 
     discovered = len(inits)
-    if args.get("quote"):
-        quote = checksum_address(args["quote"]).lower()
+    if raw_quote:
+        quote = checksum_address(raw_quote).lower()
         inits = [i for i in inits
                  if quote in (i["poolKey"]["currency0"].lower(),
                               i["poolKey"]["currency1"].lower())]
         if not inits:
             print(f"\nNone of the {discovered} v4 pools for {token} are paired with "
-                  f"{args['quote']}.")
+                  f"{raw_quote}.")
             return
 
     # Reserves cost one full log scan per pool. A quote asset like WETH sits in tens of
     # thousands of pools here, so refuse rather than grinding for an hour.
-    max_pools = int(args.get("max-pools", 60))
+    max_pools = opt_int(args, "max-pools", 60)
     if len(inits) > max_pools and mode != "ticks":
         print(f"\n{len(inits)} v4 pools reference {token} on {chain['name']}.")
         print(f"That is more than --max-pools ({max_pools}), and each pool costs a full "
@@ -741,8 +747,8 @@ def cmd_pools(client, chain: dict, args: dict) -> None:
     if hidden > 0:
         print(f"\n  {hidden} dust pool(s) below {fmt_usd(min_tvl)} omitted — pass "
               "--all-pools to see them.")
-    if args.get("quote"):
-        print(f"  filtered to pools paired with {checksum_address(args['quote'])} "
+    if raw_quote:
+        print(f"  filtered to pools paired with {checksum_address(raw_quote)} "
               f"({discovered} pools reference this token in total).")
 
     # Per-range detail for the deepest pool, which is what people actually want.
@@ -852,7 +858,7 @@ def cmd_pool(client, chain: dict, args: dict) -> None:
     m0 = token_meta(client, chain, pool["poolKey"]["currency0"])
     m1 = token_meta(client, chain, pool["poolKey"]["currency1"])
     prices = fetch_usd_prices(chain, [m0["address"], m1["address"]])
-    res = get_pool_ranges(client, chain, pool_id, pool, mode=args.get("mode"))
+    res = get_pool_ranges(client, chain, pool_id, pool, mode=opt_str(args, "mode"))
 
     # Default the mcap perspective to whichever side is not a known quote asset.
     known = chain.get("knownQuotes") or {}
@@ -906,7 +912,7 @@ def cmd_pool(client, chain: dict, args: dict) -> None:
          else f"ModifyLiquidity logs ({res['eventCount']} events)"),
     ]))
 
-    limit = int(args["ranges"]) if args.get("ranges") else len(res["ranges"])
+    limit = opt_int(args, "ranges", len(res["ranges"]))
     unit = "liquidity segments" if res["mode"] == "ticks" else "liquidity ranges"
     print(heading(f"{unit} ({min(limit, len(res['ranges']))} of {len(res['ranges'])})"))
     print_ranges({**res, "ranges": res["ranges"][:limit]}, m0, m1, ctx, chain)
@@ -1034,10 +1040,10 @@ def resolve_owner(args: dict) -> str:
     the address, and the key never enters a variable here — see
     ``chains.resolve_signer_address`` for why that stays incapable of signing.
     """
-    given = args.get("owner")
+    given = opt_str(args, "owner")
     if given:
-        return str(given)
-    signer_env = args.get("signer-env") or ENV_SIGNER
+        return given
+    signer_env = opt_str(args, "signer-env") or ENV_SIGNER
     try:
         return resolve_signer_address(signer_env)
     except RuntimeError as exc:
@@ -1265,17 +1271,20 @@ def cmd_ticks(client, chain: dict, args: dict) -> None:
     prices = fetch_usd_prices(chain, [m0["address"], m1["address"]])
 
     known = chain.get("knownQuotes") or {}
-    if args.get("token"):
-        token = checksum_address(args["token"])
+    raw_token = opt_str(args, "token")
+    if raw_token:
+        token = checksum_address(raw_token)
     else:
         token = m0["address"] if known.get(m1["address"].lower()) else m1["address"]
     ctx = mcap_context(pool["poolKey"], token, m0, m1, prices)
     token_meta_ref = m1 if ctx["tokenIsCurrency1"] else m0
     spacing = pool["poolKey"]["tickSpacing"]
 
-    if args.get("tick-lower") is not None and args.get("tick-upper") is not None:
-        tick_lower = snap_tick(int(args["tick-lower"]), spacing, "down")
-        tick_upper = snap_tick(int(args["tick-upper"]), spacing, "up")
+    raw_lower = opt_str(args, "tick-lower")
+    raw_upper = opt_str(args, "tick-upper")
+    if raw_lower is not None and raw_upper is not None:
+        tick_lower = snap_tick(int(raw_lower), spacing, "down")
+        tick_upper = snap_tick(int(raw_upper), spacing, "up")
     else:
         lo = float(require_arg(args, "mcap-lower", "lower market cap in USD"))
         hi = float(require_arg(args, "mcap-upper", "upper market cap in USD"))
@@ -1447,8 +1456,8 @@ def main() -> None:
         print(USAGE)
         sys.exit(0 if command else 1)
 
-    chain = resolve_chain(args.get("chain"))
-    client = RpcClient(chain, args.get("rpc") if isinstance(args.get("rpc"), str) else None)
+    chain = resolve_chain(opt_str(args, "chain"))
+    client = RpcClient(chain, opt_str(args, "rpc"))
 
     handler = COMMANDS.get(command)
     if handler is None:

--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/lp_write.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/lp_write.py
@@ -49,6 +49,9 @@ from unilp.fmt import (  # noqa: E402
     die,
     fmt_units,
     heading,
+    opt_float,
+    opt_int,
+    opt_str,
     parse_amount,
     parse_args,
     render_kv,
@@ -230,10 +233,11 @@ class MandateAuthorization:
 
 def resolve_signer(args: dict) -> dict:
     """Either a real key (from the environment) or a plan-only address."""
-    if args.get("from"):
-        return {"address": checksum_address(args["from"]), "privateKey": None,
+    sender = opt_str(args, "from")
+    if sender:
+        return {"address": checksum_address(sender), "privateKey": None,
                 "simulateOnly": True}
-    signer_env = args.get("signer-env") or ENV_SIGNER
+    signer_env = opt_str(args, "signer-env") or ENV_SIGNER
     private_key = resolve_private_key(signer_env)
     account = account_from_private_key(private_key)
     # Only the derived address is ever surfaced; the key itself is never logged.
@@ -525,11 +529,11 @@ def _send(client, chain: dict, args: dict, signer: dict, to: str, data: str,
     ``on_sent`` is passed straight through to :func:`send_transaction` so an unattended
     caller can persist the hash and nonce before the broadcast leaves the process.
     """
-    max_fee_cap = args.get("max-fee-per-gas")
+    max_fee_cap = opt_str(args, "max-fee-per-gas")
     tx = prepare_transaction(
         client, chain, signer["address"], to, data, value,
-        gas_multiplier=float(args.get("gas-multiplier") or DEFAULT_GAS_MULTIPLIER),
-        max_fee_cap=int(str(max_fee_cap).replace("_", "")) if max_fee_cap else None,
+        gas_multiplier=opt_float(args, "gas-multiplier", DEFAULT_GAS_MULTIPLIER),
+        max_fee_cap=int(max_fee_cap.replace("_", "")) if max_fee_cap else None,
     )
     prefix = f"  {label} " if label else "\n  "
     tx_hash = send_transaction(client, chain, tx, signer["privateKey"],
@@ -554,7 +558,7 @@ def encode_call(plan: dict, deadline: int) -> str:
 
 def deadline_offset(args: dict) -> int:
     """Seconds from now, not the absolute deadline. PLAN_HASH binds this; see plan_hash."""
-    return int(args.get("deadline-secs") or DEFAULT_DEADLINE_SECS)
+    return opt_int(args, "deadline-secs", DEFAULT_DEADLINE_SECS)
 
 
 def with_slippage_up(amount: int, bps: int) -> int:
@@ -592,10 +596,10 @@ def cmd_approve(client, chain: dict, args: dict, signer: dict) -> None:
     if info["isNative"]:
         raise RuntimeError("native ETH needs no approval")
 
-    raw_amount = args.get("amount")
-    amount = (parse_amount(str(raw_amount), info["decimals"])
+    raw_amount = opt_str(args, "amount")
+    amount = (parse_amount(raw_amount, info["decimals"])
               if raw_amount and raw_amount != "max" else MAX_UINT160)
-    expiration_days = int(args.get("expiration-days") or 30)
+    expiration_days = opt_int(args, "expiration-days", 30)
     now_secs = int(client.get_block()["timestamp"], 16)
     expiration = now_secs + expiration_days * 86400
 
@@ -666,16 +670,19 @@ def cmd_approve(client, chain: dict, args: dict, signer: dict) -> None:
 def size_liquidity(sqrt_p: int, sqrt_lower: int, sqrt_upper: int, args: dict,
                    info0: dict, info1: dict) -> int:
     """Resolve the liquidity to add from whichever sizing flag the user gave."""
-    if args.get("liquidity"):
-        return int(str(args["liquidity"]).replace("_", ""))
+    liquidity = opt_str(args, "liquidity")
+    if liquidity:
+        return int(liquidity.replace("_", ""))
 
-    has0 = args.get("amount0") is not None
-    has1 = args.get("amount1") is not None
+    raw0 = opt_str(args, "amount0")
+    raw1 = opt_str(args, "amount1")
+    has0 = raw0 is not None
+    has1 = raw1 is not None
     if not has0 and not has1:
         raise RuntimeError("need one of --amount0, --amount1 or --liquidity")
 
-    amount0 = parse_amount(str(args["amount0"]), info0["decimals"]) if has0 else 0
-    amount1 = parse_amount(str(args["amount1"]), info1["decimals"]) if has1 else 0
+    amount0 = parse_amount(raw0, info0["decimals"]) if raw0 is not None else 0
+    amount1 = parse_amount(raw1, info1["decimals"]) if raw1 is not None else 0
 
     if has0 and has1:
         return get_liquidity_for_amounts(sqrt_p, sqrt_lower, sqrt_upper, amount0, amount1)
@@ -752,18 +759,18 @@ def cmd_create_pool(client, chain: dict, args: dict, signer: dict) -> dict | Non
     # v4 does not require the initial tick to sit on the tickSpacing grid — only position
     # boundaries do — so neither branch snaps. --price still lands on the 1.0001^n grid,
     # which is why the effective price is echoed back before anything is signed.
-    # `is not None` would not do: parse_args turns a valueless `--tick` into True, and
+    # opt_str refuses a valueless `--tick` outright: parse_args turns it into True, and
     # int(True) is 1 — a silently wrong starting price is exactly the failure to avoid.
-    has_tick = args.get("tick") not in (None, True)
-    has_price = args.get("price") not in (None, True)
-    if has_tick == has_price:
+    raw_tick = opt_str(args, "tick")
+    raw_price = opt_str(args, "price")
+    if (raw_tick is None) == (raw_price is None):
         raise RuntimeError("give exactly one of --tick <t> or --price <currency1 per currency0>")
-    if has_tick:
-        tick = int(args["tick"])
+    if raw_tick is not None:
+        tick = int(raw_tick)
         price_source = "--tick"
     else:
-        tick = tick_at_price(float(args["price"]), info0["decimals"], info1["decimals"])
-        price_source = f"--price {args['price']}"
+        tick = tick_at_price(float(raw_price), info0["decimals"], info1["decimals"])
+        price_source = f"--price {raw_price}"
     sqrt_price_x96 = get_sqrt_ratio_at_tick(tick)
 
     price_1_per_0 = token_price_in_quote_at_tick(tick, False, info0["decimals"],
@@ -869,15 +876,16 @@ def cmd_mint(client, chain: dict, args: dict, signer: dict, *,
     # slippage. Doing it the other way round produces MaximumAmountExceeded reverts.
     required = get_amounts_for_liquidity(pool["sqrtPriceX96"], sqrt_lower, sqrt_upper,
                                          liquidity, True)
-    bps = int(args.get("slippage-bps") or DEFAULT_SLIPPAGE_BPS)
+    bps = opt_int(args, "slippage-bps", DEFAULT_SLIPPAGE_BPS)
     amount0_max = 0 if required["amount0"] == 0 else with_slippage_up(required["amount0"], bps)
     amount1_max = 0 if required["amount1"] == 0 else with_slippage_up(required["amount1"], bps)
 
-    recipient = checksum_address(args["recipient"]) if args.get("recipient") else signer["address"]
+    recipient = opt_str(args, "recipient")
+    recipient = checksum_address(recipient) if recipient else signer["address"]
     plan = build_mint_plan(pool_key, tick_lower, tick_upper, liquidity,
                            amount0_max, amount1_max, recipient)
 
-    max_drift = int(args.get("max-tick-drift") or pool_key["tickSpacing"])
+    max_drift = opt_int(args, "max-tick-drift", pool_key["tickSpacing"])
     now_secs = int(client.get_block()["timestamp"], 16)
     allowances = check_allowances(client, chain, signer["address"],
                                   [pool_key["currency0"], pool_key["currency1"]])
@@ -977,11 +985,12 @@ def cmd_increase(client, chain: dict, args: dict, signer: dict) -> None:
 
     required = get_amounts_for_liquidity(pool["sqrtPriceX96"], sqrt_lower, sqrt_upper,
                                          liquidity, True)
-    bps = int(args.get("slippage-bps") or DEFAULT_SLIPPAGE_BPS)
+    bps = opt_int(args, "slippage-bps", DEFAULT_SLIPPAGE_BPS)
     amount0_max = 0 if required["amount0"] == 0 else with_slippage_up(required["amount0"], bps)
     amount1_max = 0 if required["amount1"] == 0 else with_slippage_up(required["amount1"], bps)
 
-    recipient = checksum_address(args["recipient"]) if args.get("recipient") else signer["address"]
+    recipient = opt_str(args, "recipient")
+    recipient = checksum_address(recipient) if recipient else signer["address"]
     plan = build_increase_plan(pos["poolKey"], pos["tokenId"], liquidity,
                                amount0_max, amount1_max, recipient)
     deadline = int(client.get_block()["timestamp"], 16) + deadline_offset(args)
@@ -1036,8 +1045,9 @@ def cmd_decrease(client, chain: dict, args: dict, signer: dict) -> None:
     info0 = token_info(client, chain, pos["poolKey"]["currency0"])
     info1 = token_info(client, chain, pos["poolKey"]["currency1"])
 
-    if args.get("liquidity"):
-        liquidity = int(str(args["liquidity"]).replace("_", ""))
+    raw_liquidity = opt_str(args, "liquidity")
+    if raw_liquidity:
+        liquidity = int(raw_liquidity.replace("_", ""))
     else:
         pct = float(require_arg(args, "pct", "0-100"))
         if not 0 < pct <= 100:
@@ -1054,11 +1064,12 @@ def cmd_decrease(client, chain: dict, args: dict, signer: dict) -> None:
         pool["sqrtPriceX96"], get_sqrt_ratio_at_tick(pos["tickLower"]),
         get_sqrt_ratio_at_tick(pos["tickUpper"]), liquidity,
     )
-    bps = int(args.get("slippage-bps") or DEFAULT_SLIPPAGE_BPS)
+    bps = opt_int(args, "slippage-bps", DEFAULT_SLIPPAGE_BPS)
     amount0_min = with_slippage_down(expected["amount0"], bps)
     amount1_min = with_slippage_down(expected["amount1"], bps)
 
-    recipient = checksum_address(args["recipient"]) if args.get("recipient") else signer["address"]
+    recipient = opt_str(args, "recipient")
+    recipient = checksum_address(recipient) if recipient else signer["address"]
     plan = build_decrease_plan(pos["poolKey"], pos["tokenId"], liquidity,
                                amount0_min, amount1_min, recipient)
     deadline = int(client.get_block()["timestamp"], 16) + deadline_offset(args)
@@ -1108,7 +1119,8 @@ def cmd_collect(client, chain: dict, args: dict, signer: dict) -> None:
     info0 = token_info(client, chain, pos["poolKey"]["currency0"])
     info1 = token_info(client, chain, pos["poolKey"]["currency1"])
 
-    recipient = checksum_address(args["recipient"]) if args.get("recipient") else signer["address"]
+    recipient = opt_str(args, "recipient")
+    recipient = checksum_address(recipient) if recipient else signer["address"]
     plan = build_collect_plan(pos["poolKey"], pos["tokenId"], recipient)
     deadline = int(client.get_block()["timestamp"], 16) + deadline_offset(args)
 
@@ -1148,11 +1160,12 @@ def cmd_burn(client, chain: dict, args: dict, signer: dict, *,
         pool["sqrtPriceX96"], get_sqrt_ratio_at_tick(pos["tickLower"]),
         get_sqrt_ratio_at_tick(pos["tickUpper"]), pos["liquidity"],
     )
-    bps = int(args.get("slippage-bps") or DEFAULT_SLIPPAGE_BPS)
+    bps = opt_int(args, "slippage-bps", DEFAULT_SLIPPAGE_BPS)
     amount0_min = with_slippage_down(expected["amount0"], bps)
     amount1_min = with_slippage_down(expected["amount1"], bps)
 
-    recipient = checksum_address(args["recipient"]) if args.get("recipient") else signer["address"]
+    recipient = opt_str(args, "recipient")
+    recipient = checksum_address(recipient) if recipient else signer["address"]
     plan = build_burn_plan(pos["poolKey"], pos["tokenId"], pos["liquidity"],
                            amount0_min, amount1_min, recipient)
     deadline = int(client.get_block()["timestamp"], 16) + deadline_offset(args)
@@ -1195,7 +1208,7 @@ def cmd_address(args: dict) -> None:
     want the address itself — to check which wallet is configured, or to hand to another
     tool. The key is never printed.
     """
-    signer_env = args.get("signer-env") or ENV_SIGNER
+    signer_env = opt_str(args, "signer-env") or ENV_SIGNER
     address = resolve_signer_address(signer_env)
     if args.get("json"):
         print(json.dumps({"address": address, "signerEnv": signer_env}, indent=2))
@@ -1239,8 +1252,8 @@ def main() -> None:
     if not handler:
         raise RuntimeError(f'unknown command "{command}"\n{USAGE}')
 
-    chain = resolve_chain(args.get("chain"))
-    client = RpcClient(chain, args.get("rpc"))
+    chain = resolve_chain(opt_str(args, "chain"))
+    client = RpcClient(chain, opt_str(args, "rpc"))
     handler(client, chain, args, resolve_signer(args))
 
 

--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/ratchet.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/ratchet.py
@@ -39,6 +39,8 @@ from unilp.fmt import (  # noqa: E402
     die,
     fmt_units,
     heading,
+    opt_int,
+    opt_str,
     parse_args,
     render_kv,
     require_arg,
@@ -209,7 +211,7 @@ def tick_summary_line(outcome: dict) -> str:
 
 
 def _client(chain: dict, args: dict) -> RpcClient:
-    return RpcClient(chain, args.get("rpc"))
+    return RpcClient(chain, opt_str(args, "rpc"))
 
 
 def _now() -> int:
@@ -303,11 +305,12 @@ def build_mandate(client, chain: dict, args: dict, signer: dict) -> dict:
             "converted, so there is nothing for a ratchet to do"
         )
 
-    steps = parse_steps(args.get("steps"))
+    steps = parse_steps(opt_str(args, "steps"))
     thresholds = milestone_thresholds(original, steps)
 
-    expires_days = args.get("expires-days")
-    max_per_fire = args.get("max-principal-per-fire")
+    expires_days = opt_str(args, "expires-days")
+    max_per_fire = opt_str(args, "max-principal-per-fire")
+    max_fee_per_gas = opt_str(args, "max-fee-per-gas")
     info0 = lp_write.token_info(client, chain, pool_key["currency0"])
     info1 = lp_write.token_info(client, chain, pool_key["currency1"])
     principal_info = info0 if principal == CURRENCY0 else info1
@@ -329,24 +332,23 @@ def build_mandate(client, chain: dict, args: dict, signer: dict) -> dict:
         "originalTickUpper": position["tickUpper"],
         "originalPrincipalRaw": str(original),
         "stepsBps": steps,
-        "label": args.get("label") or "",
+        "label": opt_str(args, "label") or "",
     }
 
     return {
         "immutable": immutable,
         "bounds": {
-            "maxSlippageBps": int(args.get("slippage-bps") or lp_write.DEFAULT_SLIPPAGE_BPS),
+            "maxSlippageBps": opt_int(args, "slippage-bps", lp_write.DEFAULT_SLIPPAGE_BPS),
             "maxDeadlineSecs": lp_write.deadline_offset(args),
-            "maxTickDrift": int(args.get("max-tick-drift") or pool_key["tickSpacing"]),
+            "maxTickDrift": opt_int(args, "max-tick-drift", pool_key["tickSpacing"]),
             "allowHooked": bool(args.get("allow-hooked")),
-            "maxAttempts": int(args.get("max-attempts") or DEFAULT_MAX_ATTEMPTS),
+            "maxAttempts": opt_int(args, "max-attempts", DEFAULT_MAX_ATTEMPTS),
             "maxPrincipalRawPerFire": (
                 str(lp_write.parse_amount(max_per_fire, principal_info["decimals"]))
                 if max_per_fire else None
             ),
             "maxFeePerGasWei": (
-                str(int(str(args["max-fee-per-gas"]).replace("_", "")))
-                if args.get("max-fee-per-gas") else None
+                str(int(max_fee_per_gas.replace("_", ""))) if max_fee_per_gas else None
             ),
             "expiresAt": _now() + int(float(expires_days) * 86_400) if expires_days else None,
         },
@@ -1482,7 +1484,7 @@ def check_replacement(client, chain: dict, mandate: dict, token_id: int) -> dict
 
 def cmd_clear_attention(client, chain: dict, args: dict, signer: dict) -> None:
     ident = require_arg(args, "id", "mandate id")
-    replacement = args.get("token-id")
+    replacement = opt_str(args, "token-id")
     store = MandateStore(state_root(), chain["key"], ident)
     with store.lock() as acquired:
         if not acquired:
@@ -1561,7 +1563,7 @@ def main() -> None:
     if handler is None:
         raise RuntimeError(f'unknown command "{command}"\n{USAGE}')
 
-    chain = resolve_chain(args.get("chain"))
+    chain = resolve_chain(opt_str(args, "chain"))
     client = _client(chain, args)
     signer = lp_write.resolve_signer(args)
     handler(client, chain, args, signer)

--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/fmt.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/fmt.py
@@ -50,6 +50,59 @@ def require_arg(args: dict, name: str, hint: str = "") -> Any:
     return value
 
 
+# ``parse_args`` turns a bare ``--flag`` into the boolean ``True``. That sentinel
+# is right for switches and wrong for everything else: passed on unnoticed it
+# becomes ``int(True) == 1``, or crashes with a bare ``AttributeError`` deep in a
+# helper. These three coercers are the single place that distinction is made, so
+# a value-taking flag can never silently mean "1".
+
+
+def opt_str(args: dict, name: str) -> str | None:
+    """A flag's string value, or None when absent. Bare ``--flag`` is an error."""
+    value = args.get(name)
+    if value is None:
+        return None
+    if value is True:
+        raise ValueError(f"--{name} needs a value")
+    text = str(value).strip()
+    return text or None
+
+
+def opt_int(args: dict, name: str, default: int, *,
+            minimum: int | None = None, maximum: int | None = None) -> int:
+    """A flag's integer value with range checking, or ``default`` when absent."""
+    value = args.get(name)
+    if value is None:
+        return default
+    if value is True:
+        raise ValueError(f"--{name} needs a value")
+    try:
+        number = int(str(value).strip())
+    except ValueError:
+        raise ValueError(f"--{name} must be a whole number, got {value!r}") from None
+    if minimum is not None and number < minimum:
+        raise ValueError(f"--{name} must be at least {minimum}, got {number}")
+    if maximum is not None and number > maximum:
+        raise ValueError(f"--{name} must be at most {maximum}, got {number}")
+    return number
+
+
+def opt_float(args: dict, name: str, default: float, *,
+              minimum: float | None = None) -> float:
+    value = args.get(name)
+    if value is None:
+        return default
+    if value is True:
+        raise ValueError(f"--{name} needs a value")
+    try:
+        number = float(str(value).strip())
+    except ValueError:
+        raise ValueError(f"--{name} must be a number, got {value!r}") from None
+    if minimum is not None and number < minimum:
+        raise ValueError(f"--{name} must be at least {minimum}, got {number}")
+    return number
+
+
 # ---------------------------------------------------------------------------
 # Formatting
 # ---------------------------------------------------------------------------

--- a/tests/test_skill_unilp_bare_flags.py
+++ b/tests/test_skill_unilp_bare_flags.py
@@ -1,0 +1,188 @@
+"""``senior-unilp-manager`` must reject a bare value-taking ``--flag`` (#1705).
+
+``parse_args`` turns ``--slippage-bps`` with no value into ``True``; read back
+with ``int(args.get(...) or DEFAULT)`` that became ``1`` and silently replaced
+the default in a script that broadcasts transactions. The sibling
+``poolsdotfun-token-launcher`` already routes its flags through ``opt_str`` /
+``opt_int`` / ``opt_float``; this pins the older vendored copy to the same
+contract, both at the helper level and through the real call sites.
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "agentos"
+    / "skills"
+    / "bundled"
+    / "senior-unilp-manager"
+    / "scripts"
+)
+
+
+def _load(name: str):
+    """Import a module from the skill's scripts dir without touching PATH."""
+    entry = str(_SCRIPTS)
+    added = entry not in sys.path
+    if added:
+        sys.path.insert(0, entry)
+    try:
+        return importlib.import_module(name)
+    finally:
+        if added:
+            sys.path.remove(entry)
+
+
+@pytest.fixture(scope="module")
+def fmt():
+    return _load("unilp.fmt")
+
+
+@pytest.fixture(scope="module")
+def lp_write():
+    return _load("lp_write")
+
+
+@pytest.fixture(scope="module")
+def lp_read():
+    return _load("lp_read")
+
+
+# --- helpers ----------------------------------------------------------------
+
+
+def test_parse_args_still_yields_true_for_a_bare_flag(fmt) -> None:
+    """The sentinel the coercers exist to catch."""
+    assert fmt.parse_args(["mint", "--slippage-bps"])["slippage-bps"] is True
+    assert fmt.parse_args(["--slippage-bps", "--json"])["slippage-bps"] is True
+
+
+@pytest.mark.parametrize("helper", ["opt_str", "opt_int", "opt_float"])
+def test_bare_flag_is_an_error_naming_the_flag(fmt, helper: str) -> None:
+    fn = getattr(fmt, helper)
+    args = {"slippage-bps": True}
+    call = (
+        (lambda: fn(args, "slippage-bps"))
+        if helper == "opt_str"
+        else (lambda: fn(args, "slippage-bps", 50))
+    )
+    with pytest.raises(ValueError, match=r"--slippage-bps needs a value"):
+        call()
+
+
+def test_absent_flag_returns_the_default(fmt) -> None:
+    assert fmt.opt_str({}, "owner") is None
+    assert fmt.opt_int({}, "slippage-bps", 50) == 50
+    assert fmt.opt_float({}, "gas-multiplier", 1.2) == 1.2
+
+
+def test_given_flag_is_parsed(fmt) -> None:
+    args = fmt.parse_args(["--slippage-bps", "75", "--gas-multiplier=1.5", "--owner", " 0xabc "])
+    assert fmt.opt_int(args, "slippage-bps", 50) == 75
+    assert fmt.opt_float(args, "gas-multiplier", 1.2) == 1.5
+    assert fmt.opt_str(args, "owner") == "0xabc"
+
+
+def test_non_numeric_value_is_an_error_naming_the_flag(fmt) -> None:
+    with pytest.raises(ValueError, match=r"--slippage-bps must be a whole number"):
+        fmt.opt_int({"slippage-bps": "lots"}, "slippage-bps", 50)
+    with pytest.raises(ValueError, match=r"--gas-multiplier must be a number"):
+        fmt.opt_float({"gas-multiplier": "fast"}, "gas-multiplier", 1.2)
+
+
+def test_unilp_helpers_match_the_poolsfun_port(fmt) -> None:
+    """Same vendored origin, same contract — keep the two copies from drifting."""
+    # poolsfun lives in another skill dir; compare source text rather than importing
+    # both packages into one interpreter.
+    pools_src = (
+        _SCRIPTS.parent.parent / "poolsdotfun-token-launcher" / "scripts" / "poolsfun" / "fmt.py"
+    ).read_text(encoding="utf-8")
+    unilp_src = (_SCRIPTS / "unilp" / "fmt.py").read_text(encoding="utf-8")
+    for helper in ("def opt_str(", "def opt_int(", "def opt_float("):
+        assert helper in unilp_src
+        assert helper in pools_src
+
+
+# --- real call sites ----------------------------------------------------------
+
+
+def test_deadline_secs_bare_flag_no_longer_means_one_second(lp_write) -> None:
+    assert lp_write.deadline_offset({}) == lp_write.DEFAULT_DEADLINE_SECS
+    assert lp_write.deadline_offset({"deadline-secs": "600"}) == 600
+    with pytest.raises(ValueError, match=r"--deadline-secs needs a value"):
+        lp_write.deadline_offset({"deadline-secs": True})
+
+
+def test_from_bare_flag_is_rejected_before_touching_the_environment(lp_write, monkeypatch) -> None:
+    def _boom(*_a, **_k):  # pragma: no cover - must not be reached
+        raise AssertionError("resolve_private_key was called")
+
+    monkeypatch.setattr(lp_write, "resolve_private_key", _boom)
+    with pytest.raises(ValueError, match=r"--from needs a value"):
+        lp_write.resolve_signer({"from": True})
+    with pytest.raises(ValueError, match=r"--signer-env needs a value"):
+        lp_write.resolve_signer({"signer-env": True})
+
+
+def test_liquidity_bare_flag_is_rejected(lp_write) -> None:
+    with pytest.raises(ValueError, match=r"--liquidity needs a value"):
+        lp_write.size_liquidity(0, 0, 0, {"liquidity": True}, {}, {})
+    with pytest.raises(ValueError, match=r"--amount0 needs a value"):
+        lp_write.size_liquidity(0, 0, 0, {"amount0": True}, {}, {})
+
+
+def test_pool_key_from_args_rejects_a_bare_fee(lp_read) -> None:
+    args = {
+        "currency0": "0x" + "11" * 20,
+        "currency1": "0x" + "22" * 20,
+        "fee": True,
+        "tick-spacing": "60",
+    }
+    with pytest.raises(ValueError, match=r"--fee needs a value"):
+        lp_read.pool_key_from_args(args)
+
+
+def test_pool_key_from_args_still_absent_when_nothing_given(lp_read) -> None:
+    assert lp_read.pool_key_from_args({"_": []}) is None
+
+
+# --- source guard --------------------------------------------------------------
+
+# Every flag that is a genuine on/off switch. Anything else read through a raw
+# ``args.get`` / ``args[...]`` is a value-taking flag that skipped the coercers.
+_SWITCHES = {
+    "_",
+    "json",
+    "help",
+    "h",
+    "broadcast",
+    "confirm",
+    "all",
+    "all-pools",
+    "alert-only",
+    "allow-hooked",
+    "allow-odd-tier",
+    "from-current",
+    "include-empty",
+    "include-v3",
+    "no-fees",
+    "no-hook",
+    "scan-logs",
+}
+
+_RAW_READ = re.compile(r"""(?<!\w)args(?:\.get\(|\[)\s*["']([^"']+)["']""")
+
+
+@pytest.mark.parametrize("script", ["lp_write.py", "lp_read.py", "ratchet.py"])
+def test_no_value_taking_flag_is_read_raw(script: str) -> None:
+    source = (_SCRIPTS / script).read_text(encoding="utf-8")
+    offenders = sorted({name for name in _RAW_READ.findall(source) if name not in _SWITCHES})
+    assert offenders == [], f"{script} reads value-taking flags raw: {offenders}"


### PR DESCRIPTION
Fixes #1705

## Problem

`unilp/fmt.py`'s `parse_args` turns a bare `--flag` (no value, or one immediately followed by another `--flag`) into the boolean `True`. Every optional value-taking flag in `lp_write.py`, `lp_read.py` and `ratchet.py` read it back with `args.get(name) or DEFAULT` or a bare `args.get(name)`, so an operator typo:

- silently substituted `int(True) == 1` for the real default — `--slippage-bps`, `--max-tick-drift`, `--deadline-secs`, `--expiration-days`, `--gas-multiplier`, `--max-attempts`, `--max-pools`, `--ranges`, `--tick-lower/--tick-upper` in a script that broadcasts transactions;
- crashed with a low-level error that never named the flag — `--from`, `--signer-env`, `--max-fee-per-gas`, `--rpc`, `--recipient`, `--quote`, `--token`;
- or resolved to the literal string `"True"` — `--owner`, `--label`, `--mode`.

`lp_read.py`'s `main()` already guarded its own `--rpc`, and `lp_write.py`'s `--tick/--price` had a hand-rolled `not in (None, True)`, so the hazard was known but not applied consistently.

## Fix (scope as triaged: port the helpers, route every flag, no new flags)

- `unilp/fmt.py`: port `opt_str` / `opt_int` / `opt_float` verbatim from the sibling `poolsdotfun-token-launcher`'s copy of the same vendored `fmt.py`. A bare flag is `ValueError: --<flag> needs a value`; a non-numeric value is `--<flag> must be a whole number / a number, got ...`; an absent flag still yields the documented default.
- `lp_write.py`, `lp_read.py`, `ratchet.py`: every value-taking optional flag now goes through one of the three helpers. Boolean switches (`--json`, `--broadcast`, `--all-pools`, …) are untouched, `--confirm` keeps its existing mismatch message, and the hand-rolled `--rpc` / `--tick` guards collapse into the helpers. Defaults are unchanged (`ratchet.py`'s programmatic `write_args["deadline-secs"] = <int>` still round-trips through `opt_int`).

The skill's own `scripts/selftest.py` still passes (733 assertions).

## Tests

`tests/test_skill_unilp_bare_flags.py` (14 of 16 fail on `main`):
- helper contract — bare flag errors naming the flag for all three helpers, absent → default, given → parsed, non-numeric → error naming the flag;
- real call sites — `deadline_offset` (the `1`-second case from the issue), `resolve_signer` (`--from` / `--signer-env` rejected before the environment is touched), `size_liquidity`, `pool_key_from_args`;
- a source guard that scans the three scripts for any `args.get("...")` / `args["..."]` read of a name outside the boolean-switch allowlist, so a future flag cannot regress to the raw pattern.

## Merge safety

This PR is one of five opened together (#1684, #1689, #1691, #1705, #1707). Each touches a disjoint set of files and none touches `CHANGELOG.md`, so they can be merged one by one in any order; all 120 orderings were verified conflict-free against `upstream/main`, and the fully merged tree passes the complete gate (ruff, mypy, full pytest). Happy to follow up with a single `docs(changelog)` PR recording the batch once they land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
