### PR TITLE
fix(session): anchor inline compaction persistence on the loaded transcript

### DIFF
--- a/src/agentos/engine/runtime.py
+++ b/src/agentos/engine/runtime.py
@@ -187,6 +187,7 @@ from agentos.session.keys import (
     is_subagent_key,
     normalize_agent_id,
 )
+from agentos.session.manager import TranscriptSnapshot
 from agentos.session.terminal_reply import build_terminal_reply, sanitize_agent_error
 from agentos.tools.types import CallerKind, ToolContext
 
@@ -1725,6 +1726,10 @@ class TurnRunner:
         self._active_pre_compaction_flush_tasks: dict[str, asyncio.Task] = {}
         self._background_tasks: set[asyncio.Task] = set()
         self._emergency_compaction_overrides: dict[str, _EmergencyCompactionOverride] = {}
+        # Last persisted row each session's loaded history covers, keyed by
+        # session key; anchors inline compaction persistence so rows appended
+        # mid-turn (queued follow-ups) are never overwritten or archived.
+        self._compaction_snapshots: dict[str, TranscriptSnapshot] = {}
         # TurnRunner stage decomposition InputStage instance. Holds no per-turn state;
         # constructed once. Active unconditionally as of.
         self._input_stage = InputStage(extra_ctx=_TurnRunnerExtraContextAdapter())
@@ -1830,6 +1835,9 @@ class TurnRunner:
     def clear_compaction_turn_state(self, session_key: str) -> None:
         self._turn_compaction_attempted_sessions.discard(session_key)
         self._turn_compacted_sessions.discard(session_key)
+        # The anchor only means something for the turn that loaded the history;
+        # the next turn's _load_history records a fresh one.
+        self._compaction_snapshots.pop(session_key, None)
 
     def refresh_memory_snapshot(self, agent_id: str) -> None:
         """Refresh frozen snapshots for all sessions of the given agent.
@@ -6045,6 +6053,7 @@ class TurnRunner:
             return None
 
         transcript = await self._session_manager.get_transcript(session_key)
+        await self._remember_compaction_snapshot(session_key, transcript)
 
         from agentos.engine.history import reconstruct_messages_from_entry
         from agentos.provider import Message
@@ -6109,6 +6118,47 @@ class TurnRunner:
             context_states=context_states,
             skip_covered_through_ids=provider_context.covered_through_ids,
         )
+
+    async def _remember_compaction_snapshot(
+        self, session_key: str, transcript: list[Any] | None
+    ) -> None:
+        """Record which persisted rows the agent's history is built from.
+
+        ``persist_compaction_result`` anchors an inline compaction on it so a
+        follow-up ``sessions.send`` appends after this point is re-appended
+        verbatim instead of being overwritten by the agent's stale kept tail.
+        An empty transcript still records the session so a later compaction
+        of purely in-memory messages treats every persisted row as newer.
+        """
+        snapshots = getattr(self, "_compaction_snapshots", None)
+        if snapshots is None:
+            return
+        snapshots.pop(session_key, None)
+        last = transcript[-1] if transcript else None
+        session_id = getattr(last, "session_id", None)
+        message_id = getattr(last, "message_id", None)
+        if session_id and message_id:
+            snapshots[session_key] = TranscriptSnapshot(
+                session_id=str(session_id), through_message_id=str(message_id)
+            )
+            return
+        if last is not None:
+            return
+        get_session = getattr(self._session_manager, "get_session", None)
+        if not callable(get_session):
+            return
+        try:
+            node = get_session(session_key)
+            if inspect.isawaitable(node):
+                node = await node
+        except Exception:  # noqa: BLE001 - the anchor is best-effort
+            log.debug("compaction_snapshot.session_lookup_failed", session_key=session_key)
+            return
+        session_id = getattr(node, "session_id", None)
+        if session_id:
+            snapshots[session_key] = TranscriptSnapshot(
+                session_id=str(session_id), through_message_id=None
+            )
 
     async def _load_context_states(self, session_key: str) -> list[Any]:
         context_states: list[Any] = []

--- a/src/agentos/engine/turn_runner/harness.py
+++ b/src/agentos/engine/turn_runner/harness.py
@@ -707,13 +707,25 @@ class _TurnRunnerAgentRunAdapter(AgentRunPort):
         )
 
 
+class CompactionPersistRejectedError(RuntimeError):
+    """``persist_compaction_result`` wrote nothing for an inline compaction.
+
+    Raised by the persist adapter so the stream consumer stage takes its
+    failed-persist path -- a ``failed`` lifecycle notification and no
+    post-persist refresh -- instead of announcing a durable compaction that
+    never reached the transcript. The usual cause is a stale snapshot: the
+    session was reset, truncated or compacted from under the running turn.
+    """
+
+
 class _TurnRunnerCompactionPersistAdapter(CompactionPersistPort):
     """Bind ``SessionManager.persist_compaction_result`` + ``notify_compaction``.
 
