### PR TITLE
fix(channels/slack): bind approvals to the entry's configured name

### DIFF
--- a/src/agentos/channels/registry.py
+++ b/src/agentos/channels/registry.py
@@ -229,4 +229,10 @@ def _build_generic_channel(
         return cast("ManagedChannel", channel_class(config=config_class(**config_kwargs)))
 
     kwargs = {key: value for key, value in data.items() if key in accepted}
+    # ``name`` is excluded from ``data`` with the other common entry fields,
+    # so hand it over explicitly when the adapter can take it -- the same
+    # courtesy the config path extends above. Without it a flat adapter
+    # can never learn which entry it serves (#1606).
+    if "name" in accepted and hasattr(entry, "name"):
+        kwargs["name"] = entry.name
     return cast("ManagedChannel", channel_class(**kwargs))

--- a/src/agentos/channels/slack.py
+++ b/src/agentos/channels/slack.py
@@ -105,6 +105,12 @@ class SlackChannel:
     token: str
     slack_channel_id: str
     channel_id: str = "slack"
+    # The gateway entry name (``SlackChannelEntry.name``). Session keys embed
+    # it (``agent:<id>:<entry name>:group:<channel>``), so approvals are bound
+    # to it, not to ``channel_id`` -- which stays the adapter type id that
+    # keys ``pending_overflow_policy_per_channel``. The registry fills it in
+    # for every managed entry; the default only covers a hand-built adapter.
+    name: str = "slack"
     sender_id: str = "slack-user"
     bot_user_id: str | None = None
     reply_in_thread: bool = False
@@ -916,7 +922,7 @@ class SlackChannel:
                 session_mode = parts[3]
                 session_peer = parts[4]
                 expected_peer = channel_id if session_mode in ("group", "channel") else user_id
-                if session_channel != self.channel_id or session_peer != expected_peer:
+                if session_channel != self.name or session_peer != expected_peer:
                     log.warning(
                         "slack.interactive_mismatch",
                         session_key=session_key,

--- a/tests/test_channels/test_slack_approval_entry_name.py
+++ b/tests/test_channels/test_slack_approval_entry_name.py
@@ -1,0 +1,156 @@
+"""Issue #1606: the Slack approval binding must compare the sessionKey's
+channel segment against the entry's configured name.
+
+Session keys embed the *entry name* (``ChannelManager._build_session_key`` ->
+``build_group_key(channel=entry.name, ...)``). ``SlackChannel`` compared that
+segment against ``channel_id``, a dataclass default of ``"slack"`` that the
+registry never overwrote -- ``name`` sits in ``_COMMON_ENTRY_FIELDS``, so the
+generic builder excluded it by construction. On any entry not literally
+named ``slack`` every Approve/Deny click logged ``slack.interactive_mismatch``
+and the approval never resolved. Discord, Telegram and MS Teams carry the
+entry name on their config; the flat-dataclass path now gets it too.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentos.channels.registry import build_managed_channel
+from agentos.channels.slack import SlackChannel
+from agentos.gateway.approval_queue import get_approval_queue, reset_approval_queue
+from agentos.gateway.config import SlackChannelEntry
+from agentos.session.keys import DmScope, build_direct_key, build_group_key
+
+CHANNEL_ID = "C12345"
+DM_ID = "D12345"
+USER_ID = "U12345"
+
+
+@pytest.fixture(autouse=True)
+def _clean_approval_queue():
+    reset_approval_queue()
+    yield
+    reset_approval_queue()
+
+
+def _channel(name: str) -> SlackChannel:
+    entry = SlackChannelEntry(name=name, token="xoxb-test", slack_channel_id=CHANNEL_ID)
+    adapter = build_managed_channel(entry)
+    assert isinstance(adapter, SlackChannel)
+    return adapter
+
+
+def _click(approval_id: str, *, action: str = "approve", channel_id: str = CHANNEL_ID) -> dict:
+    # No ``response_url``: the handler only posts back when Slack gave it one,
+    # so the test stays offline.
+    return {
+        "type": "block_actions",
+        "user": {"id": USER_ID},
+        "channel": {"id": channel_id},
+        "team": {"id": "T1"},
+        "message": {"text": "Approval requested", "blocks": []},
+        "actions": [{"value": f"{action}:{approval_id}"}],
+    }
+
+
+def _pending(session_key: str) -> str:
+    return get_approval_queue().request(
+        "exec", {"argv": ["rm", "-rf"], "action_kind": "exec", "sessionKey": session_key}
+    )
+
+
+@pytest.mark.asyncio
+async def test_approval_resolves_for_a_non_default_entry_name() -> None:
+    queue = get_approval_queue()
+    approval_id = _pending(
+        build_group_key(agent_id="main", channel="slack-support", peer_id=CHANNEL_ID)
+    )
+    channel = _channel("slack-support")
+
+    await channel._handle_slack_interactive(_click(approval_id))
+
+    entry = queue.get(approval_id)
+    assert entry.resolved is True
+    assert entry.approved is True
+
+
+@pytest.mark.asyncio
+async def test_direct_message_approval_resolves_for_a_non_default_entry_name() -> None:
+    queue = get_approval_queue()
+    # The manager keys DMs per channel+peer; the default ``DmScope.MAIN`` would
+    # produce a 3-segment key the handler never checks at all.
+    approval_id = _pending(
+        build_direct_key(
+            agent_id="main",
+            channel="slack-support",
+            peer_id=USER_ID,
+            dm_scope=DmScope.PER_CHANNEL_PEER,
+        )
+    )
+    channel = _channel("slack-support")
+
+    await channel._handle_slack_interactive(_click(approval_id, action="deny", channel_id=DM_ID))
+
+    entry = queue.get(approval_id)
+    assert entry.resolved is True
+    assert entry.approved is False
+
+
+@pytest.mark.asyncio
+async def test_default_entry_name_keeps_working() -> None:
+    queue = get_approval_queue()
+    approval_id = _pending(build_group_key(agent_id="main", channel="slack", peer_id=CHANNEL_ID))
+    channel = _channel("slack")
+
+    await channel._handle_slack_interactive(_click(approval_id))
+
+    assert queue.get(approval_id).resolved is True
+
+
+@pytest.mark.asyncio
+async def test_click_from_another_entry_is_still_rejected() -> None:
+    """The binding is tightened, not loosened: an approval raised on the
+    ``slack-ops`` entry cannot be resolved by a click on ``slack-support``,
+    even from the same channel id."""
+    queue = get_approval_queue()
+    approval_id = _pending(
+        build_group_key(agent_id="main", channel="slack-ops", peer_id=CHANNEL_ID)
+    )
+    channel = _channel("slack-support")
+
+    await channel._handle_slack_interactive(_click(approval_id))
+
+    assert queue.get(approval_id).resolved is False
+
+
+@pytest.mark.asyncio
+async def test_click_from_another_channel_is_still_rejected() -> None:
+    queue = get_approval_queue()
+    approval_id = _pending(
+        build_group_key(agent_id="main", channel="slack-support", peer_id=CHANNEL_ID)
+    )
+    channel = _channel("slack-support")
+
+    await channel._handle_slack_interactive(_click(approval_id, channel_id="C_OTHER"))
+
+    assert queue.get(approval_id).resolved is False
+
+
+def test_registry_hands_the_entry_name_to_the_adapter() -> None:
+    entry = SlackChannelEntry(name="slack-support", token="xoxb-test", slack_channel_id=CHANNEL_ID)
+
+    adapter = build_managed_channel(entry)
+
+    assert isinstance(adapter, SlackChannel)
+    assert adapter.name == "slack-support"
+    # The other entry fields still arrive the way they did before.
+    assert adapter.token == "xoxb-test"
+    assert adapter.slack_channel_id == CHANNEL_ID
+
+
+def test_channel_id_stays_the_adapter_type_id() -> None:
+    """``channel_id`` keys ``pending_overflow_policy_per_channel`` (documented
+    as ``"slack"``); binding approvals to a separate ``name`` field leaves
+    that contract alone."""
+    assert _channel("slack-support").channel_id == "slack"
+    assert SlackChannel(token="xoxb-test", slack_channel_id=CHANNEL_ID).name == "slack"


### PR DESCRIPTION
## Summary

Fixes #1606.

`_handle_slack_interactive` compared the sessionKey's channel segment against `SlackChannel.channel_id`, a dataclass default of `"slack"` the registry never overwrote: `name` sits in `_COMMON_ENTRY_FIELDS`, so `_build_generic_channel`'s flat path excluded it by construction. Session keys embed the *entry name* (`agent:<id>:<entry name>:group:<channel>`), so on any Slack entry not literally named `slack` every Approve/Deny click logged `slack.interactive_mismatch` and the approval never resolved.

## Change

- `SlackChannel` gains a `name` field (the entry name, defaulting to `"slack"` for hand-built adapters) and the mismatch check compares against it — the way Discord (#1846), Telegram and MS Teams compare against `self.config.name`.
- The registry's flat path now passes `entry.name` to any adapter whose constructor accepts `name`, mirroring what the config path already does for config models that declare the field. Among built-ins only Slack takes the flat path with an entry model, so no other adapter's kwargs change.
- `channel_id` is deliberately left alone: it is the adapter type id that keys `pending_overflow_policy_per_channel` (documented as `"slack"`), and repurposing it for the entry name would silently move that operator override.

## Tests

`tests/test_channels/test_slack_approval_entry_name.py`, building the adapter through the real registry (`build_managed_channel(SlackChannelEntry(name="slack-support", …))`): the reported scenario (group key with `channel="slack-support"` → click resolves), the DM variant (using `DmScope.PER_CHANNEL_PEER`, the scope the manager uses — the default `MAIN` scope yields a 3-segment key the handler never checks), the default `"slack"` name still working, a click from another entry (`slack-ops`) or another channel id still rejected, the registry actually handing the name over with the other fields intact, and `channel_id` staying `"slack"`.

Related: the maintainer's triage suggested a shared regression test asserting `entry.name` reaches the approval comparison for every adapter. Left out here so this PR stays disjoint from #1846; happy to add it as a follow-up once both land.

## Merge safety

This PR is one of five opened together (#1602, #1603, #1606, #1616, #1618). Each touches a disjoint set of files and none touches `CHANGELOG.md` (the `[Unreleased]` `### Fixed` section has a single entry, which leaves too few non-adjacent insertion points for five parallel bullets), so they can be merged one by one in any order; all 120 orderings were verified conflict-free against `upstream/main`, and the fully merged tree passes the complete gate (ruff, mypy, full pytest). Happy to follow up with a single `docs(changelog)` PR recording the batch once they land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrT2hZdMcL98BWVTX8oZB1
