### PR TITLE
fix(gateway): take TaskRuntime.list()'s window from the newest tasks

### DIFF
--- a/src/agentos/gateway/task_runtime.py
+++ b/src/agentos/gateway/task_runtime.py
@@ -511,7 +511,11 @@ class TaskRuntime:
             session_key = canonicalize_session_key(session_key)
         return cast(
             list[AgentTaskRecord],
-            await self._storage.list_agent_tasks(session_key=session_key, status=status),
+            await self._storage.list_agent_tasks(
+                session_key=session_key,
+                status=status,
+                newest_first=True,
+            ),
         )
 
     async def cancel(

--- a/src/agentos/session/storage.py
+++ b/src/agentos/session/storage.py
@@ -1000,7 +1000,16 @@ class SessionStorage:
         status: str | AgentTaskStatus | None = None,
         limit: int = 100,
         offset: int = 0,
+        newest_first: bool = False,
     ) -> list[AgentTaskRecord]:
+        """List agent tasks, oldest first.
+
+        ``newest_first`` selects the newest ``limit`` rows instead of the
+        oldest ones -- what a caller watching a live session needs once a
+        session has more lifetime tasks than the limit. The rows are still
+        returned oldest-first so ``rows[-1]`` stays the latest task.
+        ``list_agent_tasks_for_sessions`` already windows this way.
+        """
         clauses: list[str] = []
         params: list[Any] = []
         if session_key is not None:
@@ -1011,12 +1020,18 @@ class SessionStorage:
             params.append(str(status))
         where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
         params += [limit, offset]
+        order = "DESC" if newest_first else "ASC"
         sql = (
             f"SELECT * FROM agent_tasks {where} "
-            "ORDER BY created_at ASC, rowid ASC LIMIT ? OFFSET ?"
+            f"ORDER BY created_at {order}, rowid {order} LIMIT ? OFFSET ?"
         )
         async with self.conn.execute(sql, params) as cur:
             rows = await cur.fetchall()
+        if newest_first:
+            # Reverse in Python rather than re-sorting in SQL: `SELECT *` does
+            # not carry `rowid`, so an outer ORDER BY would have to tie-break
+            # on another column and could reorder rows sharing a `created_at`.
+            rows = list(reversed(rows))
         return [AgentTaskRecord(**_deserialize_row(dict(row))) for row in rows]
 
     @_serialized_write

