### PR TITLE
fix(provider): release the half-open probe slot on a request-shaped failure

### DIFF
--- a/src/agentos/provider/circuit_breaker.py
+++ b/src/agentos/provider/circuit_breaker.py
@@ -163,6 +163,7 @@ class ProviderCircuitBreaker:
         open --(cooldown elapsed, one caller admitted)--> half_open
         half_open --(success)--> closed
         half_open --(failure)--> open   # with a longer cooldown
+        half_open --(request-shaped failure)--> half_open   # probe slot released
 
     All methods are safe to call from multiple threads and from concurrent
     turns; a single lock guards the whole table.
@@ -250,7 +251,16 @@ class ProviderCircuitBreaker:
         if kind is not None and not trips_breaker(kind):
             with self._lock:
                 entry = self._entries.get(provider)
-                return entry.state if entry else BreakerState.CLOSED
+                if entry is None:
+                    return BreakerState.CLOSED
+                if entry.state is BreakerState.HALF_OPEN:
+                    # The failed request was the half-open probe, and it says
+                    # nothing about provider health either way. Give the slot
+                    # back so the next caller becomes the probe; leaving
+                    # ``probe_started_at`` set would report "probe in flight"
+                    # and park every caller for a full window (#1602).
+                    entry.probe_started_at = None
+                return entry.state
         with self._lock:
             entry = self._entries.setdefault(provider, _Entry())
             now = self._clock()

