### PR TITLE
fix(cli): correlate gateway turn frames by session key and stream seq

### DIFF
--- a/src/agentos/cli/gateway_client.py
+++ b/src/agentos/cli/gateway_client.py
@@ -514,7 +514,15 @@ class GatewayClient:
         sensitive paths bypassed).
         """
         # Subscribe to message events for this session
-        await self._call("sessions.messages.subscribe", {"key": session_key})
+        subscription = await self._call("sessions.messages.subscribe", {"key": session_key})
+        # ``_recv_queue`` is connection-wide, so it can still hold frames from an
+        # earlier turn (a Ctrl-C leaves the server's asynchronous
+        # ``session.event.done(reason="aborted")`` behind) or from another
+        # subscribed session. The gateway stamps every ``session.event.*``
+        # payload with ``session_key`` and a per-session ``stream_seq``, and the
+        # subscribe response reports the seq reached so far, so anything at or
+        # below it predates this turn.
+        since_stream_seq = _stream_seq_of(subscription)
 
         params: dict[str, Any] = {
             "key": session_key,
@@ -542,6 +550,8 @@ class GatewayClient:
             frame = await self._recv_queue.get()
             event_name: str = frame.get("event", "")
             payload: dict = frame.get("payload") or {}
+            if _frame_is_from_another_turn(payload, session_key, since_stream_seq):
+                continue
             if event_name == "session.event.error":
                 payload = _normalize_session_error_payload(payload)
             if task_terminal := _task_terminal_as_session_event(event_name, payload):
@@ -628,6 +638,38 @@ class GatewayClient:
             if task is not None and task is not current_task and not task.done():
                 task.cancel()
         return err
+
+
+def _stream_seq_of(payload: Any) -> int | None:
+    """Return a payload's ``stream_seq``, or None when the server omits it."""
+
+    if not isinstance(payload, dict):
+        return None
+    seq = payload.get("stream_seq") or payload.get("current_stream_seq")
+    if isinstance(seq, bool) or not isinstance(seq, int):
+        return None
+    return seq
+
+
+def _frame_is_from_another_turn(
+    payload: dict,
+    session_key: str,
+    since_stream_seq: int | None,
+) -> bool:
+    """True when a queued frame belongs to another session or an earlier turn.
+
+    Correlation is best-effort: a frame without ``session_key``/``stream_seq``
+    (a server predating session stream buffers, or an event routed outside
+    them) is treated as belonging to this turn, exactly as before.
+    """
+
+    frame_key = payload.get("session_key")
+    if isinstance(frame_key, str) and frame_key and frame_key != session_key:
+        return True
+    if since_stream_seq is None:
+        return False
+    seq = _stream_seq_of(payload)
+    return seq is not None and seq <= since_stream_seq
 
 
 def _task_terminal_as_session_event(event_name: str, payload: dict) -> dict[str, Any] | None:

