### PR TITLE
fix(skills): walk table cells in docx replace_text and skip non-dict ops

### DIFF
--- a/src/agentos/skills/bundled/docx/SKILL.md
+++ b/src/agentos/skills/bundled/docx/SKILL.md
@@ -96,6 +96,9 @@ python {baseDir}/scripts/edit_docx.py input.docx ops.json --out output.docx
 ]
 ```
 
+`replace_text` walks body paragraphs and every table cell (nested tables
+included), so placeholders inside contract or invoice tables are found too.
+
 Edit at the **run** level, not the paragraph level — replacing whole paragraph
 text drops formatting. If a placeholder spans multiple runs (often happens
 when the original template applied bold/italic mid-word), the helper script

--- a/src/agentos/skills/bundled/docx/scripts/edit_docx.py
+++ b/src/agentos/skills/bundled/docx/scripts/edit_docx.py
@@ -4,8 +4,9 @@ Operations:
     {"op": "replace_run", "para": <int>, "run": <int>, "text": "..."}
     {"op": "replace_text", "find": "...", "with": "..."}
 
-`replace_text` walks every paragraph and matches against the joined run texts,
-so a target that spans runs is still found. The replacement is written into the
+`replace_text` walks every paragraph -- body paragraphs and the cells of every
+table, nested tables included -- and matches against the joined run texts, so a
+target that spans runs is still found. The replacement is written into the
 run that owns the first character of its match, and every character the match
 did not touch stays in the run it came from — a run is where Word keeps
 character formatting, so moving text between runs would silently restyle it.
@@ -18,10 +19,12 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from collections.abc import Iterable, Iterator
 from pathlib import Path
 from typing import Any
 
 from docx import Document
+from docx.table import Table, _Cell
 from docx.text.paragraph import Paragraph
 
 
@@ -75,9 +78,38 @@ def _replace_text_in_paragraph(para: Paragraph, find: str, replacement: str) -> 
     return True
 
 
+def _iter_table_paragraphs(tables: Iterable[Table]) -> Iterator[Paragraph]:
+    """Yield the paragraphs of every cell in *tables*, recursing into nested tables.
+
+    Cells are taken straight from the ``<w:tc>`` elements rather than through
+    ``row.cells``: that API repeats a merged cell once per grid column it spans
+    (so a replacement would hit the same text several times) and resolves
+    vertically merged cells against the row above, which raises ``ValueError``
+    on the irregular grids other generators produce. Each ``<w:tc>`` is visited
+    exactly once either way.
+    """
+    for table in tables:
+        for tc in table._tbl.iter_tcs():
+            cell = _Cell(tc, table)
+            yield from cell.paragraphs
+            yield from _iter_table_paragraphs(cell.tables)
+
+
+def _iter_all_paragraphs(doc: Document) -> Iterator[Paragraph]:
+    """Body paragraphs followed by every table-cell paragraph in the document.
+
+    ``doc.paragraphs`` is body-only in python-docx, yet contracts, reports and
+    invoices keep most of their placeholders inside tables.
+    """
+    yield from doc.paragraphs
+    yield from _iter_table_paragraphs(doc.tables)
+
+
 def apply_ops(doc: Document, ops: list[dict[str, Any]]) -> int:
     applied = 0
     for op in ops:
+        if not isinstance(op, dict):
+            continue
         kind = op.get("op")
         if kind == "replace_run":
             try:
@@ -91,7 +123,7 @@ def apply_ops(doc: Document, ops: list[dict[str, Any]]) -> int:
             replacement = str(op.get("with", ""))
             if not find:
                 continue
-            for para in doc.paragraphs:
+            for para in _iter_all_paragraphs(doc):
                 if _replace_text_in_paragraph(para, find, replacement):
                     applied += 1
     return applied

--- a/tests/test_skill_docx.py
+++ b/tests/test_skill_docx.py
@@ -257,3 +257,124 @@ def test_replace_run_still_touches_only_its_own_run() -> None:
     edit_docx._replace_run(paragraph, 1, "there")
 
     assert [(run.text, run.bold) for run in paragraph.runs] == [("Hello ", None), ("there", True)]
+
+
+def test_replace_text_reaches_table_cells(tmp_path: Path) -> None:
+    """Placeholders in contracts and invoices usually live inside tables.
+
+    `apply_ops` only walked `doc.paragraphs`, which python-docx limits to the
+    body, so a `{{CLIENT}}` in a table cell was never replaced and the op
+    reported zero applications.
+    """
+    from docx import Document
+
+    edit_docx = _edit_docx_module()
+    doc = Document()
+    doc.add_paragraph("Agreement Header")
+    table = doc.add_table(rows=2, cols=2)
+    table.cell(0, 0).text = "Client:"
+    table.cell(0, 1).text = "{{CLIENT}}"
+
+    applied = edit_docx.apply_ops(
+        doc, [{"op": "replace_text", "find": "{{CLIENT}}", "with": "Acme Corp"}]
+    )
+
+    assert applied == 1
+    assert table.cell(0, 1).text == "Acme Corp"
+    assert table.cell(0, 0).text == "Client:"
+
+
+def test_replace_text_counts_body_and_table_paragraphs_together() -> None:
+    from docx import Document
+
+    edit_docx = _edit_docx_module()
+    doc = Document()
+    doc.add_paragraph("Dear {{NAME}},")
+    doc.add_table(rows=1, cols=1).cell(0, 0).text = "Signed: {{NAME}}"
+
+    applied = edit_docx.apply_ops(doc, [{"op": "replace_text", "find": "{{NAME}}", "with": "Wei"}])
+
+    assert applied == 2
+    assert doc.paragraphs[0].text == "Dear Wei,"
+    assert doc.tables[0].cell(0, 0).text == "Signed: Wei"
+
+
+def test_replace_text_reaches_nested_tables() -> None:
+    from docx import Document
+
+    edit_docx = _edit_docx_module()
+    doc = Document()
+    outer = doc.add_table(rows=1, cols=1)
+    inner = outer.cell(0, 0).add_table(rows=1, cols=1)
+    inner.cell(0, 0).text = "Total: {{TOTAL}}"
+
+    applied = edit_docx.apply_ops(
+        doc, [{"op": "replace_text", "find": "{{TOTAL}}", "with": "42.00"}]
+    )
+
+    assert applied == 1
+    assert inner.cell(0, 0).text == "Total: 42.00"
+
+
+def test_replace_text_visits_a_merged_cell_once() -> None:
+    """`row.cells` repeats a merged cell for every grid column it spans.
+
+    Walking it once per column would apply the replacement again to text the
+    first pass already rewrote; a replacement containing its own needle makes
+    that visible.
+    """
+    from docx import Document
+
+    edit_docx = _edit_docx_module()
+    doc = Document()
+    table = doc.add_table(rows=1, cols=3)
+    merged = table.cell(0, 0).merge(table.cell(0, 2))
+    merged.text = "{{X}}"
+
+    applied = edit_docx.apply_ops(doc, [{"op": "replace_text", "find": "{{X}}", "with": "{{X}}!"}])
+
+    assert applied == 1
+    assert merged.text == "{{X}}!"
+
+
+def test_replace_text_survives_an_irregular_vertical_merge() -> None:
+    """`row.cells` resolves a `vMerge=continue` cell against the row above and
+    raises `ValueError` when no cell starts at that grid offset there -- a
+    layout non-Word generators produce. Walking the `<w:tc>` elements directly
+    never enters that path, so the whole edit (body included) still lands."""
+    from docx import Document
+    from docx.oxml import OxmlElement
+    from docx.oxml.ns import qn
+
+    edit_docx = _edit_docx_module()
+    doc = Document()
+    doc.add_paragraph("Header {{X}}")
+    table = doc.add_table(rows=2, cols=2)
+    table.cell(0, 0).merge(table.cell(0, 1))
+    table.cell(1, 0).text = "Cell {{X}}"
+    continue_marker = OxmlElement("w:vMerge")
+    continue_marker.set(qn("w:val"), "continue")
+    table.cell(1, 1)._tc.get_or_add_tcPr().append(continue_marker)
+
+    applied = edit_docx.apply_ops(doc, [{"op": "replace_text", "find": "{{X}}", "with": "Y"}])
+
+    assert applied == 2
+    assert doc.paragraphs[0].text == "Header Y"
+    assert table.cell(1, 0).text == "Cell Y"
+
+
+def test_apply_ops_skips_non_dict_ops() -> None:
+    """Malformed op lists are ignored, as `edit_xlsx.apply_ops` already does."""
+    from docx import Document
+
+    edit_docx = _edit_docx_module()
+    doc = Document()
+    doc.add_paragraph("Hello {{NAME}}")
+
+    applied = edit_docx.apply_ops(
+        doc,
+        [None, "replace_text", 3, {"op": "replace_text", "find": "{{NAME}}", "with": "Wei"}],
+    )
+
+    assert applied == 1
+    assert doc.paragraphs[0].text == "Hello Wei"


### PR DESCRIPTION
Fixes #1653

## Problem

`apply_ops` in `docx/scripts/edit_docx.py` iterated `doc.paragraphs` only, which python-docx limits to the body, so a placeholder inside a table — where contract, report and invoice fields usually live — was never replaced and the op reported `applied == 0`. A non-dict entry in the ops list crashed at `op.get("op")` with `AttributeError`, where `edit_xlsx.apply_ops` already guards.

## Fix

- `_iter_all_paragraphs(doc)` yields body paragraphs and then every table-cell paragraph, recursing into nested tables. Cells are taken straight from the `<w:tc>` elements (`table._tbl.iter_tcs()`) rather than through `row.cells`: that API repeats a merged cell once per grid column it spans (a replacement would hit the same text several times) and resolves vertically merged cells against the row above, which raises `ValueError` on the irregular grids other generators produce. Each `<w:tc>` is visited exactly once either way.
- `apply_ops` skips non-dict ops.
- The run-preserving `_replace_text_in_paragraph` is untouched; `replace_run` / `inspect_docx` paragraph indices stay body-only and consistent with each other.
- SKILL.md notes that `replace_text` covers table cells.

## Tests

Added to `tests/test_skill_docx.py` (all fail on `main`):
- the repro from the report (`{{CLIENT}}` in a table cell → `applied == 1`, cell updated)
- body + table occurrences are counted together
- nested table
- a merged cell is visited once (replacement containing its own needle would otherwise be applied twice)
- an irregular `vMerge=continue` layout does not abort the edit
- non-dict ops are skipped

## Gate

- `uv run ruff check src tests` — clean (bundled scripts are excluded from mypy by `pyproject.toml`)
- `tests/test_skill_docx.py` — 25 passed

## Merge safety

Part of a batch of five fix PRs (#1625, #1645, #1653, #1673, #1674). Each touches a disjoint set of files, and all 120 merge orderings were checked for conflicts on a scratch worktree off `upstream/main` (0 conflicts), so they can be merged one by one in any order. The `CHANGELOG.md` entry is deliberately not in this PR — `[Unreleased] / ### Fixed` has a single bullet, so five PRs inserting there would conflict in every order; the batch entry is in a separate `docs(changelog)` PR that only touches that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dPxJwmC1LQnzwN83SpH2G