--- a/tests/test_gateway/test_task_runtime_list_truncation.py
+++ b/tests/test_gateway/test_task_runtime_list_truncation.py
@@ -1,0 +1,252 @@
+"""Regression tests for #1805: TaskRuntime.list() must surface the newest tasks.
+
+``agent_tasks`` rows are only deleted when a session is deleted, so a
+long-lived session outgrows ``list_agent_tasks``' 100-row window. With the
+window taken from the *oldest* end, ``TaskRuntime.list()`` stops reporting a
+session's current task, and the two callers the issue names act on a stale
+row: ``sessions_yield`` waits on ``rows[-1]`` and session reset/delete scans
+the same rows for something still running.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from agentos.gateway.task_runtime import TaskRuntime
+from agentos.session.models import AgentTaskRecord, AgentTaskStatus
+from agentos.session.storage import SessionStorage
+
+KEY = "agent:main:webchat:long-lived"
+TOTAL = 105
+RUNNING_TASK = f"task-{TOTAL - 1:03d}"
+
+
+async def _storage_with_tasks(tmp_path, *, name: str = "tasks.db") -> SessionStorage:
+    """105 tasks for one session: all succeeded except the newest, still running."""
+
+    storage = SessionStorage(str(tmp_path / name))
+    await storage.connect()
+    for index in range(TOTAL):
+        await storage.create_agent_task(
+            AgentTaskRecord(
+                task_id=f"task-{index:03d}",
+                session_key=KEY,
+                source_kind="webui",
+                queue_mode="followup",
+                run_kind="web_turn",
+                status=(
+                    AgentTaskStatus.RUNNING if index == TOTAL - 1 else AgentTaskStatus.SUCCEEDED
+                ),
+                created_at=1000 + index,
+                updated_at=1000 + index,
+            )
+        )
+    return storage
+
+
+def _runtime(storage: SessionStorage) -> TaskRuntime:
+    async def _handler(*_args: Any, **_kwargs: Any) -> None:  # pragma: no cover - never run
+        return None
+
+    return TaskRuntime(storage=storage, turn_handler=_handler)
+
+
+# --------------------------------------------------------------------------
+# storage layer
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_newest_first_window_keeps_the_running_task(tmp_path) -> None:
+    storage = await _storage_with_tasks(tmp_path)
+    try:
+        rows = await storage.list_agent_tasks(session_key=KEY, newest_first=True)
+
+        assert len(rows) == 100
+        assert rows[-1].task_id == RUNNING_TASK
+        assert rows[-1].status == AgentTaskStatus.RUNNING
+        # Still oldest-first within the window, so `rows[-1]` is the latest.
+        assert [row.task_id for row in rows] == sorted(row.task_id for row in rows)
+        assert rows[0].task_id == f"task-{TOTAL - 100:03d}"
+    finally:
+        await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_default_window_is_unchanged_for_other_callers(tmp_path) -> None:
+    """The reviewer's constraint: other callers keep the oldest-first default."""
+
+    storage = await _storage_with_tasks(tmp_path)
+    try:
+        rows = await storage.list_agent_tasks(session_key=KEY)
+
+        assert len(rows) == 100
+        assert rows[0].task_id == "task-000"
+        assert rows[-1].task_id == "task-099"
+        assert all(row.status == AgentTaskStatus.SUCCEEDED for row in rows)
+    finally:
+        await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_newest_first_breaks_ties_by_insertion_order(tmp_path) -> None:
+    """Tasks can share a `created_at`; `task_id` is a random uuid.
+
+    The newest-first window must tie-break on insertion order, or `rows[-1]`
+    becomes a coin flip among rows written in the same millisecond.
+    """
+
+    storage = SessionStorage(str(tmp_path / "ties.db"))
+    await storage.connect()
+    try:
+        # Deliberately descending ids so any id-based ordering reverses them.
+        for task_id in ("task-zzz", "task-mmm", "task-aaa"):
+            await storage.create_agent_task(
+                AgentTaskRecord(
+                    task_id=task_id,
+                    session_key=KEY,
+                    source_kind="webui",
+                    queue_mode="followup",
+                    run_kind="web_turn",
+                    status=AgentTaskStatus.SUCCEEDED,
+                    created_at=5000,
+                    updated_at=5000,
+                )
+            )
+
+        rows = await storage.list_agent_tasks(session_key=KEY, newest_first=True, limit=2)
+
+        assert [row.task_id for row in rows] == ["task-mmm", "task-aaa"]
+    finally:
+        await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_newest_first_still_honours_the_status_filter(tmp_path) -> None:
+    storage = await _storage_with_tasks(tmp_path)
+    try:
+        rows = await storage.list_agent_tasks(
+            session_key=KEY,
+            status=AgentTaskStatus.RUNNING,
+            newest_first=True,
+        )
+
+        assert [row.task_id for row in rows] == [RUNNING_TASK]
+    finally:
+        await storage.close()
+
+
+# --------------------------------------------------------------------------
+# TaskRuntime
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_task_runtime_list_surfaces_the_running_task(tmp_path) -> None:
+    storage = await _storage_with_tasks(tmp_path)
+    try:
+        rows = await _runtime(storage).list(session_key=KEY)
+
+        assert any(row.task_id == RUNNING_TASK for row in rows)
+        assert rows[-1].task_id == RUNNING_TASK
+    finally:
+        await storage.close()
+
+
+# --------------------------------------------------------------------------
+# caller 1: sessions_yield
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sessions_yield_waits_on_the_running_task(tmp_path, monkeypatch) -> None:
+    """Issue #1805: `latest = rows[-1]` must be the in-flight task."""
+
+    from agentos.tools.builtin import sessions as sessions_tools
+
+    storage = await _storage_with_tasks(tmp_path)
+    runtime = _runtime(storage)
+
+    class _Manager:
+        async def get_current_session(self) -> Any:
+            return None
+
+        async def get_session(self, key: str) -> Any:
+            assert key == KEY
+            return type("_Session", (), {"session_key": key, "status": "running"})()
+
+    monkeypatch.setattr(sessions_tools, "_session_manager", _Manager())
+    monkeypatch.setattr(sessions_tools, "_task_runtime", runtime)
+
+    try:
+        payload = json.loads(await sessions_tools.sessions_yield(session_key=KEY))
+    finally:
+        await storage.close()
+
+    assert payload["waited"] is True
+    assert payload["task_id"] == RUNNING_TASK
+    assert payload["status"] == str(AgentTaskStatus.RUNNING)
+
+
+# --------------------------------------------------------------------------
+# caller 2: session reset / delete
+# --------------------------------------------------------------------------
+
+
+async def _drain_and_record(tmp_path, drain, *, name: str) -> list[str]:
+    """Run a drain helper and report which task ids it tried to settle."""
+
+    storage = await _storage_with_tasks(tmp_path, name=name)
+    runtime = _runtime(storage)
+    waited: list[str] = []
+    original_wait = runtime.wait
+
+    async def _recording_wait(task_id: str, timeout: float | None = None) -> Any:
+        waited.append(task_id)
+        return await original_wait(task_id, timeout)
+
+    runtime.wait = _recording_wait  # type: ignore[method-assign]
+    try:
+        await drain(runtime)
+    finally:
+        await storage.close()
+    return waited
+
+
+@pytest.mark.asyncio
+async def test_session_reset_settles_the_running_task(tmp_path) -> None:
+    """Issue #1805: reset must see a running task past the 100th turn."""
+
+    from agentos.gateway import rpc_sessions
+
+    waited = await _drain_and_record(
+        tmp_path,
+        lambda runtime: rpc_sessions._drain_task_runtime_for_reset(runtime, KEY),
+        name="reset.db",
+    )
+
+    assert RUNNING_TASK in waited
+
+
+@pytest.mark.asyncio
+async def test_session_delete_settles_the_running_task(tmp_path) -> None:
+    """The delete path shares the same drain helper and the same blind spot."""
+
+    from agentos.gateway import rpc_sessions
+
+    waited = await _drain_and_record(
+        tmp_path,
+        lambda runtime: rpc_sessions._drain_task_runtime_for_session(
+            runtime,
+            KEY,
+            source="sessions_delete",
+            reason="session_deleted",
+            op="delete",
+        ),
+        name="delete.db",
+    )
+
+    assert RUNNING_TASK in waited