--- a/tests/test_cli/test_gateway_client_turn_correlation.py
+++ b/tests/test_cli/test_gateway_client_turn_correlation.py
@@ -1,0 +1,233 @@
+"""Regression tests for turn/session correlation in ``GatewayClient.send_message``.
+
+``_recv_queue`` is connection-wide. A Ctrl-C leaves the gateway's asynchronous
+``session.event.done(reason="aborted")`` in it, and a connection subscribed to
+more than one session mixes their frames. ``send_message`` must only observe
+frames belonging to its own turn.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agentos.cli.gateway_client import GatewayClient
+
+SESSION = "agent:main:abc123"
+OTHER_SESSION = "agent:main:def456"
+
+
+def _client(current_stream_seq: int | None) -> tuple[GatewayClient, list[tuple[str, dict]]]:
+    """Client whose ``sessions.messages.subscribe`` reports ``current_stream_seq``."""
+
+    client = GatewayClient()
+    calls: list[tuple[str, dict]] = []
+
+    async def fake_call(method: str, params: dict | None = None) -> dict[str, Any]:
+        calls.append((method, params or {}))
+        if method == "sessions.messages.subscribe" and current_stream_seq is not None:
+            return {"subscribed": True, "key": SESSION, "current_stream_seq": current_stream_seq}
+        return {}
+
+    client._call = fake_call  # type: ignore[method-assign]
+    return client, calls
+
+
+async def _drain(client: GatewayClient) -> list[dict[str, Any]]:
+    return [event async for event in client.send_message(SESSION, "second message")]
+
+
+@pytest.mark.asyncio
+async def test_stale_aborted_done_from_a_previous_turn_is_discarded() -> None:
+    """The issue's repro: a Ctrl-C's `done` must not terminate the next turn."""
+
+    client, _ = _client(current_stream_seq=7)
+    for frame in (
+        # Left over from the aborted turn (recorded before this turn subscribed).
+        {
+            "event": "session.event.done",
+            "payload": {"reason": "aborted", "session_key": SESSION, "stream_seq": 7},
+        },
+        {
+            "event": "session.event.text_delta",
+            "payload": {"text": "actual answer", "session_key": SESSION, "stream_seq": 8},
+        },
+        {
+            "event": "session.event.done",
+            "payload": {"reason": "stop", "session_key": SESSION, "stream_seq": 9},
+        },
+    ):
+        client._recv_queue.put_nowait(frame)
+
+    events = await _drain(client)
+
+    assert [event["event"] for event in events] == [
+        "session.event.text_delta",
+        "session.event.done",
+    ]
+    assert events[0]["text"] == "actual answer"
+    assert events[-1]["reason"] == "stop"
+
+
+@pytest.mark.asyncio
+async def test_stale_frame_queued_behind_a_fresh_one_is_still_discarded() -> None:
+    """Correlation is by ``stream_seq``, not by queue position.
+
+    ``sessions.abort`` only confirms the abort was requested, so the aborted
+    turn's ``done`` can be delivered after this turn's first frames. Discarding
+    on arrival order alone would let it through.
+    """
+
+    client, _ = _client(current_stream_seq=4)
+    for frame in (
+        {
+            "event": "session.event.text_delta",
+            "payload": {"text": "fresh", "session_key": SESSION, "stream_seq": 5},
+        },
+        {
+            "event": "session.event.done",
+            "payload": {"reason": "aborted", "session_key": SESSION, "stream_seq": 4},
+        },
+        {
+            "event": "session.event.done",
+            "payload": {"reason": "stop", "session_key": SESSION, "stream_seq": 6},
+        },
+    ):
+        client._recv_queue.put_nowait(frame)
+
+    events = await _drain(client)
+
+    assert [event.get("reason") for event in events if event["event"] == "session.event.done"] == [
+        "stop"
+    ]
+    assert [event["event"] for event in events] == [
+        "session.event.text_delta",
+        "session.event.done",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stale_text_delta_is_not_misattributed_to_the_new_turn() -> None:
+    """Dropped output is the other half of the bug: stale text must not leak in."""
+
+    client, _ = _client(current_stream_seq=2)
+    for frame in (
+        {
+            "event": "session.event.text_delta",
+            "payload": {"text": "previous answer", "session_key": SESSION, "stream_seq": 2},
+        },
+        {
+            "event": "session.event.text_delta",
+            "payload": {"text": "this answer", "session_key": SESSION, "stream_seq": 3},
+        },
+        {
+            "event": "session.event.done",
+            "payload": {"reason": "stop", "session_key": SESSION, "stream_seq": 4},
+        },
+    ):
+        client._recv_queue.put_nowait(frame)
+
+    events = await _drain(client)
+
+    assert [event.get("text") for event in events if "text" in event] == ["this answer"]
+
+
+@pytest.mark.asyncio
+async def test_frames_for_another_subscribed_session_are_skipped() -> None:
+    """One connection can hold subscriptions for several sessions."""
+
+    client, _ = _client(current_stream_seq=0)
+    for frame in (
+        {
+            "event": "session.event.done",
+            "payload": {"reason": "stop", "session_key": OTHER_SESSION, "stream_seq": 1},
+        },
+        {
+            "event": "session.event.text_delta",
+            "payload": {"text": "mine", "session_key": SESSION, "stream_seq": 1},
+        },
+        {
+            "event": "session.event.done",
+            "payload": {"reason": "stop", "session_key": SESSION, "stream_seq": 2},
+        },
+    ):
+        client._recv_queue.put_nowait(frame)
+
+    events = await _drain(client)
+
+    assert [event["event"] for event in events] == [
+        "session.event.text_delta",
+        "session.event.done",
+    ]
+    assert events[0]["text"] == "mine"
+
+
+@pytest.mark.asyncio
+async def test_another_session_is_filtered_even_without_a_seq_baseline() -> None:
+    """Session-key correlation does not depend on the subscribe response."""
+
+    client, _ = _client(current_stream_seq=None)
+    client._recv_queue.put_nowait(
+        {"event": "session.event.done", "payload": {"reason": "stop", "session_key": OTHER_SESSION}}
+    )
+    client._recv_queue.put_nowait(
+        {"event": "session.event.done", "payload": {"reason": "stop", "session_key": SESSION}}
+    )
+
+    events = await _drain(client)
+
+    assert [event["session_key"] for event in events] == [SESSION]
+    assert [event["event"] for event in events] == ["session.event.done"]
+
+
+@pytest.mark.asyncio
+async def test_first_frame_of_this_turn_is_kept() -> None:
+    """Boundary guard: ``stream_seq == baseline + 1`` is this turn's own output."""
+
+    client, _ = _client(current_stream_seq=11)
+    client._recv_queue.put_nowait(
+        {
+            "event": "session.event.done",
+            "payload": {"reason": "stop", "session_key": SESSION, "stream_seq": 12},
+        }
+    )
+
+    events = await _drain(client)
+
+    assert [event["event"] for event in events] == ["session.event.done"]
+    assert events[0]["stream_seq"] == 12
+
+
+@pytest.mark.asyncio
+async def test_uncorrelated_frames_still_stream_through() -> None:
+    """A server that stamps neither field behaves exactly as before the fix."""
+
+    client, calls = _client(current_stream_seq=None)
+    client._recv_queue.put_nowait(
+        {"event": "session.event.text_delta", "payload": {"text": "hello"}}
+    )
+    client._recv_queue.put_nowait({"event": "session.event.done", "payload": {}})
+
+    events = await _drain(client)
+
+    assert [event["event"] for event in events] == [
+        "session.event.text_delta",
+        "session.event.done",
+    ]
+    assert [method for method, _ in calls] == ["sessions.messages.subscribe", "sessions.send"]
+
+
+@pytest.mark.asyncio
+async def test_task_terminal_fallback_survives_correlation() -> None:
+    """Task-runtime terminals carry no session stamp and must keep ending the turn."""
+
+    client, _ = _client(current_stream_seq=3)
+    client._recv_queue.put_nowait(
+        {"event": "task.cancelled", "payload": {"task_id": "task-1"}},
+    )
+
+    events = await _drain(client)
+
+    assert [event["event"] for event in events] == ["session.event.done"]
+    assert events[0]["reason"] == "aborted"


