### PR TITLE
fix(tools): notify memory sources for USER.md and memory.md in apply_patch

### DIFF
--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -12,6 +12,7 @@ import os
 import posixpath
 import re
 import zipfile
+from collections.abc import Iterable
 from pathlib import Path
 from xml.etree import ElementTree as ET
 
@@ -114,9 +115,16 @@ def _resolve_base(path: str | None) -> Path:
     return root if root is not None else Path.cwd()
 
 
-def _memory_source_rel_path(path: Path) -> str | None:
+def _memory_source_rel_path(path: Path, roots: Iterable[Path] | None = None) -> str | None:
+    """Return *path* relative to the memory root it is a source file of, or ``None``.
+
+    This is the single definition of "which Markdown files feed the memory
+    snapshot"; ``apply_patch`` delegates here rather than keeping its own
+    copy, so the two tools cannot disagree about what counts as a source.
+    *roots* defaults to :func:`_memory_roots`.
+    """
     resolved = path.resolve(strict=False)
-    for root in _memory_roots():
+    for root in _memory_roots() if roots is None else roots:
         try:
             rel = resolved.relative_to(root)
         except ValueError:
@@ -890,9 +898,7 @@ def _locate_edit(original: str, old_text: str, new_text: str, *, path: str) -> F
     argv_factory=lambda a: ("fs.edit", str(a.get("path", ""))),
     record_payload=False,
 )
-async def edit_file(
-    path: str, old_text: str, new_text: str, approval_id: str | None = None
-) -> str:
+async def edit_file(path: str, old_text: str, new_text: str, approval_id: str | None = None) -> str:
     p = _resolve_path(path)
     approval = await _gate_out_of_workspace_write("edit_file", p, path, approval_id)
     if approval is not None:

--- a/src/agentos/tools/builtin/patch.py
+++ b/src/agentos/tools/builtin/patch.py
@@ -169,18 +169,25 @@ def _validate_path(path: str, root: Path | None = None) -> Path:
     return resolved
 
 
-def _memory_source_rel_path(path: str, root: Path) -> str | None:
-    resolved = _validate_path(path, root)
-    try:
-        rel = resolved.relative_to(root)
-    except ValueError:
-        return None
+def _memory_roots(root: Path) -> tuple[Path, ...]:
+    """The patch root plus every memory root the filesystem tools know about."""
+    from agentos.tools.builtin import filesystem
 
-    if rel.parts == ("MEMORY.md",):
-        return "MEMORY.md"
-    if len(rel.parts) >= 2 and rel.parts[0] == "memory" and rel.suffix == ".md":
-        return rel.as_posix()
-    return None
+    roots = [root]
+    for candidate in filesystem._memory_roots():
+        if candidate not in roots:
+            roots.append(candidate)
+    return tuple(roots)
+
+
+def _memory_source_rel_path(path: str, root: Path) -> str | None:
+    # Delegate to the filesystem tool's classifier so USER.md, memory.md and a
+    # memory_source_dir nested under the workspace refresh the snapshot the
+    # same way they do through write_file / edit_file.
+    from agentos.tools.builtin import filesystem
+
+    resolved = _validate_path(path, root)
+    return filesystem._memory_source_rel_path(resolved, roots=_memory_roots(root))
 
 
 def _bootstrap_source_rel_path(path: str, root: Path) -> str | None:

