### PR TITLE
fix(skills): apply the pdf-toolkit table strategy to both axes

### DIFF
--- a/src/agentos/skills/bundled/pdf-toolkit/SKILL.md
+++ b/src/agentos/skills/bundled/pdf-toolkit/SKILL.md
@@ -75,8 +75,10 @@ Output:
 
 Text uses `pdfplumber` (already in default dependencies) which preserves
 column layout better than naive PDF text extraction. Tables use
-`pdfplumber.extract_tables()` with default settings; for tricky layouts
-pass `--tables-strategy lines|text|explicit` to switch detection mode.
+`pdfplumber.extract_tables()` with the `lines` strategy (ruling lines on both
+axes); for borderless tables pass `--tables-strategy text` to detect rows and
+columns from word positions instead. pdfplumber's `explicit` mode is not
+offered because it needs line coordinates this script cannot supply.
 
 For OCR (scanned PDFs), this skill does not include Tesseract — use the
 sibling skill that wraps an OCR engine (out of scope here).

--- a/src/agentos/skills/bundled/pdf-toolkit/scripts/extract.py
+++ b/src/agentos/skills/bundled/pdf-toolkit/scripts/extract.py
@@ -11,6 +11,27 @@ from typing import Any
 import pdfplumber
 from pypdf import PdfReader
 
+# pdfplumber's third mode, ``explicit``, needs ``explicit_vertical_lines`` /
+# ``explicit_horizontal_lines`` that this script has no way to supply, so it
+# crashed inside pdfplumber on every call. It is deliberately not offered.
+TABLE_STRATEGIES = ("lines", "text")
+
+
+def _table_settings(tables_strategy: str | None) -> dict[str, str]:
+    """pdfplumber table settings for *tables_strategy* (default ``lines``).
+
+    The strategy applies to both axes: setting only ``vertical_strategy`` left
+    the horizontal axis on ``lines``, so ``text`` never found a row in the
+    borderless tables it exists for.
+    """
+    strategy = tables_strategy or "lines"
+    if strategy not in TABLE_STRATEGIES:
+        raise ValueError(
+            f"unsupported --tables-strategy {strategy!r}; "
+            f"choose one of: {', '.join(TABLE_STRATEGIES)}"
+        )
+    return {"vertical_strategy": strategy, "horizontal_strategy": strategy}
+
 
 def extract(path: Path, tables_strategy: str | None) -> dict[str, Any]:
     reader = PdfReader(str(path))
@@ -21,7 +42,7 @@ def extract(path: Path, tables_strategy: str | None) -> dict[str, Any]:
 
     pages_text: list[dict[str, Any]] = []
     tables: list[dict[str, Any]] = []
-    table_settings = {"vertical_strategy": tables_strategy or "lines"}
+    table_settings = _table_settings(tables_strategy)
     with pdfplumber.open(str(path)) as pdf:
         for idx, page in enumerate(pdf.pages, start=1):
             content = page.extract_text() or ""
@@ -42,9 +63,9 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("path", type=Path)
     parser.add_argument(
         "--tables-strategy",
-        choices=("lines", "text", "explicit"),
+        choices=TABLE_STRATEGIES,
         default=None,
-        help="pdfplumber table-detection strategy",
+        help="pdfplumber table-detection strategy for both axes (default: lines)",
     )
     parser.add_argument("--out", type=Path, default=None)
     parser.add_argument("--json", action="store_true", help="Force JSON output (default)")

--- a/tests/test_skill_pdf_toolkit.py
+++ b/tests/test_skill_pdf_toolkit.py
@@ -127,3 +127,75 @@ def test_extract_creates_parent_directory(tmp_path: Path, monkeypatch: pytest.Mo
     )
     assert extract.main() == 0
     assert out_file.is_file()
