### PR TITLE
fix(skills): commit only the reported ids in cron watcher watermarks

### DIFF
--- a/src/agentos/skills/bundled/cron-watchers/SKILL.md
+++ b/src/agentos/skills/bundled/cron-watchers/SKILL.md
@@ -34,8 +34,10 @@ which is exactly the contract a cron `script` job wants.
 | `watch_github.py` | A repo's issues, pulls, or releases | `--repo`, `--scope`, `--name` |
 
 All three also take `--limit` (max lines per run, default 10) and
-`--first-run-reports` (report everything on the first run instead of starting
-quiet).
+`--first-run-reports` (report on the first run instead of starting quiet).
+When more than `--limit` items are new, the run reports the oldest of them and
+leaves the rest for the following runs; only what was reported is marked seen.
+An item is lost only if it drops off the feed's page before its turn comes.
 
 `--url` must be `http://` or `https://`. Any other scheme is refused with exit
 code 1 — `urlopen` speaks `file:`, `ftp:` and `data:` too, and a watcher

--- a/src/agentos/skills/bundled/cron-watchers/scripts/_watermark.py
+++ b/src/agentos/skills/bundled/cron-watchers/scripts/_watermark.py
@@ -9,11 +9,23 @@ script, so the scripts directory stays read-only in practice.
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
 from pathlib import Path
 
 MAX_REMEMBERED_IDS = 500
+
+
+def positive_int(raw: str) -> int:
+    """argparse type for ``--limit``: a cap of 0 or less would stall the watermark."""
+    try:
+        value = int(raw)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"expected an integer, got {raw!r}") from None
+    if value < 1:
+        raise argparse.ArgumentTypeError(f"must be at least 1, got {value}")
+    return value
 
 
 def _state_root() -> Path:
@@ -53,17 +65,37 @@ def save_seen(name: str, ids: list[str]) -> None:
     tmp.replace(path)
 
 
-def select_new(name: str, ids: list[str], *, first_run_reports: bool = False) -> list[str]:
-    """Return the ids not seen before and record them.
+def select_new(
+    name: str,
+    ids: list[str],
+    *,
+    first_run_reports: bool = False,
+    limit: int | None = None,
+) -> list[str]:
+    """Return the ids to report this run and record only those as seen.
+
+    ``limit`` caps how much one run reports, not how much the feed may
+    publish: the surplus is left out of the watermark so the next run picks it
+    up. Committing every fresh id while printing only the first ``limit`` lost
+    the rest for good, silently, on exactly the busy feeds a watcher is for.
+    Feeds list newest first, so the capped run takes the *tail* of the fresh
+    ids: the backlog drains oldest first, in feed order, and what is deferred
+    is the newest, which stays on the page longest. An id that leaves the page
+    before its turn comes is still never reported -- the page is the only
+    memory the watcher has of it.
 
     The first run reports nothing by default: a watcher that has never run has
     no idea which of the 50 items on the page are actually new, and dumping all