--- a/tests/test_tools/test_apply_patch_memory_source_notify.py
+++ b/tests/test_tools/test_apply_patch_memory_source_notify.py
@@ -1,0 +1,171 @@
+"""``apply_patch`` must recognise the same memory sources as the filesystem tools.
+
+``filesystem._memory_source_rel_path`` walks every memory root (workspace and
+``memory_source_dir``) and treats ``MEMORY.md``, ``memory.md``, ``USER.md`` and
+``memory/*.md`` as sources whose write must refresh the frozen memory
+snapshot. ``patch._memory_source_rel_path`` had its own copy of that rule
+that only knew ``MEMORY.md`` under the single patch root, so patching
+``USER.md`` or ``memory.md`` never fired ``on_memory_source_write`` and the
+change stayed invisible to the model for the rest of the session -- while the
+very same edit through ``write_file`` refreshed the snapshot. The two helpers
+must not drift again, so the patch tool now delegates to the filesystem one.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+
+import pytest
+
+from agentos.tools.builtin import filesystem
+from agentos.tools.builtin import patch as patch_tool
+from agentos.tools.types import ToolContext, current_tool_context
+
+
+def _original_async(fn: Callable[..., Awaitable[str]]) -> Callable[..., Awaitable[str]]:
+    return fn.__wrapped__.__wrapped__  # type: ignore[attr-defined, no-any-return]
+
+
+def _update(path: str, old: str, new: str) -> str:
+    return f"*** Update File: {path}\n@@@ -1,1 +1,1 @@@\n-{old}\n+{new}\n"
+
+
+async def _patch_in(
+    workspace: Path,
+    sections: str,
+    *,
+    memory_source_dir: Path | None = None,
+) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
+    memory_calls: list[tuple[str, str]] = []
+    bootstrap_calls: list[tuple[str, str]] = []
+    token = current_tool_context.set(
+        ToolContext(
+            agent_id="main",
+            workspace_dir=str(workspace),
+            memory_source_dir=str(memory_source_dir or workspace),
+            on_memory_source_write=lambda agent_id, path: memory_calls.append((agent_id, path)),
+            on_bootstrap_source_write=lambda agent_id, path: bootstrap_calls.append(
+                (agent_id, path)
+            ),
+        )
+    )
+    apply_patch = _original_async(patch_tool.apply_patch)
+    try:
+        result = await apply_patch(f"*** Begin Patch\n{sections}*** End Patch")
+    finally:
+        current_tool_context.reset(token)
+    assert result.startswith("Applied patch:"), result
+    return memory_calls, bootstrap_calls
+
+
+@pytest.mark.asyncio
+async def test_patching_user_md_refreshes_the_memory_snapshot(tmp_path: Path) -> None:
+    """The regression this file exists for: USER.md is a curated memory store."""
+    (tmp_path / "USER.md").write_text("Name:\n", encoding="utf-8")
+
+    memory_calls, bootstrap_calls = await _patch_in(
+        tmp_path, _update("USER.md", "Name:", "Name: Alice")
+    )
+
+    assert memory_calls == [("main", "USER.md")]
+    # It is also a bootstrap file, so both snapshots are still invalidated.
+    assert bootstrap_calls == [("main", "USER.md")]
+
+
+@pytest.mark.asyncio
+async def test_patching_legacy_memory_md_refreshes_the_memory_snapshot(tmp_path: Path) -> None:
+    """Kept deliberately: runtime.py still falls back to reading memory.md."""
+    (tmp_path / "memory.md").write_text("old\n", encoding="utf-8")
+
+    memory_calls, _ = await _patch_in(tmp_path, _update("memory.md", "old", "new"))
+
+    assert memory_calls == [("main", "memory.md")]
+
+
+@pytest.mark.asyncio
+async def test_patching_a_memory_source_dir_inside_the_workspace(tmp_path: Path) -> None:
+    """A ``memory_source_dir`` nested under the workspace is a memory root too.
+
+    Only the workspace root used to be considered, so a patch to
+    ``state/MEMORY.md`` looked like a stray file named ``MEMORY.md`` two
+    levels down and never notified.
+    """
+    state = tmp_path / "state"
+    (state / "memory").mkdir(parents=True)
+    (state / "MEMORY.md").write_text("# MEMORY\n", encoding="utf-8")
+    (state / "memory" / "2026-09-12.md").write_text("old\n", encoding="utf-8")
+
+    memory_calls, bootstrap_calls = await _patch_in(
+        tmp_path,
+        _update("state/MEMORY.md", "# MEMORY", "# MEMORY v2")
+        + _update("state/memory/2026-09-12.md", "old", "new"),
+        memory_source_dir=state,
+    )
+
+    assert memory_calls == [("main", "MEMORY.md"), ("main", "memory/2026-09-12.md")]
+    # Bootstrap files are only recognised at the workspace root.
+    assert bootstrap_calls == []
+
+
+@pytest.mark.asyncio
+async def test_other_root_files_do_not_refresh_the_memory_snapshot(tmp_path: Path) -> None:
+    """Widening past MEMORY.md must not sweep in every root-level file."""
+    for name in ("SOUL.md", "notes.md", "USER.txt"):
+        (tmp_path / name).write_text("old\n", encoding="utf-8")
+
+    memory_calls, bootstrap_calls = await _patch_in(
+        tmp_path,
+        _update("SOUL.md", "old", "new")
+        + _update("notes.md", "old", "new")
+        + _update("USER.txt", "old", "new"),
+    )
+
+    assert memory_calls == []
+    assert bootstrap_calls == [("main", "SOUL.md")]
+
+
+@pytest.mark.asyncio
+async def test_each_memory_source_is_notified_once_per_patch(tmp_path: Path) -> None:
+    (tmp_path / "USER.md").write_text("a\nb\n", encoding="utf-8")
+
+    memory_calls, _ = await _patch_in(
+        tmp_path,
+        "*** Update File: USER.md\n@@@ -1,1 +1,1 @@@\n-a\n+A\n@@@ -2,1 +2,1 @@@\n-b\n+B\n",
+    )
+
+    assert memory_calls == [("main", "USER.md")]
+
+
+@pytest.mark.parametrize(
+    "rel",
+    [
+        "MEMORY.md",
+        "memory.md",
+        "USER.md",
+        "memory/2026-09-12.md",
+        "memory/nested/note.md",
+        "SOUL.md",
+        "AGENTS.md",
+        "notes.md",
+        "USER.txt",
+        "memory/README.txt",
+        "docs/MEMORY.md",
+    ],
+)
+def test_patch_helper_agrees_with_the_filesystem_helper(tmp_path: Path, rel: str) -> None:
+    """Parity guard: the two tools must classify every path identically."""
+    token = current_tool_context.set(
+        ToolContext(
+            agent_id="main",
+            workspace_dir=str(tmp_path),
+            memory_source_dir=str(tmp_path),
+        )
+    )
+    try:
+        via_patch = patch_tool._memory_source_rel_path(rel, tmp_path.resolve())
+        via_filesystem = filesystem._memory_source_rel_path(tmp_path / rel)
+    finally:
+        current_tool_context.reset(token)
+
+    assert via_patch == via_filesystem

--- a/tests/test_tools/test_bootstrap_write_notifications.py
+++ b/tests/test_tools/test_bootstrap_write_notifications.py
@@ -77,4 +77,6 @@ async def test_patch_notifies_bootstrap_and_memory_sources(tmp_path) -> None:
         current_tool_context.reset(token)
 
     assert bootstrap_calls == [("main", "USER.md")]
-    assert memory_calls == [("main", "memory/2026-05-01.md")]
+    # USER.md is a curated memory store as well as a bootstrap file, so the
+    # patch tool must refresh the memory snapshot for it exactly like write_file.
+    assert memory_calls == [("main", "USER.md"), ("main", "memory/2026-05-01.md")]


### PR DESCRIPTION
Fixes #1625

## Problem

`patch._memory_source_rel_path` kept its own copy of the "which files feed the memory snapshot" rule: it matched only `rel.parts == ("MEMORY.md",)` and only against the single patch root. `filesystem._memory_source_rel_path` walks every memory root and treats `MEMORY.md`, `memory.md`, `USER.md` and `memory/*.md` as sources. So an `apply_patch` to `USER.md` (a curated memory store), `memory.md`, or a note under a `memory_source_dir` nested in the workspace never fired `on_memory_source_write`, and the edit stayed invisible to the model for the rest of the session — while the same edit through `write_file` / `edit_file` refreshed the snapshot.

## Fix

As the triage suggested, the patch tool now delegates instead of re-implementing the match:

- `filesystem._memory_source_rel_path(path, roots=None)` gains an optional `roots` argument (defaults to `_memory_roots()`, so `write_file` / `edit_file` are unchanged).
- `patch._memory_source_rel_path` validates the path against the patch root as before and calls the filesystem classifier with the patch root plus every filesystem memory root. One definition, no drift.

The existing `test_patch_notifies_bootstrap_and_memory_sources` pinned the old behaviour (USER.md notified bootstrap only); it now expects the memory callback too, matching `write_file`.

## Tests

`tests/test_tools/test_apply_patch_memory_source_notify.py` (new, fails on `main`):
- patching `USER.md` refreshes the memory snapshot (and still the bootstrap one)
- patching legacy `memory.md` refreshes the memory snapshot
- a `memory_source_dir` nested under the workspace (`state/MEMORY.md`, `state/memory/*.md`) notifies with the memory-root-relative path
- `SOUL.md` / `notes.md` / `USER.txt` do not
- one notification per source per patch
- parity guard: the patch and filesystem helpers classify 11 paths identically

## Gate

- `uv run ruff check src tests` — clean
- `uv run mypy src/agentos` — clean (625 files, on the merged batch tree)
- `tests/test_tools`, `tests/test_memory_user_md_notify.py`, `tests/test_engine/test_bootstrap_snapshot_invalidation.py` — pass; full suite on the merged batch tree — see batch note below

## Merge safety

Part of a batch of five fix PRs (#1625, #1645, #1653, #1673, #1674). Each touches a disjoint set of files, and all 120 merge orderings were checked for conflicts on a scratch worktree off `upstream/main` (0 conflicts), so they can be merged one by one in any order. The `CHANGELOG.md` entry is deliberately not in this PR — `[Unreleased] / ### Fixed` has a single bullet, so five PRs inserting there would conflict in every order; the batch entry is in a separate `docs(changelog)` PR that only touches that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dPxJwmC1LQnzwN83SpH2G