+
+
+def _extract_module():
+    sys.path.insert(0, str(SCRIPTS))
+    try:
+        import extract  # type: ignore[import-not-found]
+    finally:
+        sys.path.pop(0)
+    return extract
+
+
+def _make_borderless_table_pdf(path: Path) -> None:
+    """A platypus table with no ruling lines -- the layout `text` mode exists for."""
+    from reportlab.lib.pagesizes import LETTER
+    from reportlab.platypus import SimpleDocTemplate, Table
+
+    doc = SimpleDocTemplate(str(path), pagesize=LETTER)
+    # Four rows: pdfplumber's `text` mode needs ``min_words_vertical`` (default
+    # 3) aligned words to accept a column edge, so stay clear of that threshold.
+    doc.build([Table([["Name", "Qty"], ["Widget", "3"], ["Gadget", "7"], ["Gizmo", "9"]])])
+
+
+def test_tables_strategy_text_detects_a_borderless_table(tmp_path: Path) -> None:
+    """`--tables-strategy text` must switch both axes.
+
+    Only `vertical_strategy` used to be set, so the horizontal axis kept
+    looking for ruling lines a borderless table does not have and the flag's
+    one documented use case returned no tables at all.
+    """
+    extract = _extract_module()
+    pdf_file = tmp_path / "borderless.pdf"
+    _make_borderless_table_pdf(pdf_file)
+
+    payload = extract.extract(pdf_file, tables_strategy="text")
+
+    cells = {cell for table in payload["tables"] for row in table["rows"] for cell in row if cell}
+    assert {"Name", "Qty", "Widget", "3", "Gadget", "7", "Gizmo", "9"} <= cells
+
+
+def test_tables_strategy_lines_still_the_default(tmp_path: Path) -> None:
+    extract = _extract_module()
+    pdf_file = tmp_path / "borderless.pdf"
+    _make_borderless_table_pdf(pdf_file)
+
+    assert extract._table_settings(None) == {
+        "vertical_strategy": "lines",
+        "horizontal_strategy": "lines",
+    }
+    # A borderless table has no ruling lines, so the default finds nothing.
+    assert extract.extract(pdf_file, tables_strategy=None)["tables"] == []
+
+
+def test_tables_strategy_explicit_is_rejected_with_a_clear_message(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """pdfplumber's `explicit` mode needs line lists this script cannot supply.
+
+    It used to be advertised in `choices` and then crash inside pdfplumber
+    with `TypeError: object of type 'NoneType' has no len()` on every call.
+    """
+    extract = _extract_module()
+    pdf_file = tmp_path / "doc.pdf"
+    _make_one_page_pdf(pdf_file, "TEST")
+
+    with pytest.raises(ValueError, match="explicit"):
+        extract.extract(pdf_file, tables_strategy="explicit")
+
+    monkeypatch.setattr(sys, "argv", ["extract.py", str(pdf_file), "--tables-strategy", "explicit"])
+    with pytest.raises(SystemExit) as exc_info:
+        extract.main()
+    assert exc_info.value.code == 2
+    assert "invalid choice: 'explicit'" in capsys.readouterr().err


### PR DESCRIPTION
Fixes #1673

## Problem

`pdf-toolkit/scripts/extract.py` built `{"vertical_strategy": tables_strategy or "lines"}` and never set `horizontal_strategy`, so `--tables-strategy text` kept looking for ruling lines on the horizontal axis and returned `"tables": []` on the borderless tables the flag is documented for. `explicit` — advertised in `choices` and SKILL.md — needs `explicit_vertical_lines` / `explicit_horizontal_lines` the script has no way to supply, so every invocation died inside pdfplumber with `TypeError: object of type 'NoneType' has no len()`.

## Fix

Per the triage scope (both axes; drop or fail clearly on `explicit`; no new flags):

- `_table_settings(strategy)` returns `{"vertical_strategy": s, "horizontal_strategy": s}`; the default is still `lines` on both axes, i.e. pdfplumber's default, so `extract(path, None)` behaves exactly as before.
- `explicit` is removed from the argparse `choices` (argparse rejects it with the usual `invalid choice` message and exit 2) and `extract()` raises a clear `ValueError` for programmatic callers.
- SKILL.md now describes `lines` vs `text` and says why `explicit` is not offered.

## Tests

Added to `tests/test_skill_pdf_toolkit.py` (fail on `main`):
- a borderless reportlab platypus table (four rows, clear of pdfplumber's `min_words_vertical=3` threshold) is detected with `--tables-strategy text`
- the default is `lines` on both axes and still finds nothing in that table
- `explicit` is rejected by `extract()` (`ValueError`) and by the CLI (exit 2, `invalid choice: 'explicit'`)

## Gate

- `uv run ruff check src tests` — clean (bundled scripts are excluded from mypy by `pyproject.toml`)
- `tests/test_skill_pdf_toolkit.py`, `tests/test_skills_default_prompt_contract.py` — pass

## Merge safety

Part of a batch of five fix PRs (#1625, #1645, #1653, #1673, #1674). Each touches a disjoint set of files, and all 120 merge orderings were checked for conflicts on a scratch worktree off `upstream/main` (0 conflicts), so they can be merged one by one in any order. The `CHANGELOG.md` entry is deliberately not in this PR — `[Unreleased] / ### Fixed` has a single bullet, so five PRs inserting there would conflict in every order; the batch entry is in a separate `docs(changelog)` PR that only touches that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dPxJwmC1LQnzwN83SpH2G