-    Compaction refresh: the adapter forwards the persist call verbatim and
-    follows it with a completed lifecycle notification. Failed persistence
-    is handled by the stream consumer stage so completed is never emitted
-    before durable storage succeeds. The re-entrancy contract on
+    Compaction refresh: the adapter forwards the persist call verbatim,
+    anchored on the ``TranscriptSnapshot`` ``_load_history`` recorded for the
+    session, and follows it with a completed lifecycle notification. Failed
+    persistence is handled by the stream consumer stage so completed is never
+    emitted before durable storage succeeds. The re-entrancy contract on
     ``persist_compaction_result`` is untouched.
     """
 
@@ -735,6 +747,7 @@ class _TurnRunnerCompactionPersistAdapter(CompactionPersistPort):
             compaction_lifecycle_payload,
             new_compaction_id,
         )
+        from agentos.session.manager import TranscriptSnapshot
 
         session_manager = self._runner._session_manager
         if session_manager is None:
@@ -750,12 +763,30 @@ class _TurnRunnerCompactionPersistAdapter(CompactionPersistPort):
             p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()
         ):
             persist_kwargs["trigger_reason"] = "agent_inline_overflow"
+        # Anchor the rewrite on the rows the agent's history was loaded from
+        # so a follow-up queued mid-turn is never overwritten or archived.
+        snapshots = getattr(self._runner, "_compaction_snapshots", None)
+        snapshot = snapshots.get(session_key) if snapshots is not None else None
+        if snapshot is not None and "snapshot" in params:
+            persist_kwargs["snapshot"] = snapshot
         async with self._runner._session_write_context(session_key):
-            await persist_method(
+            persisted = await persist_method(
                 session_key,
                 summary,
                 kept_entries,
                 **persist_kwargs,
+            )
+        if isinstance(persisted, TranscriptSnapshot):
+            # The next compaction of this same in-memory history must anchor
+            # on the kept tail that was just written, not on the old rows.
+            if snapshots is not None:
+                snapshots[session_key] = persisted
+        elif "snapshot" in params:
+            # A snapshot-aware manager returns None only when it wrote nothing
+            # (stale snapshot, missing session); do not report it as persisted.
+            raise CompactionPersistRejectedError(
+                f"inline compaction for {session_key} was not persisted: the transcript "
+                "changed since the agent loaded its history"
             )
         compaction_id = compaction_id or new_compaction_id()
         notify_compaction(

--- a/src/agentos/session/manager.py
+++ b/src/agentos/session/manager.py
@@ -9,7 +9,7 @@ import os
 import re
 import uuid
 from collections.abc import AsyncIterator, Callable
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -149,6 +149,41 @@ def _compaction_entry_payloads(entries: list[TranscriptEntry]) -> list[dict[str,
         }
         for e in entries
     ]
+
+
+@dataclass(frozen=True)
+class TranscriptSnapshot:
+    """Which persisted rows a running agent built its in-memory history from.
+
+    Captured by the turn runner right after it loads history, handed back on
+    ``persist_compaction_result`` so an inline compaction only rewrites and
+    archives rows the compactor actually saw. ``through_message_id`` is the
+    last such row; ``None`` means the agent holds no persisted rows at all
+    (for example right after a full compaction), so every transcript row is
+    newer than the snapshot. ``message_id`` is used rather than the row id
+    because a compaction rewrite re-inserts rows and renumbers them.
+    """
+
+    session_id: str
+    through_message_id: str | None
+
+
+def _split_at_snapshot(
+    entries: list[TranscriptEntry],
+    snapshot: TranscriptSnapshot,
+) -> tuple[list[TranscriptEntry], list[TranscriptEntry]] | None:
+    """Split *entries* into (rows inside the snapshot, rows appended after it).
+
+    Returns ``None`` when the anchor row is gone -- the transcript was reset,
+    truncated or compacted from under the caller -- so the stale result must
+    not be applied to it.
+    """
+    if snapshot.through_message_id is None:
+        return [], list(entries)
+    for index in range(len(entries) - 1, -1, -1):
+        if entries[index].message_id == snapshot.through_message_id:
+            return list(entries[: index + 1]), list(entries[index + 1 :])
+    return None
 
 
 def _transcript_preimage(entries: list[TranscriptEntry]) -> tuple[tuple[Any, ...], ...]:
@@ -1431,12 +1466,26 @@ class SessionManager:
         compaction_id: str | None = None,
         trigger_reason: str | None = None,
         flush_receipt_status: str | None = None,
-    ) -> None:
+        snapshot: TranscriptSnapshot | None = None,
+    ) -> TranscriptSnapshot | None:
         """Persist a pre-computed compaction result directly (no LLM re-compaction).
 
         Called by TurnRunner when Agent emits CompactionEvent. Writes the Agent's
         actual compaction output to DB, avoiding the double-compaction bug that
         would occur if we called compact() (which re-reads DB and re-runs LLM).
