### PR TITLE
fix(gateway): normalize sessions.create displayName like rename and patch

### DIFF
--- a/src/agentos/cli/tui/adapters/slash_standalone.py
+++ b/src/agentos/cli/tui/adapters/slash_standalone.py
@@ -320,7 +320,7 @@ async def _replace_with_new_session(
         )
     )
     sync_session_chrome_from_state(state)
-    label = f" ({title})" if title else ""
+    label = f" ({markup_escape(title)})" if title else ""
     console.print(f"[green]Started new session{label}:[/green] {session_key}")
     return session_key
 
@@ -497,7 +497,9 @@ async def handle_standalone_slash_command(
         return True
 
     if parts := _slash_parts(cmd, "/new"):
-        title = parts[1].strip() if len(parts) > 1 else None
+        # Standalone mode never reaches ``sessions.create``, so the title is
+        # normalized here -- the same shape ``/rename`` below stores (#1618).
+        title = normalize_session_name(parts[1]) if len(parts) > 1 else None
         await _replace_with_new_session(context, title=title)
         return True
 

--- a/src/agentos/gateway/rpc_sessions.py
+++ b/src/agentos/gateway/rpc_sessions.py
@@ -862,7 +862,11 @@ async def _handle_sessions_create(params: dict | None, ctx: RpcContext) -> dict:
     if not isinstance(params, dict):
         params = {}
     agent_id = normalize_agent_id(params.get("agentId", "main"))
-    display_name = params.get("displayName")
+    # Same normalizer ``sessions.rename`` and ``sessions.patch`` use: the name
+    # is user-typed (``/new <title>`` pastes arrive here verbatim) and is
+    # later rendered on a terminal, so control bytes, newlines and length
+    # are cut down before storage rather than on every read (#1618).
+    display_name = normalize_session_name(params.get("displayName"))
     message = params.get("message")
     model = _model_value(params.get("model")) or _agent_registry_model(ctx, agent_id)
     kind = params.get("kind") or params.get("sessionKind")

--- a/tests/test_gateway/test_rpc_sessions_create_display_name.py
+++ b/tests/test_gateway/test_rpc_sessions_create_display_name.py
@@ -1,0 +1,144 @@
+"""``sessions.create`` normalizes ``displayName`` like ``rename`` / ``patch`` do.
+
+Regression for #1618: ``_handle_sessions_create`` passed ``displayName``
+to ``SessionManager.create`` verbatim, the one write path that skipped
+``normalize_session_name``. Raw ANSI/OSC bytes reached whatever terminal later
+rendered the session list or toolbar chip (``markup_escape`` only handles
+Rich's bracket syntax), and multi-line or over-length names broke the
+single-line, <=120-character shape every list row assumes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from agentos.gateway.config import GatewayConfig
+from agentos.gateway.rpc import RpcContext, get_dispatcher
+from agentos.session.naming import MAX_SESSION_NAME_LENGTH, normalize_session_name
+
+
+@dataclass
+class _Session:
+    session_key: str
+    session_id: str
+    display_name: str | None
+
+
+class _SessionManager:
+    """Records exactly what ``sessions.create`` hands to ``create``."""
+
+    def __init__(self) -> None:
+        self.create_calls: list[dict[str, Any]] = []
+
+    async def create(
+        self,
+        session_key: str,
+        agent_id: str = "main",
+        display_name: str | None = None,
+        model: str | None = None,
+    ) -> _Session:
+        self.create_calls.append(
+            {"session_key": session_key, "agent_id": agent_id, "display_name": display_name}
+        )
+        return _Session(session_key, session_key.rsplit(":", 1)[-1], display_name)
+
+
+def _ctx(manager: _SessionManager) -> RpcContext:
+    ctx = RpcContext(conn_id="test-conn", config=GatewayConfig())
+    ctx.session_manager = manager
+    return ctx
+
+
+async def _create(manager: _SessionManager, params: dict[str, Any]):
+    return await get_dispatcher().dispatch("r1", "sessions.create", params, _ctx(manager))
+
+
+@pytest.mark.asyncio
+async def test_create_strips_terminal_escape_sequences() -> None:
+    manager = _SessionManager()
+    raw = "\x1b[2J\x1b]0;pwned\x07ops \x1b[31mreview\x1b[0m"
+
+    res = await _create(manager, {"displayName": raw})
+
+    assert res.ok is True
+    stored = manager.create_calls[0]["display_name"]
+    assert stored == "[2J]0;pwnedops [31mreview[0m"
+    assert "\x1b" not in stored and "\x07" not in stored
+    assert stored == normalize_session_name(raw)
+
+
+@pytest.mark.asyncio
+async def test_create_collapses_pasted_multi_line_names() -> None:
+    manager = _SessionManager()
+
+    res = await _create(manager, {"displayName": "  first line\n\n\tsecond   line \r\n"})
+
+    assert res.ok is True
+    assert manager.create_calls[0]["display_name"] == "first line second line"
+
+
+@pytest.mark.asyncio
+async def test_create_trims_over_length_names() -> None:
+    manager = _SessionManager()
+
+    res = await _create(manager, {"displayName": "x" * (MAX_SESSION_NAME_LENGTH * 3)})
+
+    assert res.ok is True
+    assert manager.create_calls[0]["display_name"] == "x" * MAX_SESSION_NAME_LENGTH
+
+
+@pytest.mark.asyncio
+async def test_create_stores_no_name_for_a_blank_display_name() -> None:
+    manager = _SessionManager()
+
+    res = await _create(manager, {"displayName": "  \n\t "})
+
+    assert res.ok is True
+    assert manager.create_calls[0]["display_name"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_without_display_name_is_unchanged() -> None:
+    manager = _SessionManager()
+
+    res = await _create(manager, {"agentId": "main"})
+
+    assert res.ok is True
+    assert manager.create_calls[0]["display_name"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_keeps_an_already_clean_name() -> None:
+    manager = _SessionManager()
+
+    res = await _create(manager, {"displayName": "Ops review"})
+
+    assert res.ok is True
+    assert manager.create_calls[0]["display_name"] == "Ops review"
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_a_non_string_display_name() -> None:
+    manager = _SessionManager()
+
+    res = await _create(manager, {"displayName": ["not", "a", "string"]})
+
+    assert res.ok is False
+    assert res.error is not None
+    assert "session name must be a string" in res.error.message
+    assert manager.create_calls == []
+
+
+@pytest.mark.asyncio
+async def test_create_matches_what_rename_would_store() -> None:
+    """The invariant the normalizer's docstring promises: every write path
+    stores the same shape for the same input."""
+    manager = _SessionManager()
+    raw = "\x1b[1m Q3 \n planning \x1b[0m"
+
+    await _create(manager, {"displayName": raw})
+
+    assert manager.create_calls[0]["display_name"] == normalize_session_name(raw)

--- a/tests/unit/cli/repl/test_slash_new_display_name.py
+++ b/tests/unit/cli/repl/test_slash_new_display_name.py
@@ -1,0 +1,80 @@
+"""Issue #1618: ``/new <title>`` stores a normalized display name.
+
+Gateway mode hands the title to ``sessions.create``, which now normalizes it
+server-side (see ``tests/test_gateway/test_rpc_sessions_create_display_name``).
+Standalone mode never reaches the gateway, so it normalizes before calling the
+session manager -- the same shape ``/rename`` stores on that surface.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agentos.cli.chat.session_state import ChatSessionState
+from agentos.cli.tui.adapters.slash_standalone import (
+    StandaloneSlashContext,
+    StandaloneSlashServices,
+    handle_standalone_slash_command,
+)
+
+
+class _StandaloneManager:
+    def __init__(self) -> None:
+        self.creates: list[tuple[str, dict[str, Any]]] = []
+
+    async def create(self, session_key: str, **fields: Any) -> None:
+        self.creates.append((session_key, fields))
+
+
+def _standalone_context(manager: _StandaloneManager) -> StandaloneSlashContext:
+    state = ChatSessionState(session_key="agent:main:standalone:test", model="openai/test")
+    return StandaloneSlashContext(
+        state=state,
+        session_key=state.session_key,
+        model=state.model,
+        tool_ctx=object(),
+        slash_services=StandaloneSlashServices(create_session=manager.create),
+        turn_runner=object(),
+        build_tool_ctx=lambda _session_key: object(),
+        replace_session=lambda **_updates: None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_standalone_new_persists_a_normalized_title() -> None:
+    manager = _StandaloneManager()
+    context = _standalone_context(manager)
+
+    handled = await handle_standalone_slash_command("/new \x1b[2Jops \n\n  review\x1b[0m ", context)
+
+    assert handled is True
+    assert len(manager.creates) == 1
+    _, fields = manager.creates[0]
+    assert fields["display_name"] == "[2Jops review[0m"
+    assert context.state.display_name == "[2Jops review[0m"
+
+
+@pytest.mark.asyncio
+async def test_standalone_new_with_a_blank_title_stores_no_name() -> None:
+    manager = _StandaloneManager()
+    context = _standalone_context(manager)
+
+    handled = await handle_standalone_slash_command("/new   \t ", context)
+
+    assert handled is True
+    assert manager.creates[0][1]["display_name"] is None
+    assert context.state.display_name is None
+
+
+@pytest.mark.asyncio
+async def test_standalone_new_without_a_title_is_unchanged() -> None:
+    manager = _StandaloneManager()
+    context = _standalone_context(manager)
+
+    handled = await handle_standalone_slash_command("/new", context)
+
+    assert handled is True
+    assert manager.creates[0][1]["display_name"] is None
+    assert context.state.display_name is None


### PR DESCRIPTION
## Summary

Fixes #1618.

`_handle_sessions_create` passed `displayName` to `SessionManager.create` verbatim — the one gateway write path that skipped `normalize_session_name`, even though the normalizer's docstring promises every write path funnels through it and both `sessions.rename` and `sessions.patch` do. `SessionNode.display_name` has no validation of its own, so whatever an RPC/HTTP client sent was stored as-is: raw ANSI/OSC bytes reached whatever terminal later rendered the session list or the CLI toolbar chip (`markup_escape` only handles Rich's bracket syntax), and a pasted multi-line or over-long `/new` title broke the single-line, ≤120-character shape list rows assume.

## Change

- `sessions.create` runs `displayName` through the same normalizer: control characters dropped, whitespace runs collapsed, trimmed to `MAX_SESSION_NAME_LENGTH`, blank names stored as `None`, and a non-string rejected with the same `INVALID_REQUEST` error `rename` raises. The gateway-mode TUI already mirrors the gateway's stored name after `/new`, so its chip picks up the normalized value with no client change.
- The standalone TUI never reaches the gateway, so its `/new <title>` branch (`slash_standalone.py`) normalizes the title itself before handing it to the session manager — the shape its `/rename` three lines below already stores — and the confirmation line escapes it the way `/rename` does. Without this the same invariant hole stayed open on that surface.

## Tests

`tests/test_gateway/test_rpc_sessions_create_display_name.py` (ESC/OSC/BEL bytes stripped; pasted multi-line collapsed; over-length trimmed; blank → `None`; absent unchanged; clean name kept; non-string rejected without reaching `create`; output equals what `rename` would store for the same input) and `tests/unit/cli/repl/test_slash_new_display_name.py` (standalone `/new` with control bytes + newlines, blank title, no title).

## Merge safety

This PR is one of five opened together (#1602, #1603, #1606, #1616, #1618). Each touches a disjoint set of files and none touches `CHANGELOG.md` (the `[Unreleased]` `### Fixed` section has a single entry, which leaves too few non-adjacent insertion points for five parallel bullets), so they can be merged one by one in any order; all 120 orderings were verified conflict-free against `upstream/main`, and the fully merged tree passes the complete gate (ruff, mypy, full pytest). Happy to follow up with a single `docs(changelog)` PR recording the batch once they land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrT2hZdMcL98BWVTX8oZB1