### PR DESCRIPTION
Fixes #1790

## The bug

`GatewayClient._recv_queue` is one queue per **connection**, but `send_message()` reads it as if it were one queue per **turn**:

```python
# src/agentos/cli/gateway_client.py
await self._call("sessions.messages.subscribe", {"key": session_key})
...
while True:
    frame = await self._recv_queue.get()
    event_name: str = frame.get("event", "")
    payload: dict = frame.get("payload") or {}
    ...
    if event_name in ("session.event.done", "session.event.error"):
        ...
        break
```

Nothing checks whose turn — or whose session — a frame belongs to. On Ctrl-C the CLI abandons the generator and calls `sessions.abort`, whose RPC response only confirms the abort was *requested*; the turn task's own `session.event.done(reason="aborted")` (`rpc_sessions.py`, `except asyncio.CancelledError`) is emitted afterwards, asynchronously. The next `send_message()` pops that `done` first, reports `cancelled=True` for a message the user never cancelled, and returns — leaving the real answer in the queue for whatever reads next, where it is either dropped or misattributed to a later turn.

The same gap makes a connection subscribed to two sessions cross-feed: whichever `send_message()` happens to be reading consumes the other session's frames.

Ctrl-C then retry is an ordinary `agentos chat --gateway` flow, so this is reachable without any unusual configuration.

## The fix

The correlation keys already exist on the wire — this PR just uses them. `SessionStreamRegistry.record()` stamps every `session.event.*` payload:

```python
enriched["session_key"] = session_key
enriched["stream_seq"] = stream_seq   # monotonic, per session
```

and `sessions.messages.subscribe` already returns `current_stream_seq`, i.e. the seq the session had reached at the moment this turn subscribed. So anything at or below it predates the turn:

```python
subscription = await self._call("sessions.messages.subscribe", {"key": session_key})
since_stream_seq = _stream_seq_of(subscription)
...
    if _frame_is_from_another_turn(payload, session_key, since_stream_seq):
        continue
```