+
+        *snapshot* says which persisted rows the agent's history was built
+        from. Only those rows are replaced by ``kept_entries`` or archived
+        under the summary; anything appended after the snapshot (a queued
+        follow-up from ``sessions.send``) is re-appended verbatim -- same
+        ``message_id``, content, metadata and order -- and the summary's
+        coverage never reaches it. A snapshot whose session or anchor row no
+        longer exists is stale and the result is dropped rather than written
+        over a transcript the compactor never saw. Without a snapshot the
+        whole transcript is treated as seen (legacy callers).
+
+        Returns the snapshot to anchor the next compaction of the same
+        in-memory history on, or ``None`` when nothing was persisted.
         """
         session_key = canonicalize_session_key(session_key)
         import structlog as _structlog
@@ -1446,9 +1495,27 @@ class SessionManager:
         node = await self._storage.get_session(session_key)
         if node is None:
             _log.warning("persist_compaction.session_not_found", session_key=session_key)
-            return
+            return None
 
         entries = await self._storage.get_transcript(node.session_id)
+        newer_entries: list[TranscriptEntry] = []
+        if snapshot is not None:
+            split = (
+                _split_at_snapshot(entries, snapshot)
+                if snapshot.session_id == node.session_id
+                else None
+            )
+            if split is None:
+                _log.warning(
+                    "persist_compaction.stale_snapshot_not_persisted",
+                    session_key=session_key,
+                    snapshot_session_id=snapshot.session_id,
+                    session_id=node.session_id,
+                    entries=len(entries),
+                    kept=len(kept_entries),
+                )
+                return None
+            entries, newer_entries = split
         removed_entries = entries[: max(0, len(entries) - len(kept_entries))]
         preserved_entries = entries[len(removed_entries) :]
         if removed_entries and not summary:
@@ -1458,7 +1525,7 @@ class SessionManager:
                 removed=len(removed_entries),
                 kept=len(kept_entries),
             )
-            return
+            return None
 
         # Store summary out-of-band. New compactions must not prepend a
         # transcript system marker because history loading would make that
@@ -1514,7 +1581,18 @@ class SessionManager:
                 tool_call_id=raw.get("tool_call_id"),
                 turn_usage=raw.get("turn_usage"),
             )
+            # The transcript is ordered by created_at; a kept row minted now
+            # must not sort behind a follow-up that was appended earlier.
+            if newer_entries and entry.created_at > newer_entries[0].created_at:
+                entry.created_at = newer_entries[0].created_at
             rewritten_entries.append(entry)
+        next_snapshot = TranscriptSnapshot(
+            session_id=node.session_id,
+            through_message_id=rewritten_entries[-1].message_id if rewritten_entries else None,
+        )
+        # Rows the compactor never saw keep their identity and stay behind
+        # the kept tail, exactly where they were appended.
+        rewritten_entries.extend(newer_entries)
 
         node.compaction_count = (node.compaction_count or 0) + 1
         node.updated_at = _now_ms()
@@ -1531,7 +1609,9 @@ class SessionManager:
             session_key=session_key,
             summary_len=len(summary),
             kept=len(kept_entries),
+            preserved_newer=len(newer_entries),
         )
+        return next_snapshot
 
     async def truncate(self, session_key: str, max_messages: int = 20) -> dict:
         """Truncate transcript to the most recent *max_messages* entries.