### PR DESCRIPTION
Fixes #1805

## The bug

`agent_tasks` rows are created once per turn and only deleted when the session is deleted, so a long-lived session eventually holds more rows than `list_agent_tasks` will return. That window was taken from the **oldest** end:

```python
# src/agentos/session/storage.py
params += [limit, offset]
sql = (
    f"SELECT * FROM agent_tasks {where} "
    "ORDER BY created_at ASC, rowid ASC LIMIT ? OFFSET ?"
)
```

and `TaskRuntime.list()` passed no limit, so it took the default 100. Past turn 100 it therefore reports only tasks 000–099 and never the session's current one. Both callers the issue names act on that stale answer:

- **`sessions_yield`** (`tools/builtin/sessions.py:704`) picks `latest = rows[-1]`, gets an already-finished task, and `runtime.wait()` returns immediately — the tool reports `waited: true` on a turn it never waited for.
- **session reset / delete** (`_drain_task_runtime_for_reset` → `_drain_task_runtime_for_session`, `gateway/rpc_sessions.py:218`) scans the same rows for anything `running` and finds nothing, so a live turn is neither settled nor drained before its session's rows are torn out from under it.

Both are ordinary long-session behaviour, not an edge case: a main session crosses 100 turns routinely.

The codebase already has the right shape one method down. `list_agent_tasks_for_sessions` — same table, same purpose — windows from the newest end:

```python
"ORDER BY session_key ASC, created_at DESC, rowid DESC"
```

`list_agent_tasks` is the one that doesn't.

## The fix

An opt-in `newest_first` flag on the storage method, and `TaskRuntime.list()` opting into it:

```python
order = "DESC" if newest_first else "ASC"
sql = (
    f"SELECT * FROM agent_tasks {where} "
    f"ORDER BY created_at {order}, rowid {order} LIMIT ? OFFSET ?"
)
async with self.conn.execute(sql, params) as cur:
    rows = await cur.fetchall()
if newest_first:
    rows = list(reversed(rows))
```

Three deliberate choices:

**The storage default is untouched.** The issue's scope note says to order DESC *for this caller* and warns against changing the default for others without checking them. I checked them — `_list_task_rows` (`rpc_sessions.py:647`) and `subagent_announce.py:451` also reach `list_agent_tasks` directly — and left their behaviour exactly as it was rather than move it underneath them. A test pins the old default so it cannot drift later.

**Rows come back oldest-first inside the window**, so `rows[-1]` is still the latest task and no caller's indexing changes meaning. Only *which* rows are in the window changes.