-    of them into a chat is the wrong first impression.
+    of them into a chat is the wrong first impression. That silent run adopts
+    the whole feed, so no backlog is left behind.
     """
-    seen = set(load_seen(name))
+    seen = load_seen(name)
+    known = set(seen)
     is_first_run = not seen
-    fresh = [item for item in ids if item not in seen]
-    save_seen(name, [*load_seen(name), *fresh])
+    fresh = [item for item in ids if item not in known]
     if is_first_run and not first_run_reports:
+        save_seen(name, [*seen, *fresh])
         return []
-    return fresh
+    reported = fresh if limit is None else fresh[-limit:]
+    save_seen(name, [*seen, *reported])
+    return reported

--- a/src/agentos/skills/bundled/cron-watchers/scripts/watch_github.py
+++ b/src/agentos/skills/bundled/cron-watchers/scripts/watch_github.py
@@ -26,7 +26,7 @@ from typing import Any
 
 sys.path.insert(0, str(Path(__file__).parent))
 
-from _watermark import select_new  # noqa: E402
+from _watermark import positive_int, select_new  # noqa: E402
 
 API_ROOT = "https://api.github.com"
 USER_AGENT = "AgentOS-cron-watcher/1.0"
@@ -66,7 +66,9 @@ def main() -> int:
     parser.add_argument("--repo", required=True, help="owner/name")
     parser.add_argument("--scope", default="issues", choices=SCOPES, help="What to watch")
     parser.add_argument("--name", default="", help="Watermark name (default: repo+scope)")
-    parser.add_argument("--limit", type=int, default=10, help="Max items to report")
+    parser.add_argument(
+        "--limit", type=positive_int, default=10, help="Max items to report per run"
+    )
     parser.add_argument(
         "--first-run-reports",
         action="store_true",
@@ -110,11 +112,13 @@ def main() -> int:
         if identifier:
             lines[identifier] = line
 
-    fresh = select_new(watermark, list(lines), first_run_reports=args.first_run_reports)
+    fresh = select_new(
+        watermark, list(lines), first_run_reports=args.first_run_reports, limit=args.limit
+    )
     if not fresh:
         return 0
 
-    for identifier in fresh[: args.limit]:
+    for identifier in fresh:
         print(lines[identifier])
     return 0
 

--- a/src/agentos/skills/bundled/cron-watchers/scripts/watch_http_json.py
+++ b/src/agentos/skills/bundled/cron-watchers/scripts/watch_http_json.py
@@ -27,7 +27,7 @@ from typing import Any
 sys.path.insert(0, str(Path(__file__).parent))
 
 from _url import require_http_url  # noqa: E402
-from _watermark import select_new  # noqa: E402
+from _watermark import positive_int, select_new  # noqa: E402
 
 USER_AGENT = "AgentOS-cron-watcher/1.0"
 
@@ -71,7 +71,9 @@ def main() -> int:
         default=[],
         help="Extra request header as 'Key: value'. Repeatable.",
     )
-    parser.add_argument("--limit", type=int, default=10, help="Max items to report")
+    parser.add_argument(
+        "--limit", type=positive_int, default=10, help="Max items to report per run"
+    )
     parser.add_argument(
         "--first-run-reports",
         action="store_true",
@@ -117,11 +119,13 @@ def main() -> int:
             continue
         by_id[str(identifier)] = item
 
-    fresh = select_new(args.name, list(by_id), first_run_reports=args.first_run_reports)
+    fresh = select_new(
+        args.name, list(by_id), first_run_reports=args.first_run_reports, limit=args.limit
+    )
     if not fresh:
         return 0
 
-    for identifier in fresh[: args.limit]:
+    for identifier in fresh:
         print(f"- {_summarize(by_id[identifier], args.field)}")
     return 0
 

--- a/src/agentos/skills/bundled/cron-watchers/scripts/watch_rss.py
+++ b/src/agentos/skills/bundled/cron-watchers/scripts/watch_rss.py
@@ -23,7 +23,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))
 
 from _url import require_http_url  # noqa: E402
-from _watermark import select_new  # noqa: E402
+from _watermark import positive_int, select_new  # noqa: E402
 
 USER_AGENT = "AgentOS-cron-watcher/1.0"
 
@@ -62,7 +62,9 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--url", required=True, help="Feed URL")
     parser.add_argument("--name", required=True, help="Watermark name, unique per feed")
-    parser.add_argument("--limit", type=int, default=10, help="Max entries to report")
+    parser.add_argument(
+        "--limit", type=positive_int, default=10, help="Max entries to report per run"
+    )
     parser.add_argument(
         "--first-run-reports",
         action="store_true",
@@ -94,11 +96,13 @@ def main() -> int:
 
     entries = _entries(root)
     by_id = {entry[0]: entry for entry in entries}
-    fresh = select_new(args.name, list(by_id), first_run_reports=args.first_run_reports)
+    fresh = select_new(
+        args.name, list(by_id), first_run_reports=args.first_run_reports, limit=args.limit
+    )
     if not fresh:
         return 0
 
-    for guid in fresh[: args.limit]:
+    for guid in fresh:
         _, title, link = by_id[guid]
         print(f"- {title or guid}" + (f"\n  {link}" if link else ""))
     return 0

--- a/tests/test_skills/test_cron_watchers.py
+++ b/tests/test_skills/test_cron_watchers.py
@@ -302,3 +302,110 @@ def test_github_rejects_an_unknown_scope(state_dir):
     result = _run("watch_github.py", "--repo", "o/n", "--scope", "stars", env_home=state_dir)
 
     assert result.returncode == 2  # argparse rejects the choice
+
+
+# ── --limit must not consume the backlog (Issue #1674) ──────────────────────
+
+
+def _watermark_module():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("_watermark", SCRIPTS / "_watermark.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_select_new_commits_only_the_ids_it_reports(state_dir):
+    """`select_new` used to mark every fresh id seen while the watcher printed
+    only the first ``--limit`` of them, so a busy feed lost the surplus for
+    good. The limit caps one run's report; the rest comes back next run.
+
+    Feeds list newest first, so ``ids`` here is newest first too and a capped
+    run drains from the old end: the deferred ids are the newest, which stay on
+    the page longest."""
+    watermark = _watermark_module()
+    ids = [f"item-{i:02d}" for i in range(25, 0, -1)]  # item-25 (newest) .. item-01
+    oldest_five = ids[-5:]
+
+    assert watermark.select_new("demo", oldest_five, limit=10) == []  # first run adopts silently
+    second = watermark.select_new("demo", ids, limit=10)
+    third = watermark.select_new("demo", ids, limit=10)
+    fourth = watermark.select_new("demo", ids, limit=10)
+
+    assert second == ids[10:20]  # item-15 .. item-06: the oldest unseen ten
+    assert third == ids[0:10]  # item-25 .. item-16
+    assert fourth == []
+    assert watermark.load_seen("demo") == [*oldest_five, *ids[10:20], *ids[0:10]]
+
+
+def test_select_new_without_a_limit_reports_everything(state_dir):
+    watermark = _watermark_module()
+    watermark.select_new("all", ["a"])
+
+    assert watermark.select_new("all", ["a", "b", "c"]) == ["b", "c"]
+    assert watermark.select_new("all", ["a", "b", "c"]) == []
+
+
+def test_select_new_first_run_still_adopts_the_whole_feed_silently(state_dir):
+    """The silent first run is deliberate: it must not leave a backlog behind."""
+    watermark = _watermark_module()
+    ids = [f"item-{i:02d}" for i in range(30)]
+
+    assert watermark.select_new("quiet", ids, limit=10) == []
+    assert watermark.load_seen("quiet") == ids
+    assert watermark.select_new("quiet", ids, limit=10) == []
+
+
+def test_select_new_first_run_reports_respects_the_limit_too(state_dir):
+    watermark = _watermark_module()
+    ids = [f"item-{i:02d}" for i in range(12)]
+
+    first = watermark.select_new("loud", ids, limit=10, first_run_reports=True)
+    second = watermark.select_new("loud", ids, limit=10, first_run_reports=True)
+
+    assert first == ids[2:]
+    assert second == ids[:2]
+
+
+@pytest.mark.parametrize("limit", ["0", "-1", "ten"])
+def test_limit_must_be_a_positive_integer(limit, state_dir):
+    """A cap of 0 or less would report nothing and commit nothing, forever."""
+    result = _run(
+        "watch_rss.py",
+        "--url",
+        "http://127.0.0.1:1/x",
+        "--name",
+        "t",
+        "--limit",
+        limit,
+        env_home=state_dir,
+    )
+
+    assert result.returncode == 2  # argparse rejects the value
+    assert "--limit" in result.stderr
+
+
+def test_rss_surplus_past_the_limit_is_reported_on_the_next_run(state_dir, base_url):
+    url = _feed(state_dir, base_url, "feed.xml", RSS)
+    _run("watch_rss.py", "--url", url, "--name", "t", env_home=state_dir)
+    _feed(
+        state_dir,
+        base_url,
+        "feed.xml",
+        RSS.replace(
+            "</channel>",
+            "<item><title>Third post</title><guid>3</guid></item>"
+            "<item><title>Fourth post</title><guid>4</guid></item></channel>",
+        ),
+    )
+
+    first = _run("watch_rss.py", "--url", url, "--name", "t", "--limit", "1", env_home=state_dir)
+    second = _run("watch_rss.py", "--url", url, "--name", "t", "--limit", "1", env_home=state_dir)
+    third = _run("watch_rss.py", "--url", url, "--name", "t", "--limit", "1", env_home=state_dir)
+
+    # The feed lists newest last here, so the tail -- Fourth -- is drained first.
+    assert first.returncode == 0 and first.stdout.strip() == "- Fourth post"
+    assert second.returncode == 0 and second.stdout.strip() == "- Third post"
+    assert third.returncode == 0 and third.stdout == ""


### PR DESCRIPTION
Fixes #1674

## Problem

`_watermark.select_new` committed every fresh id to the watermark before returning, and all three watchers printed only `fresh[:args.limit]`. Anything past `--limit` was marked seen without ever being printed, so no later run could report it. `watch_github.py` fetches `per_page=30` against a default limit of 10, so one busy poll could silently drop 20 items.

## Fix

- `select_new(name, ids, *, first_run_reports=False, limit=None)` now takes the limit, returns at most `limit` ids and commits **only those**; the surplus stays out of the watermark and surfaces on the following runs. The three watchers pass `limit=args.limit` and print everything returned.
- Feeds list newest first, so a capped run takes the *tail* of the fresh ids: the backlog drains oldest first (in feed order) and what is deferred is the newest, which stays on the page longest. An item is lost only if it drops off the feed's page before its turn comes — the page is the only memory the watcher has of it. SKILL.md says so.
- `--limit` is validated as a positive integer (shared `positive_int` argparse type): a cap of 0 or less would report nothing and commit nothing forever.
- The silent first run still adopts the whole feed, as the report asks; with `--first-run-reports` it behaves like any other run (capped, surplus deferred).

## Tests

Added to `tests/test_skills/test_cron_watchers.py` (fail on `main`):
- `select_new` reports 10 of 20 new ids and the other 10 on the next run; the watermark ends up holding exactly the reported ids (in-process via `importlib`, no subprocess)
- no limit → everything reported, once
- the silent first run leaves no backlog
- `--first-run-reports` respects the limit
- end to end: `watch_rss.py --limit 1` reports one new post per run until the feed is drained, then stays silent
- `--limit 0` / `-1` / `ten` are rejected with exit 2

The subprocess tests reuse the existing loopback fixture and Windows-safe `_run` helper.

## Gate

- `uv run ruff check src tests` — clean (bundled scripts are excluded from mypy by `pyproject.toml`)
- `tests/test_skills/test_cron_watchers.py` — 26 passed

## Merge safety

Part of a batch of five fix PRs (#1625, #1645, #1653, #1673, #1674). Each touches a disjoint set of files, and all 120 merge orderings were checked for conflicts on a scratch worktree off `upstream/main` (0 conflicts), so they can be merged one by one in any order. The `CHANGELOG.md` entry is deliberately not in this PR — `[Unreleased] / ### Fixed` has a single bullet, so five PRs inserting there would conflict in every order; the batch entry is in a separate `docs(changelog)` PR that only touches that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dPxJwmC1LQnzwN83SpH2G