--- a/tests/test_engine/test_inline_compaction_snapshot_anchor.py
+++ b/tests/test_engine/test_inline_compaction_snapshot_anchor.py
@@ -1,0 +1,194 @@
+"""The turn runner anchors inline compaction persistence on the history it loaded.
+
+``TurnRunner._load_history`` records a ``TranscriptSnapshot`` of the last
+persisted row the agent's history covers; the compaction persist adapter
+hands it to ``SessionManager.persist_compaction_result`` and re-anchors on
+the snapshot that call returns, so a follow-up queued by ``sessions.send``
+during a long turn survives one -- or several -- inline compactions.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentos.engine import Agent, AgentConfig
+from agentos.engine.runtime import TurnRunner
+from agentos.engine.turn_runner.harness import (
+    CompactionPersistRejectedError,
+    _TurnRunnerCompactionPersistAdapter,
+)
+from agentos.session.manager import SessionManager, TranscriptSnapshot
+from agentos.session.storage import SessionStorage
+
+KEY = "agent:main:anchor"
+
+
+class _Provider:
+    provider_name = "fake"
+
+    async def chat(self, *args: Any, **kwargs: Any) -> Any:  # pragma: no cover - never called
+        raise AssertionError("provider must not be called")
+
+
+@pytest.fixture
+async def session_manager() -> AsyncIterator[SessionManager]:
+    storage = SessionStorage(":memory:")
+    await storage.connect()
+    manager = SessionManager(storage, inject_time_prefix=False)
+    yield manager
+    await storage.close()
+
+
+def _runner(session_manager: Any) -> TurnRunner:
+    return TurnRunner(provider_selector=MagicMock(), session_manager=session_manager)
+
+
+def _agent() -> Agent:
+    return Agent(provider=_Provider(), config=AgentConfig(system_prompt="base"), session_key=KEY)
+
+
+async def _seed(session_manager: SessionManager) -> None:
+    await session_manager.create(KEY)
+    await session_manager.append_message(KEY, "user", "A", token_count=1)
+    await session_manager.append_message(KEY, "assistant", "B", token_count=1)
+    await session_manager.append_message(KEY, "user", "C", token_count=1)
+
+
+@pytest.mark.asyncio
+async def test_load_history_records_the_last_loaded_row(session_manager: SessionManager) -> None:
+    await _seed(session_manager)
+    runner = _runner(session_manager)
+
+    await runner._load_history(_agent(), KEY, trim_last_user=True)
+
+    node = await session_manager.get_session(KEY)
+    rows = await session_manager.get_transcript(KEY)
+    assert node is not None
+    assert runner._compaction_snapshots[KEY] == TranscriptSnapshot(
+        session_id=node.session_id,
+        through_message_id=rows[-1].message_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_history_of_an_empty_transcript_records_an_empty_snapshot(
+    session_manager: SessionManager,
+) -> None:
+    node = await session_manager.create(KEY)
+    runner = _runner(session_manager)
+
+    await runner._load_history(_agent(), KEY, trim_last_user=True)
+
+    assert runner._compaction_snapshots[KEY] == TranscriptSnapshot(
+        session_id=node.session_id,
+        through_message_id=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_queued_follow_up_survives_repeated_inline_compactions(
+    session_manager: SessionManager,
+) -> None:
+    """End to end through the adapter: load history, queue D, compact twice."""
+    await _seed(session_manager)
+    runner = _runner(session_manager)
+    await runner._load_history(_agent(), KEY, trim_last_user=True)
+    queued = await session_manager.append_message(KEY, "user", "D", token_count=1)
+    adapter = _TurnRunnerCompactionPersistAdapter(runner)
+
+    await adapter.persist_and_notify(
+        session_key=KEY,
+        summary="summary of A",
+        kept_entries=[{"role": "assistant", "content": "B"}, {"role": "user", "content": "C"}],
+        compaction_id="cmp_1",
+    )
+    live = await session_manager.get_transcript(KEY)
+    assert [entry.content for entry in live] == ["B", "C", "D"]
+    assert live[-1].message_id == queued.message_id
+    # Re-anchored on the kept tail the first persist wrote.
+    assert runner._compaction_snapshots[KEY].through_message_id == live[1].message_id
+
+    await session_manager.append_message(KEY, "user", "E", token_count=1)
+    await adapter.persist_and_notify(
+        session_key=KEY,
+        summary="summary of A and B",
+        kept_entries=[{"role": "user", "content": "C"}],
+        compaction_id="cmp_2",
+    )
+
+    live = await session_manager.get_transcript(KEY)
+    assert [entry.content for entry in live] == ["C", "D", "E"]
+    assert live[1].message_id == queued.message_id
+    canonical = await session_manager.get_canonical_transcript(KEY)
+    assert [entry.content for entry in canonical] == ["A", "B", "C", "D", "E"]
+
+
+@pytest.mark.asyncio
+async def test_stale_snapshot_is_reported_as_a_failed_persist(
+    session_manager: SessionManager,
+) -> None:
+    """Nothing was written, so the adapter must not announce a completed persist.
+
+    The stream consumer stage turns the exception into a ``failed`` lifecycle
+    notification and skips the post-persist prompt refresh.
+    """
+    await _seed(session_manager)
+    runner = _runner(session_manager)
+    await runner._load_history(_agent(), KEY, trim_last_user=True)
+    stale = runner._compaction_snapshots[KEY]
+    await session_manager.truncate(KEY, max_messages=0)
+    await session_manager.append_message(KEY, "user", "fresh", token_count=1)
+    before = await session_manager.get_transcript(KEY)
+
+    with pytest.raises(CompactionPersistRejectedError, match="not persisted"):
+        await _TurnRunnerCompactionPersistAdapter(runner).persist_and_notify(
+            session_key=KEY,
+            summary="summary of A",
+            kept_entries=[{"role": "assistant", "content": "B"}, {"role": "user", "content": "C"}],
+        )
+
+    assert await session_manager.get_transcript(KEY) == before
+    assert await session_manager.get_summaries(KEY) == []
+    assert runner._compaction_snapshots[KEY] == stale
+
+
+@pytest.mark.asyncio
+async def test_the_anchor_is_dropped_with_the_rest_of_the_turn_state(
+    session_manager: SessionManager,
+) -> None:
+    """Keyed per session and re-recorded by every _load_history, so it must not
+    outlive the turn -- ephemeral subagent sessions would pile up otherwise."""
+    await _seed(session_manager)
+    runner = _runner(session_manager)
+    await runner._load_history(_agent(), KEY, trim_last_user=True)
+    assert KEY in runner._compaction_snapshots
+
+    runner.clear_compaction_turn_state(KEY)
+
+    assert KEY not in runner._compaction_snapshots
+
+
+@pytest.mark.asyncio
+async def test_adapter_tolerates_a_persist_method_without_snapshot_support() -> None:
+    """Older / fake session managers keep receiving the three positional args."""
+    calls: list[tuple[Any, ...]] = []
+
+    class _Legacy:
+        async def persist_compaction_result(self, session_key, summary, kept):
+            calls.append((session_key, summary, list(kept)))
+
+        async def get_transcript(self, session_key):
+            return []
+
+    runner = _runner(_Legacy())
+    runner._compaction_snapshots[KEY] = TranscriptSnapshot(session_id="s", through_message_id="m")
+
+    await _TurnRunnerCompactionPersistAdapter(runner).persist_and_notify(
+        session_key=KEY, summary="S", kept_entries=[1, 2]
+    )
+
+    assert calls == [(KEY, "S", [1, 2])]

--- a/tests/test_session/test_compaction_snapshot_anchor.py
+++ b/tests/test_session/test_compaction_snapshot_anchor.py
@@ -1,0 +1,213 @@
+"""Inline compaction must not delete messages the compactor never saw.
+
+``persist_compaction_result`` used to derive the cut point purely from
+counts -- ``len(entries) - len(kept_entries)`` against the *live* transcript.
+When ``sessions.send`` appended a follow-up between the agent loading its
+history and the ``CompactionEvent`` being persisted, that follow-up fell
+into the overwritten tail and vanished from both the live and the canonical
+transcript. The persist call now takes the ``TranscriptSnapshot`` the runner
+captured at history load, rewrites only rows inside it, re-appends everything
+newer verbatim, and rejects a snapshot the transcript has moved away from.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from agentos.session.manager import SessionManager, TranscriptSnapshot
+from agentos.session.models import SessionIntent
+from agentos.session.storage import SessionStorage
+
+KEY = "agent:main:main"
+
+
+@pytest_asyncio.fixture
+async def manager():
+    storage = SessionStorage(":memory:")
+    await storage.connect()
+    mgr = SessionManager(storage, inject_time_prefix=False)
+    yield mgr
+    await storage.close()
+
+
+async def _seed(manager: SessionManager) -> TranscriptSnapshot:
+    """A, B, C as the running agent loaded them; returns the agent's snapshot."""
+    await manager.create(KEY)
+    await manager.append_message(KEY, "user", "A", token_count=1)
+    await manager.append_message(KEY, "assistant", "B", token_count=1)
+    await manager.append_message(KEY, "user", "C", token_count=1)
+    entries = await manager.get_transcript(KEY)
+    node = await manager.get_session(KEY)
+    assert node is not None
+    return TranscriptSnapshot(session_id=node.session_id, through_message_id=entries[-1].message_id)
+
+
+def _kept(*contents: str) -> list[dict]:
+    roles = {"A": "user", "B": "assistant", "C": "user", "D": "user", "E": "user"}
+    return [{"role": roles[c], "content": c} for c in contents]
+
+
+@pytest.mark.asyncio
+async def test_follow_up_appended_after_the_snapshot_survives(manager: SessionManager) -> None:
+    """The regression from the report: A, B, C snapshotted, kept=[B, C], D queued."""
+    snapshot = await _seed(manager)
+    queued = await manager.append_message(
+        KEY,
+        "user",
+        "D",
+        token_count=7,
+        provenance={"kind": "queued_follow_up", "source_channel": "cli"},
+    )
+    queued_row = (await manager.get_transcript(KEY))[-1]
+    assert queued_row.message_id == queued.message_id
+
+    persisted = await manager.persist_compaction_result(
+        KEY, "summary of A", _kept("B", "C"), snapshot=snapshot, compaction_id="cmp_1"
+    )
+
+    live = await manager.get_transcript(KEY)
+    assert [entry.content for entry in live] == ["B", "C", "D"]
+    canonical = await manager.get_canonical_transcript(KEY)
+    assert [entry.content for entry in canonical] == ["A", "B", "C", "D"]
+
+    survivor = live[-1]
+    assert survivor.message_id == queued.message_id
+    assert survivor.token_count == 7
+    assert survivor.provenance_kind == "queued_follow_up"
+    assert survivor.provenance_source_channel == "cli"
+
+    (summary,) = await manager.get_summaries(KEY)
+    assert summary.removed_count == 1
+    assert summary.kept_count == 2
+    # Coverage stops at the last row the compactor actually saw (A here).
+    assert summary.covered_through_id == canonical[0].id
+    assert summary.covered_through_id < queued_row.id
+
+    # The returned anchor points at the last kept row, not the follow-up.
+    assert persisted is not None
+    assert persisted.session_id == snapshot.session_id
+    assert persisted.through_message_id == live[1].message_id
+
+
+@pytest.mark.asyncio
+async def test_repeated_inline_compactions_keep_queued_follow_ups(manager: SessionManager) -> None:
+    snapshot = await _seed(manager)
+    await manager.append_message(KEY, "user", "D", token_count=1)
+    snapshot = await manager.persist_compaction_result(
+        KEY, "summary of A", _kept("B", "C"), snapshot=snapshot
+    )
+    assert snapshot is not None
+    await manager.append_message(KEY, "user", "E", token_count=1)
+
+    # Second compaction in the same turn: the agent still only knows B, C.
+    second = await manager.persist_compaction_result(
+        KEY, "summary of A and B", _kept("C"), snapshot=snapshot
+    )
+
+    live = await manager.get_transcript(KEY)
+    assert [entry.content for entry in live] == ["C", "D", "E"]
+    canonical = await manager.get_canonical_transcript(KEY)
+    assert [entry.content for entry in canonical] == ["A", "B", "C", "D", "E"]
+    summaries = await manager.get_summaries(KEY)
+    assert [s.removed_count for s in summaries] == [1, 1]
+    assert second is not None
+    assert second.through_message_id == live[0].message_id
+
+
+@pytest.mark.asyncio
+async def test_full_compaction_leaves_an_empty_snapshot_that_still_protects_follow_ups(
+    manager: SessionManager,
+) -> None:
+    snapshot = await _seed(manager)
+    await manager.append_message(KEY, "user", "D", token_count=1)
+
+    emptied = await manager.persist_compaction_result(
+        KEY, "summary of everything", [], snapshot=snapshot
+    )
+    assert emptied is not None
+    assert emptied.through_message_id is None
+    assert [entry.content for entry in await manager.get_transcript(KEY)] == ["D"]
+
+    # Later in the same turn the agent compacts again; the rows it holds are
+    # all in-memory, so nothing in the transcript belongs to its snapshot.
+    await manager.append_message(KEY, "user", "E", token_count=1)
+    await manager.persist_compaction_result(
+        KEY,
+        "summary again",
+        [{"role": "assistant", "content": "in-memory reply"}],
+        snapshot=emptied,
+    )
+
+    assert [entry.content for entry in await manager.get_transcript(KEY)] == [
+        "in-memory reply",
+        "D",
+        "E",
+    ]
+    canonical = await manager.get_canonical_transcript(KEY)
+    assert [entry.content for entry in canonical] == ["A", "B", "C", "in-memory reply", "D", "E"]
+
+
+@pytest.mark.asyncio
+async def test_stale_result_after_same_key_reset_is_not_persisted(manager: SessionManager) -> None:
+    snapshot = await _seed(manager)
+    await manager.apply_intent(KEY, SessionIntent.RESET_SAME_KEY)
+    await manager.append_message(KEY, "user", "fresh start", token_count=1)
+    before = await manager.get_transcript(KEY)
+
+    result = await manager.persist_compaction_result(
+        KEY, "summary of A", _kept("B", "C"), snapshot=snapshot
+    )
+
+    assert result is None
+    assert await manager.get_transcript(KEY) == before
+    assert await manager.get_summaries(KEY) == []
+
+
+@pytest.mark.asyncio
+async def test_stale_result_after_the_anchor_row_disappeared_is_not_persisted(
+    manager: SessionManager,
+) -> None:
+    snapshot = await _seed(manager)
+    await manager.truncate(KEY, max_messages=0)
+    await manager.append_message(KEY, "user", "D", token_count=1)
+    before = await manager.get_transcript(KEY)
+
+    result = await manager.persist_compaction_result(
+        KEY, "summary of A", _kept("B", "C"), snapshot=snapshot
+    )
+
+    assert result is None
+    assert await manager.get_transcript(KEY) == before
+    assert await manager.get_summaries(KEY) == []
+
+
+@pytest.mark.asyncio
+async def test_empty_summary_with_removed_rows_keeps_the_snapshot_valid(
+    manager: SessionManager,
+) -> None:
+    snapshot = await _seed(manager)
+
+    result = await manager.persist_compaction_result(KEY, "", _kept("B", "C"), snapshot=snapshot)
+
+    # Nothing was persisted, so the caller keeps anchoring on the old snapshot.
+    assert result is None
+    assert [entry.content for entry in await manager.get_transcript(KEY)] == ["A", "B", "C"]
+
+
+@pytest.mark.asyncio
+async def test_without_a_snapshot_the_legacy_tail_arithmetic_is_unchanged(
+    manager: SessionManager,
+) -> None:
+    await _seed(manager)
+
+    result = await manager.persist_compaction_result(KEY, "summary of A", _kept("B", "C"))
+
+    assert [entry.content for entry in await manager.get_transcript(KEY)] == ["B", "C"]
+    assert [entry.content for entry in await manager.get_canonical_transcript(KEY)] == [
+        "A",
+        "B",
+        "C",
+    ]
+    assert result is not None
+    assert result.through_message_id == (await manager.get_transcript(KEY))[-1].message_id


