### PR TITLE
feat(gateway): expose `reasoning` in the models.list wire capabilities

### DIFF
--- a/src/agentos/gateway/rpc_models.py
+++ b/src/agentos/gateway/rpc_models.py
@@ -17,6 +17,8 @@ def _model_info_to_wire(m: dict[str, Any]) -> dict[str, Any]:
         capabilities.append("tools")
     if m.get("supports_vision"):
         capabilities.append("vision")
+    if m.get("supports_reasoning"):
+        capabilities.append("reasoning")
     return {
         "id": m.get("model_id", ""),
         "name": m.get("display_name") or m.get("model_id", ""),

--- a/tests/test_gateway/test_rpc_models_wire_capabilities.py
+++ b/tests/test_gateway/test_rpc_models_wire_capabilities.py
@@ -1,0 +1,73 @@
+"""``models.list`` wire ``capabilities`` must reflect every ModelInfo flag.
+
+The CLI exposes a free-form ``--capability`` filter, so a flag the wire mapper
+forgets is a filter that can never match: ``agentos models list -c reasoning``
+returned ``[]`` while the catalog carried ``supports_reasoning=True`` (#1707).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from agentos.gateway.rpc import RpcContext, get_dispatcher
+from agentos.gateway.rpc_models import _model_info_to_wire
+from agentos.provider.model_catalog import ModelInfo
+
+
+def _wire(**flags: bool) -> list[str]:
+    row = {"model_id": "m", "display_name": "m", "provider": "p", **flags}
+    return _model_info_to_wire(row)["capabilities"]
+
+
+def test_reasoning_flag_maps_to_the_reasoning_capability() -> None:
+    assert _wire(supports_reasoning=True) == ["chat", "reasoning"]
+    assert _wire(supports_reasoning=False) == ["chat"]
+    assert _wire() == ["chat"]
+
+
+def test_capability_order_is_stable_across_all_flags() -> None:
+    assert _wire(supports_tools=True, supports_vision=True, supports_reasoning=True) == [
+        "chat",
+        "tools",
+        "vision",
+        "reasoning",
+    ]
+
+
+def test_model_info_dump_round_trips_reasoning() -> None:
+    """The real ``ModelInfo.model_dump()`` shape, not a hand-written dict."""
+    info = ModelInfo(
+        model_id="deepseek-r1",
+        provider="deepseek",
+        supports_reasoning=True,
+        supports_tools=True,
+    )
+
+    assert _model_info_to_wire(info.model_dump())["capabilities"] == ["chat", "tools", "reasoning"]
+
+
+def _ctx(rows: list[dict]) -> RpcContext:
+    ctx = RpcContext(conn_id="test")
+    ctx.config = SimpleNamespace(llm=SimpleNamespace(provider="deepseek"))
+    ctx.model_catalog = SimpleNamespace(
+        list_models=lambda: [SimpleNamespace(model_dump=lambda row=row: row) for row in rows]
+    )
+    return ctx
+
+
+def test_models_list_filter_by_reasoning_finds_the_reasoning_model() -> None:
+    ctx = _ctx(
+        [
+            {"model_id": "deepseek-chat", "provider": "deepseek", "supports_reasoning": False},
+            {"model_id": "deepseek-r1", "provider": "deepseek", "supports_reasoning": True},
+        ]
+    )
+
+    result = asyncio.run(
+        get_dispatcher().dispatch("r1", "models.list", {"capabilities": ["reasoning"]}, ctx)
+    )
+
+    assert result.error is None, result.error
+    assert [m["id"] for m in result.payload] == ["deepseek-r1"]
+    assert result.payload[0]["capabilities"] == ["chat", "reasoning"]


### PR DESCRIPTION
Closes #1707

## Problem

`ModelCatalog` populates `supports_reasoning` (`provider/model_catalog.py`), but `_model_info_to_wire` (`gateway/rpc_models.py`) mapped only `supports_tools` → `tools` and `supports_vision` → `vision` onto the wire `capabilities` list. The CLI exposes a free-form `--capability` filter on that list, so `agentos models list -c reasoning` (and any RPC caller passing `capabilities: ["reasoning"]`) could never match and always returned `[]`.

## Fix

The one `if m.get("supports_reasoning"): capabilities.append("reasoning")` branch, as scoped in triage. No other capability name is introduced and the existing order (`chat`, `tools`, `vision`) is unchanged; `reasoning` is appended after them.

## Tests

`tests/test_gateway/test_rpc_models_wire_capabilities.py` (all 4 fail on `main`): the flag maps to `reasoning` and its absence does not; the full capability order is stable; a real `ModelInfo.model_dump()` round-trips; and a dispatched `models.list` with `capabilities: ["reasoning"]` returns exactly the reasoning model.

No docs enumerate the wire capability names, so nothing in `docs/cli.md` or the bundled SKILL.md needed to change.

## Merge safety

This PR is one of five opened together (#1684, #1689, #1691, #1705, #1707). Each touches a disjoint set of files and none touches `CHANGELOG.md`, so they can be merged one by one in any order; all 120 orderings were verified conflict-free against `upstream/main`, and the fully merged tree passes the complete gate (ruff, mypy, full pytest). Happy to follow up with a single `docs(changelog)` PR recording the batch once they land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