--- a/tests/test_provider_circuit_breaker_probe_release.py
+++ b/tests/test_provider_circuit_breaker_probe_release.py
@@ -1,0 +1,137 @@
+"""A request-shaped failure on the half-open probe must release the probe slot.
+
+Regression for #1602: ``record_failure`` ignores non-tripping kinds
+(``MODEL_NOT_FOUND``, ``BAD_REQUEST``, ...) because they say something about
+the request, not the provider. But when the ignored failure *was* the
+half-open probe, returning early left ``probe_started_at`` set, so ``allow()``
+kept reporting "a probe is in flight" and blocked every other caller for a
+full cooldown window -- parking a provider nothing has shown to be unhealthy.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentos.provider.circuit_breaker import (
+    TRIPPING_FAILURE_KINDS,
+    BreakerSettings,
+    BreakerState,
+    ProviderCircuitBreaker,
+)
+from agentos.provider.failures import ProviderFailureKind
+
+NON_TRIPPING_KINDS = sorted(
+    (kind for kind in ProviderFailureKind if kind not in TRIPPING_FAILURE_KINDS),
+    key=str,
+)
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = 1_000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _half_open_breaker(clock: FakeClock) -> ProviderCircuitBreaker:
+    """A breaker whose probe for ``openrouter`` has just been admitted."""
+    breaker = ProviderCircuitBreaker(
+        BreakerSettings(failure_threshold=1, cooldown_seconds=60.0, max_cooldown_seconds=600.0),
+        clock=clock,
+    )
+    breaker.record_failure("openrouter", ProviderFailureKind.RATE_LIMITED, "429")
+    assert breaker.allow("openrouter") is False
+    clock.advance(60.0)
+    assert breaker.allow("openrouter") is True
+    assert breaker.state("openrouter") is BreakerState.HALF_OPEN
+    return breaker
+
+
+@pytest.mark.parametrize("kind", NON_TRIPPING_KINDS, ids=str)
+def test_request_shaped_probe_failure_releases_the_probe_slot(
+    kind: ProviderFailureKind,
+) -> None:
+    clock = FakeClock()
+    breaker = _half_open_breaker(clock)
+
+    # The probe request itself failed for a reason unrelated to provider
+    # health (e.g. a wrong model id). The breaker stays half-open: the
+    # provider is still unproven, so the next caller becomes the new probe.
+    assert breaker.record_failure("openrouter", kind, "bad model") is BreakerState.HALF_OPEN
+
+    assert breaker.allow("openrouter") is True
+    assert breaker.state("openrouter") is BreakerState.HALF_OPEN
+
+
+def test_released_slot_still_admits_only_one_probe_at_a_time() -> None:
+    clock = FakeClock()
+    breaker = _half_open_breaker(clock)
+    breaker.record_failure("openrouter", ProviderFailureKind.MODEL_NOT_FOUND, "bad model")
+
+    assert breaker.allow("openrouter") is True  # the replacement probe
+    # A second concurrent caller still waits on that probe's outcome.
+    assert breaker.allow("openrouter") is False
+    clock.advance(60.0)
+    assert breaker.allow("openrouter") is True
+
+
+def test_request_shaped_probe_failure_leaves_the_failure_history_alone() -> None:
+    clock = FakeClock()
+    breaker = _half_open_breaker(clock)
+    before = breaker.status("openrouter")
+
+    breaker.record_failure("openrouter", ProviderFailureKind.BAD_REQUEST, "400")
+
+    after = breaker.status("openrouter")
+    assert after.state is BreakerState.HALF_OPEN
+    assert after.consecutive_failures == before.consecutive_failures
+    assert after.total_failures == before.total_failures
+    assert after.total_trips == before.total_trips
+    assert after.last_failure_kind == str(ProviderFailureKind.RATE_LIMITED)
+
+
+def test_replacement_probe_outcome_still_drives_the_breaker() -> None:
+    clock = FakeClock()
+    breaker = _half_open_breaker(clock)
+    breaker.record_failure("openrouter", ProviderFailureKind.MODEL_NOT_FOUND, "bad model")
+    assert breaker.allow("openrouter") is True
+
+    # The replacement probe's *provider-shaped* failure reopens with backoff...
+    state = breaker.record_failure("openrouter", ProviderFailureKind.PROVIDER_OVERLOADED, "503")
+    assert state is BreakerState.OPEN
+    clock.advance(60.0)
+    assert breaker.allow("openrouter") is False
+    clock.advance(60.0)
+    assert breaker.allow("openrouter") is True
+
+    # ...and a success closes it.
+    breaker.record_success("openrouter")
+    assert breaker.state("openrouter") is BreakerState.CLOSED
+
+
+def test_request_shaped_failure_outside_a_probe_is_still_a_no_op() -> None:
+    clock = FakeClock()
+    breaker = ProviderCircuitBreaker(
+        BreakerSettings(failure_threshold=1, cooldown_seconds=60.0), clock=clock
+    )
+
+    # Closed and untracked: nothing to release, nothing recorded.
+    assert (
+        breaker.record_failure("openrouter", ProviderFailureKind.MODEL_NOT_FOUND)
+        is BreakerState.CLOSED
+    )
+    assert breaker.snapshot() == []
+
+    # Open with the cooldown still running: the window is not shortened.
+    breaker.record_failure("openrouter", ProviderFailureKind.RATE_LIMITED, "429")
+    clock.advance(30.0)
+    assert (
+        breaker.record_failure("openrouter", ProviderFailureKind.MODEL_NOT_FOUND)
+        is BreakerState.OPEN
+    )
+    assert breaker.allow("openrouter") is False
+    assert breaker.status("openrouter").cooldown_remaining_seconds == 30.0


### PR DESCRIPTION
## Summary

Fixes #1602.

`record_failure` ignores non-tripping kinds (`MODEL_NOT_FOUND`, `BAD_REQUEST`, `UNSUPPORTED_FEATURE`, …) because they describe the request, not the provider. But when the ignored failure *was* the half-open probe, the early return left `probe_started_at` set, so `allow()` kept reporting a probe in flight and blocked every other caller to that provider for a full cooldown window (up to `max_cooldown_seconds`, 600s by default) — parking a provider nothing has shown to be unhealthy, which is exactly what the non-tripping list exists to prevent.

## Change

A request-shaped failure recorded while the breaker is `HALF_OPEN` now clears `probe_started_at` and leaves the state, failure counters and backoff untouched: the provider is still unproven, so the next caller becomes the probe. Outside a probe (closed, or open with the cooldown still running) the branch remains a no-op. The `record_failure` docstring and the lifecycle diagram in the class docstring document the new transition.

Known limitation, shared with the pre-existing tripping-kind path: the breaker cannot tell *which* admitted request a failure belongs to, so a stale request (e.g. an abandoned probe that eventually returns after the window re-admitted a replacement) reporting a request-shaped failure releases the slot while the replacement probe is still in flight — one extra concurrent probe, bounded. Closing that properly needs per-admission tokens and is out of scope here.

## Tests

`tests/test_provider_circuit_breaker_probe_release.py`: the reported scenario for every non-tripping kind (probe admitted → request-shaped failure → an unrelated `allow()` is admitted, state stays `HALF_OPEN`); the released slot still admits exactly one probe at a time; failure history and backoff are untouched; the replacement probe's own outcome still drives the breaker (provider-shaped failure reopens with doubled backoff, success closes); and the branch stays a no-op when closed/untracked or open with the cooldown running.

## Merge safety

This PR is one of five opened together (#1602, #1603, #1606, #1616, #1618). Each touches a disjoint set of files and none touches `CHANGELOG.md` (the `[Unreleased]` `### Fixed` section has a single entry, which leaves too few non-adjacent insertion points for five parallel bullets), so they can be merged one by one in any order; all 120 orderings were verified conflict-free against `upstream/main`, and the fully merged tree passes the complete gate (ruff, mypy, full pytest). Happy to follow up with a single `docs(changelog)` PR recording the batch once they land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrT2hZdMcL98BWVTX8oZB1