### PR DESCRIPTION
Fixes #1645

## Problem

`persist_compaction_result` re-read the live transcript and derived the cut point purely from counts:

```python
removed_entries = entries[: max(0, len(entries) - len(kept_entries))]
preserved_entries = entries[len(removed_entries) :]
```

With `[A, B, C]` snapshotted, `kept=[B, C]` and `D` appended by `sessions.send` before the persist, the live transcript is `[A, B, C, D]`, so `removed=[A, B]` and the tail `[C, D]` is overwritten by the stale kept tail — `D` is neither kept nor archived, and its `message_id` is gone. The per-session write lock serialises the writes but says nothing about which rows the compactor actually saw.

## Fix

Anchor the persist on the rows the agent's history was built from, instead of on the live tail.

- **`TranscriptSnapshot`** (`session/manager.py`): frozen `(session_id, through_message_id)`. `through_message_id` is the last persisted row the agent loaded; `None` means the agent holds no persisted rows (e.g. right after a full compaction). `message_id` is used rather than the row id because a compaction rewrite re-inserts rows and renumbers them.
- **`TurnRunner._load_history`** records the snapshot for the session key right after reading the transcript (the input row is already persisted at that point, so it is inside the snapshot; `sessions.send` appends land after it). It is dropped with the rest of the per-turn compaction state in `clear_compaction_turn_state`.
- **`persist_compaction_result(..., snapshot=)`** splits the transcript at the anchor. Only rows inside the snapshot are subject to the kept/removed arithmetic and archived under the summary; rows after it are re-appended verbatim (same `message_id`, content, provenance, `token_count`, order). Minted kept rows have their `created_at` clamped so they never sort behind an earlier follow-up. `covered_through_id` is computed from the archived (snapshot) rows only. The call returns the snapshot to anchor the next compaction on (the kept tail it just wrote), or `None` when nothing was persisted. Without a `snapshot` argument the previous behaviour is unchanged.
- **Stale results are rejected**: a snapshot whose `session_id` differs (same-key reset) or whose anchor row is gone (truncate, manual compaction) logs `persist_compaction.stale_snapshot_not_persisted` and writes nothing.
- **`_TurnRunnerCompactionPersistAdapter`** passes the snapshot when the manager accepts it (same signature introspection already used for `compaction_id` / `trigger_reason`, so fakes with the three-positional signature keep working), re-anchors on the returned snapshot, and raises `CompactionPersistRejectedError` when a snapshot-aware manager returns `None` so the stream consumer stage takes its failed-persist path instead of announcing a completed compaction that never reached the transcript.