**The window is reversed in Python, not re-sorted in SQL.** This is the subtle one. `task_id` is a random uuid (`models.py:329`) and `created_at` is a millisecond timestamp, so tasks created in the same millisecond tie — and `SELECT *` does not carry `rowid`, so an outer `ORDER BY` in SQL has to tie-break on some *other* column. Doing that reorders tied rows relative to the window that selected them, which puts a stale row back at `rows[-1]` — the exact failure this issue is about. Measured on three rows written in one millisecond:

| | returned window (`limit=2`) | `rows[-1]` |
|---|---|---|
| insertion order | `task-zzz`, `task-mmm`, `task-aaa` | newest is `task-aaa` |
| outer `ORDER BY created_at ASC, task_id ASC` | `task-aaa`, `task-mmm` | ❌ `task-mmm` |
| this branch | `task-mmm`, `task-aaa` | ✅ `task-aaa` |

Reversing the fetched window keeps the tie-break identical to the one that chose the rows, by construction.

Source change is 5 lines of logic across 2 files; no signature is removed or renamed, and `TaskRuntime.list()`'s own signature is unchanged.

## Tests

`tests/test_gateway/test_task_runtime_list_truncation.py` — 8 cases, offline, no network, no credentials, deterministic (fixed `created_at` values, no sleeps). The fixture is the issue's own scenario: 105 tasks for one session, 104 succeeded and the newest one running.

Storage layer:
- `test_newest_first_window_keeps_the_running_task` — the window is the newest 100, still oldest-first, `rows[-1]` is the running task.
- `test_default_window_is_unchanged_for_other_callers` — the default still returns `task-000`…`task-099`. This is the reviewer's "do not change the default" constraint, pinned.
- `test_newest_first_breaks_ties_by_insertion_order` — the table above, as an assertion.
- `test_newest_first_still_honours_the_status_filter` — the flag composes with `status=`.

Runtime and the two callers the issue names:
- `test_task_runtime_list_surfaces_the_running_task`
- `test_sessions_yield_waits_on_the_running_task` — drives the real `sessions_yield` and asserts the returned JSON names the running task, not a stale finished one.
- `test_session_reset_settles_the_running_task` and `test_session_delete_settles_the_running_task` — drive the real drain helpers and assert on **which task ids they actually tried to settle**, per branch, rather than on a return value.

Reverting only `task_runtime.py` to `upstream/main` (keeping the storage parameter, so the failure is the behaviour and not an unknown kwarg) fails the four runtime/caller tests. The four storage tests pass either way by design — they pin the new parameter's contract and the untouched default, which is what stops a later change from quietly re-breaking this.

## Verification

```
$ git show upstream/main:src/agentos/gateway/task_runtime.py > src/agentos/gateway/task_runtime.py
$ uv run pytest -q tests/test_gateway/test_task_runtime_list_truncation.py
4 failed, 4 passed in 3.48s

$ # fix restored
$ uv run pytest -q tests/test_gateway/test_task_runtime_list_truncation.py
8 passed in 3.28s

$ uv run ruff check src tests
All checks passed!

$ uv run mypy --show-error-codes src
Success: no issues found in 625 source files

$ uv run pytest -q
6 failed, 10449 passed, 34 skipped, 3 errors in 250.57s
```

The 6 failures and 3 errors are pre-existing on a pristine `upstream/main` in this environment and unrelated to this change: `test_pilot_encoder.py` and `test_build_wheelhouse_zip.py` need a hydrated MiniLM ONNX asset that is not in the checkout, and `test_public_release_hygiene.py::test_tracked_public_files_do_not_carry_this_machines_timezone` is a machine-timezone guard. None touch `agentos.gateway` or `agentos.session`.

No CLI surface changed (no commands, flags, config keys, ports or paths), so `SKILL.md` and `docs/cli.md` need no update.

## One adjacent case, deliberately left alone

Checking the other callers turned up one more spot with the same shape: `subagent_announce.py:451` calls `list_agent_tasks(session_key=key, limit=10)` and then `_select_latest_task_row(rows)` — with the oldest-first default that is the latest of the ten *oldest* tasks. I left it alone, because it is only reachable on a storage backend that lacks `list_agent_tasks_for_sessions`: the real `SessionStorage` has that method, the code prefers it, and that batch path already windows newest-first correctly. So on `main` today the line is a fallback that never runs. Happy to pass `newest_first=True` there too in this PR if you would rather close the shape everywhere than leave a latent one — say the word and I will add it with a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