```python
def _frame_is_from_another_turn(payload, session_key, since_stream_seq) -> bool:
    frame_key = payload.get("session_key")
    if isinstance(frame_key, str) and frame_key and frame_key != session_key:
        return True
    if since_stream_seq is None:
        return False
    seq = _stream_seq_of(payload)
    return seq is not None and seq <= since_stream_seq
```

Deliberate properties:

- **Correlation, not draining.** The issue's scope note offers "drain the queue before subscribing" as an alternative. Draining only removes what has *already* arrived; the aborted `done` is emitted asynchronously and can land after the new turn is under way, in which case a drain has nothing to remove. `stream_seq` is assigned when the gateway records the event, so a stale frame is identified as stale no matter when the socket delivers it. The second test below covers exactly that ordering.
- **Fail-open.** A payload carrying neither field (a server predating session stream buffers, task-runtime terminals such as `task.cancelled`, `sessions.changed`) streams through exactly as before. Nothing new can hang the CLI.
- **No frame is stolen from another reader.** `_recv_queue` has exactly one consumer (`send_message`, `gateway_client.py:542`), and `_emit_to_subscribers` only delivers a payload to connections subscribed to that payload's own `session_key` — so a frame for a different session was already being misdelivered, never legitimately consumed here.
- One source file, no changes to the gateway, the REPL, or the TUI adapters.

## Tests

`tests/test_cli/test_gateway_client_turn_correlation.py` — 8 cases, all offline, no sockets, no credentials, no timing:

- `test_stale_aborted_done_from_a_previous_turn_is_discarded` — the issue's repro: stale `done(reason="aborted")`, then the real delta and `done(reason="stop")`.
- `test_stale_frame_queued_behind_a_fresh_one_is_still_discarded` — the stale `done` arrives *after* this turn's first delta; correlation is by seq, not by queue position.
- `test_stale_text_delta_is_not_misattributed_to_the_new_turn` — the other half of the bug: a previous turn's text must not leak into this turn's output.
- `test_frames_for_another_subscribed_session_are_skipped` — two sessions on one connection.
- `test_another_session_is_filtered_even_without_a_seq_baseline` — session-key correlation does not depend on the subscribe response.
- `test_first_frame_of_this_turn_is_kept` — boundary guard: `stream_seq == baseline + 1` is kept.
- `test_uncorrelated_frames_still_stream_through` — server stamping neither field behaves as before.
- `test_task_terminal_fallback_survives_correlation` — `task.cancelled` still ends the turn.

The first five fail on `upstream/main` and pass with the fix. The last three are guards that **pass either way by design** — they exist to pin the fail-open and boundary behaviour the filter must not break, and they would catch an over-eager future version of this filter.

The existing `send_message` tests in `tests/test_cli/test_chat_cmd.py` stub `_call` to return `{}`, so they exercise the fail-open path unchanged and needed no edits.

## Verification

```
$ git show upstream/main:src/agentos/cli/gateway_client.py > src/agentos/cli/gateway_client.py
$ uv run pytest -q tests/test_cli/test_gateway_client_turn_correlation.py
5 failed, 3 passed in 0.69s

$ # fix restored
$ uv run pytest -q tests/test_cli/test_gateway_client_turn_correlation.py
8 passed in 0.66s

$ uv run ruff check src tests
All checks passed!

$ uv run mypy --show-error-codes src
Success: no issues found in 625 source files

$ uv run pytest -q
6 failed, 10449 passed, 34 skipped, 3 errors in 250.65s
```

The 6 failures and 3 errors are pre-existing on a pristine `upstream/main` in this environment and unrelated to this change: `test_pilot_encoder.py` and `test_build_wheelhouse_zip.py` need a hydrated MiniLM ONNX asset that is not in the checkout, and `test_public_release_hygiene.py::test_tracked_public_files_do_not_carry_this_machines_timezone` is a machine-timezone guard. None touch `agentos.cli`.

No CLI surface changed (no commands, flags, config keys, ports or paths), so `SKILL.md` and `docs/cli.md` need no update.

## One adjacent case, deliberately left alone

The issue also notes that no `sessions.messages.unsubscribe` call exists anywhere in `cli/`, so subscriptions accumulate across `/new`, `/resume` and retried turns. That is real, but it is a lifecycle change in the REPL rather than a correlation bug, and with this fix the accumulated subscriptions are no longer *harmful* — their frames are filtered by session key instead of being consumed by the wrong turn. Happy to follow up in a separate PR if you want the unsubscribe wired into the session-switch paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
