### PR TITLE
fix(scheduler): honour the timezone alias in structured cron schedules

### DIFF
--- a/src/agentos/gateway/rpc_cron.py
+++ b/src/agentos/gateway/rpc_cron.py
@@ -852,8 +852,10 @@ async def _handle_cron_update(params: dict | None, ctx: RpcContext) -> dict[str,
         patch["schedule_kind"] = sched_kind
         patch["schedule_value"] = sched_value
         schedule_raw = params.get("schedule")
-        schedule_tz_was_supplied = (
-            isinstance(schedule_raw, dict) and "tz" in schedule_raw
+        # ``timezone`` is an alias of ``tz`` inside ``schedule`` too, so an
+        # explicit ``"timezone": ""`` is a clear, not an omission.
+        schedule_tz_was_supplied = isinstance(schedule_raw, dict) and (
+            "tz" in schedule_raw or "timezone" in schedule_raw
         )
         if sched_kind == ScheduleKind.CRON and (
             sched_tz or tz_was_supplied or schedule_tz_was_supplied

--- a/src/agentos/scheduler/schedule_normalizer.py
+++ b/src/agentos/scheduler/schedule_normalizer.py
@@ -14,14 +14,13 @@ def coerce_schedule_from_params(params: dict[str, Any]) -> tuple[ScheduleKind, s
         schedule = dict(schedule_raw)
         top_level_tz = _top_level_tz(params)
         if top_level_tz and schedule.get("kind") == ScheduleKind.CRON.value:
-            schedule_tz = schedule.get("tz")
-            if isinstance(schedule_tz, str):
-                schedule_tz = schedule_tz.strip()
-            else:
-                schedule_tz = ""
+            # ``_schedule_tz`` reads both ``tz`` and its ``timezone`` alias, so
+            # a top-level tz is checked against whichever one the caller used.
+            schedule_tz = _schedule_tz(schedule)
             if schedule_tz and schedule_tz != top_level_tz:
                 raise ValueError("schedule.tz conflicts with tz")
             schedule["tz"] = top_level_tz
+            schedule.pop("timezone", None)
         return coerce_schedule(schedule)
     expression = params.get("expression")
     if isinstance(expression, str) and expression.strip():
@@ -48,6 +47,30 @@ def _top_level_tz(params: dict[str, Any]) -> str:
     if tz and timezone and tz != timezone:
         raise ValueError("tz conflicts with timezone")
     return tz or timezone
+
+
+def _schedule_tz(raw: dict[str, Any]) -> str:
+    """Resolve ``schedule.tz`` and its ``schedule.timezone`` alias.
+
+    Mirrors :func:`_top_level_tz` for the structured cron path: either
+    spelling is accepted, both must agree when present, and a non-string
+    value is rejected instead of being silently dropped -- a dropped tz
+    schedules the job in UTC with no error anywhere (#1603).
+    """
+    tz = _tz_string(raw, "tz")
+    timezone = _tz_string(raw, "timezone")
+    if tz and timezone and tz != timezone:
+        raise ValueError("schedule.tz conflicts with schedule.timezone")
+    return tz or timezone
+
+
+def _tz_string(raw: dict[str, Any], key: str) -> str:
+    value = raw.get(key)
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise ValueError(f"schedule.{key} must be a string IANA timezone name")
+    return value.strip()
 
 
 def coerce_schedule(raw: dict[str, Any]) -> tuple[ScheduleKind, str, str]:
@@ -81,10 +104,7 @@ def _coerce_cron(raw: dict[str, Any]) -> tuple[ScheduleKind, str, str]:
         raise ValueError(
             f"schedule.expr invalid: {exc}; expected 5-field POSIX cron"
         ) from exc
-    tz_raw = raw.get("tz") or ""
-    if not isinstance(tz_raw, str):
-        raise ValueError("schedule.tz must be a string IANA timezone name")
-    tz_value = tz_raw.strip()
+    tz_value = _schedule_tz(raw)
     try:
         validate_tz(tz_value)
     except ValueError as exc:

--- a/tests/test_gateway/test_rpc_cron_update_timezone_alias.py
+++ b/tests/test_gateway/test_rpc_cron_update_timezone_alias.py
@@ -1,0 +1,92 @@
+"""``cron.update`` treats ``schedule.timezone`` as the alias of ``schedule.tz``.
+
+Companion to the #1603 normalizer fix: once the alias resolves inside
+``schedule``, an explicit ``"timezone": ""`` must clear the job's timezone the
+way ``"tz": ""`` already does, instead of being read as "not supplied".
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentos.gateway.rpc import RpcContext
+from agentos.gateway.rpc_cron import _handle_cron_update
+from agentos.scheduler.types import CronJob, ScheduleKind
+
+
+class _FakeScheduler:
+    def __init__(self, job: CronJob) -> None:
+        self.job = job
+        self.updated: dict | None = None
+
+    async def update_job(self, job_id: str, **patch) -> CronJob:
+        self.updated = patch
+        for key, value in patch.items():
+            if key == "schedule_value":
+                self.job.cron_expr = value
+                self.job.schedule_raw = value
+            elif key == "schedule_kind":
+                self.job.schedule_kind = value
+            elif key == "schedule_tz":
+                # ``ops.update`` folds the structured tz into ``job.tz``.
+                self.job.tz = value
+            else:
+                setattr(self.job, key, value)
+        return self.job
+
+    async def get_job(self, job_id: str) -> CronJob | None:
+        return self.job
+
+
+def _shanghai_job() -> CronJob:
+    return CronJob(
+        id="job-A",
+        name="orig",
+        cron_expr="0 9 * * *",
+        schedule_raw="0 9 * * *",
+        schedule_kind=ScheduleKind.CRON,
+        handler_key="agent_run",
+        tz="Asia/Shanghai",
+    )
+
+
+async def _update(scheduler: _FakeScheduler, schedule: dict) -> None:
+    await _handle_cron_update(
+        {"id": "job-A", "schedule": schedule},
+        RpcContext(conn_id="test", cron_scheduler=scheduler),
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_sets_the_timezone_through_the_alias() -> None:
+    scheduler = _FakeScheduler(_shanghai_job())
+
+    await _update(
+        scheduler, {"kind": "cron", "expr": "0 10 * * *", "timezone": "America/Los_Angeles"}
+    )
+
+    assert scheduler.updated is not None
+    assert scheduler.updated["schedule_value"] == "0 10 * * *"
+    assert scheduler.updated["schedule_tz"] == "America/Los_Angeles"
+
+
+@pytest.mark.asyncio
+async def test_update_clears_the_timezone_through_the_alias() -> None:
+    scheduler = _FakeScheduler(_shanghai_job())
+
+    await _update(scheduler, {"kind": "cron", "expr": "0 9 * * *", "timezone": ""})
+
+    assert scheduler.updated is not None
+    assert scheduler.updated["schedule_tz"] == ""
+    assert scheduler.job.tz == ""
+
+
+@pytest.mark.asyncio
+async def test_update_without_either_key_leaves_the_timezone_alone() -> None:
+    scheduler = _FakeScheduler(_shanghai_job())
+
+    await _update(scheduler, {"kind": "cron", "expr": "0 10 * * *"})
+
+    assert scheduler.updated is not None
+    assert "schedule_tz" not in scheduler.updated
+    assert scheduler.job.tz == "Asia/Shanghai"

--- a/tests/test_scheduler/test_schedule_normalizer_timezone_alias.py
+++ b/tests/test_scheduler/test_schedule_normalizer_timezone_alias.py
@@ -1,0 +1,161 @@
+"""Structured cron schedules honour the ``timezone`` alias like the shorthand path.
+
+Regression for #1603: ``{"schedule": {"kind": "cron", ..., "timezone": X}}``
+dropped ``X`` on the floor and silently scheduled the job in UTC, while
+``{"expression": ..., "timezone": X}`` kept it. Both spellings now resolve,
+and the same conflict / type checks ``_top_level_tz`` applies to the
+top-level pair apply inside ``schedule``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentos.scheduler.schedule_normalizer import coerce_schedule, coerce_schedule_from_params
+from agentos.scheduler.types import ScheduleKind
+
+
+def test_structured_cron_honours_timezone_alias() -> None:
+    kind, expr, tz = coerce_schedule_from_params(
+        {"schedule": {"kind": "cron", "expr": "0 9 * * 1-5", "timezone": "Asia/Shanghai"}}
+    )
+
+    assert kind == ScheduleKind.CRON
+    assert expr == "0 9 * * 1-5"
+    assert tz == "Asia/Shanghai"
+
+
+def test_coerce_schedule_honours_timezone_alias_directly() -> None:
+    # ``coerce_schedule`` is also reached without the params wrapper.
+    assert coerce_schedule(
+        {"kind": "cron", "expr": "0 9 * * *", "timezone": " Asia/Shanghai "}
+    ) == (ScheduleKind.CRON, "0 9 * * *", "Asia/Shanghai")
+
+
+def test_structured_cron_accepts_matching_tz_and_timezone() -> None:
+    _, _, tz = coerce_schedule_from_params(
+        {
+            "schedule": {
+                "kind": "cron",
+                "expr": "0 9 * * *",
+                "tz": "Asia/Shanghai",
+                "timezone": "Asia/Shanghai",
+            }
+        }
+    )
+    assert tz == "Asia/Shanghai"
+
+
+def test_structured_cron_prefers_tz_over_a_blank_timezone() -> None:
+    _, _, tz = coerce_schedule_from_params(
+        {"schedule": {"kind": "cron", "expr": "0 9 * * *", "tz": "Asia/Shanghai", "timezone": ""}}
+    )
+    assert tz == "Asia/Shanghai"
+
+
+def test_structured_cron_rejects_conflicting_tz_and_timezone() -> None:
+    with pytest.raises(ValueError, match=r"schedule\.tz conflicts with schedule\.timezone"):
+        coerce_schedule_from_params(
+            {
+                "schedule": {
+                    "kind": "cron",
+                    "expr": "0 9 * * *",
+                    "tz": "Asia/Shanghai",
+                    "timezone": "America/Los_Angeles",
+                }
+            }
+        )
+
+
+def test_structured_timezone_alias_rejects_conflicting_top_level_tz() -> None:
+    with pytest.raises(ValueError, match=r"schedule\.tz conflicts with tz"):
+        coerce_schedule_from_params(
+            {
+                "schedule": {"kind": "cron", "expr": "0 9 * * *", "timezone": "Asia/Shanghai"},
+                "tz": "America/Los_Angeles",
+            }
+        )
+
+
+def test_structured_timezone_alias_rejects_conflicting_top_level_timezone() -> None:
+    with pytest.raises(ValueError, match=r"schedule\.tz conflicts with tz"):
+        coerce_schedule_from_params(
+            {
+                "schedule": {"kind": "cron", "expr": "0 9 * * *", "timezone": "Asia/Shanghai"},
+                "timezone": "America/Los_Angeles",
+            }
+        )
+
+
+def test_structured_timezone_alias_agrees_with_top_level_tz() -> None:
+    _, _, tz = coerce_schedule_from_params(
+        {
+            "schedule": {"kind": "cron", "expr": "0 9 * * *", "timezone": "Asia/Shanghai"},
+            "tz": "Asia/Shanghai",
+        }
+    )
+    assert tz == "Asia/Shanghai"
+
+
+def test_top_level_tz_fills_a_blank_structured_timezone() -> None:
+    _, _, tz = coerce_schedule_from_params(
+        {
+            "schedule": {"kind": "cron", "expr": "0 9 * * *", "timezone": "  "},
+            "tz": "Asia/Shanghai",
+        }
+    )
+    assert tz == "Asia/Shanghai"
+
+
+@pytest.mark.parametrize(
+    "bad", [5, 0, ["Asia/Shanghai"], [], {"name": "Asia/Shanghai"}, {}, True, False]
+)
+def test_structured_cron_rejects_non_string_timezone(bad: object) -> None:
+    with pytest.raises(ValueError, match=r"schedule\.timezone must be a string IANA timezone"):
+        coerce_schedule_from_params(
+            {"schedule": {"kind": "cron", "expr": "0 9 * * *", "timezone": bad}}
+        )
+
+
+def test_structured_cron_rejects_non_string_timezone_even_with_top_level_tz() -> None:
+    # A top-level tz used to paper over a garbage ``schedule.tz``; the alias
+    # gets the same strictness as ``schedule.tz`` on its own.
+    with pytest.raises(ValueError, match=r"schedule\.timezone must be a string IANA timezone"):
+        coerce_schedule_from_params(
+            {
+                "schedule": {"kind": "cron", "expr": "0 9 * * *", "timezone": 5},
+                "tz": "Asia/Shanghai",
+            }
+        )
+
+
+@pytest.mark.parametrize("bad", [5, 0, [], {}, False])
+def test_structured_cron_rejects_non_string_tz(bad: object) -> None:
+    # Falsy non-strings used to slip through ``raw.get("tz") or ""`` and
+    # schedule the job in UTC; the alias must not inherit that hole.
+    with pytest.raises(ValueError, match=r"schedule\.tz must be a string IANA timezone"):
+        coerce_schedule_from_params({"schedule": {"kind": "cron", "expr": "0 9 * * *", "tz": bad}})
+
+
+def test_structured_cron_treats_null_tz_and_timezone_as_unset() -> None:
+    assert coerce_schedule({"kind": "cron", "expr": "0 9 * * *", "tz": None, "timezone": None}) == (
+        ScheduleKind.CRON,
+        "0 9 * * *",
+        "",
+    )
+
+
+def test_structured_timezone_alias_is_validated() -> None:
+    with pytest.raises(ValueError, match=r"schedule\.tz invalid"):
+        coerce_schedule_from_params(
+            {"schedule": {"kind": "cron", "expr": "0 9 * * *", "timezone": "Mars/Base"}}
+        )
+
+
+def test_timezone_alias_is_ignored_for_non_cron_kinds() -> None:
+    # ``every`` / ``at`` carry no tz today; a stray alias is not an error,
+    # exactly like a stray ``tz`` on those kinds.
+    kind, value, tz = coerce_schedule_from_params(
+        {"schedule": {"kind": "every", "every_seconds": 300, "timezone": "Asia/Shanghai"}}
+    )
+    assert (kind, value, tz) == (ScheduleKind.EVERY, "300", "")


### PR DESCRIPTION
## Summary

Fixes #1603.

`coerce_schedule_from_params` read only `schedule.tz`, so a structured cron schedule carrying the `timezone` alias — the spelling the expression-shorthand path already honours via `_top_level_tz`, and the comment on that path says the parity was meant to run the other way — had its timezone silently dropped and the job scheduled in UTC with no error anywhere.

## Change

`_coerce_cron` resolves the tz through a new `_schedule_tz` helper that mirrors `_top_level_tz` for the structured path:

- either `schedule.tz` or `schedule.timezone` is accepted;
- both present and different → `schedule.tz conflicts with schedule.timezone`;
- a non-string value — including the falsy ones `raw.get("tz") or ""` used to swallow (`0`, `False`, `[]`, `{}`) — → `schedule.<key> must be a string IANA timezone name` (the message names the key the caller actually sent); `None` still means "unset".

The top-level conflict check in `coerce_schedule_from_params` goes through the same helper, so a `schedule.timezone` that disagrees with a top-level `tz`/`timezone` now raises `schedule.tz conflicts with tz` instead of being overwritten.

`cron.update`'s explicit-clear detection (`rpc_cron.py`) learns the alias too: once `schedule.timezone` is meaningful, an explicit `"timezone": ""` must clear the job's timezone the way `"tz": ""` already does, instead of reading as "not supplied".

## Tests

`tests/test_scheduler/test_schedule_normalizer_timezone_alias.py` (the repro; `coerce_schedule` directly; matching / blank / conflicting `tz`+`timezone`; conflict and agreement against top-level `tz` and `timezone`; top-level tz filling a blank alias; non-string rejection for both keys including falsy values and with a top-level tz present; alias validated against IANA names; alias ignored on non-cron kinds like a stray `tz`) and `tests/test_gateway/test_rpc_cron_update_timezone_alias.py` (set / clear / leave-alone through the alias on `cron.update`).

## Merge safety

This PR is one of five opened together (#1602, #1603, #1606, #1616, #1618). Each touches a disjoint set of files and none touches `CHANGELOG.md` (the `[Unreleased]` `### Fixed` section has a single entry, which leaves too few non-adjacent insertion points for five parallel bullets), so they can be merged one by one in any order; all 120 orderings were verified conflict-free against `upstream/main`, and the fully merged tree passes the complete gate (ruff, mypy, full pytest). Happy to follow up with a single `docs(changelog)` PR recording the batch once they land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrT2hZdMcL98BWVTX8oZB1