## Acceptance criteria from the report

- Only messages represented by the agent's compaction snapshot are replaced or archived — split at the anchor.
- Newer follow-ups keep `message_id`, content, metadata and order — re-appended verbatim; asserted on provenance and `token_count`.
- Summary coverage never includes messages the compactor never saw — `covered_through_id` from archived rows only; asserted `< D.id`.
- Repeated inline compactions remain safe with queued follow-ups — the returned snapshot re-anchors on the kept tail; asserted through the real adapter twice in one turn.
- A changed/reset transcript is not overwritten by a stale result — reset and truncate cases both skip and are reported as failed persists.
- Public offline regression tests — below, all fail on `main`.

## Tests

- `tests/test_session/test_compaction_snapshot_anchor.py` (new, in-memory `SessionStorage`): the reported repro (A, B, C / kept B, C / D queued); repeated compactions; full compaction leaving an empty snapshot that still protects follow-ups; stale after same-key reset; stale after the anchor row disappeared; empty summary keeps the old anchor valid; legacy no-snapshot path unchanged.
- `tests/test_engine/test_inline_compaction_snapshot_anchor.py` (new): `_load_history` records the anchor (non-empty and empty transcript); queued follow-up survives two inline compactions end to end through the adapter; stale snapshot raises `CompactionPersistRejectedError` and leaves transcript and anchor untouched; the anchor is dropped with the turn state; a legacy manager without `snapshot` support still gets the three positional args.
- Existing `tests/test_session`, `tests/test_engine/turn_runner`, `test_prompt_cache_stability`, `test_preflight_compaction`, `test_t3_upgrade_compaction` all pass unchanged.

## Gate

- `uv run ruff check src tests` — clean
- `uv run mypy src/agentos` — clean (625 files, on the merged batch tree)
- Full suite on the merged batch tree — see batch note below

## Merge safety

Part of a batch of five fix PRs (#1625, #1645, #1653, #1673, #1674). Each touches a disjoint set of files, and all 120 merge orderings were checked for conflicts on a scratch worktree off `upstream/main` (0 conflicts), so they can be merged one by one in any order. The `CHANGELOG.md` entry is deliberately not in this PR — `[Unreleased] / ### Fixed` has a single bullet, so five PRs inserting there would conflict in every order; the batch entry is in a separate `docs(changelog)` PR that only touches that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dPxJwmC1LQnzwN83SpH2G
