### PR TITLE
fix(channels): advance the refill clock past a RateLimiter wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- The channel `RateLimiter` admitted roughly twice its configured rate under
+  contention. A caller that had to wait for a token slept for the shortfall but
+  left `_last_refill` at its pre-sleep reading, so the interval it had just
+  slept through was credited again as refill to the next caller — every second
+  acquisition came back for free. The limiter guards every Discord REST call
+  (send, edit, reactions, uploads) at a default 30 req/s, so a busy session
+  could push ~60 req/s and collect exactly the 429s the limiter exists to
+  avoid. The refill clock now moves past the wait it just paid for.
+
 - `ApprovalQueue.wait()` could leave an approval pending forever after its full
   default timeout had elapsed. The wait deadline was measured on the monotonic
   clock but the "has the approval's lifespan expired?" check re-read

--- a/src/agentos/channels/_util.py
+++ b/src/agentos/channels/_util.py
@@ -146,7 +146,13 @@ class RateLimiter:
             if self._tokens < 1.0:
                 wait = (1.0 - self._tokens) / self.refill_rate
                 await asyncio.sleep(wait)
+                # The waiter drains exactly the token that accrued while it
+                # slept, so the refill clock has to move past the sleep too.
+                # Leaving ``_last_refill`` at the pre-sleep reading credits
+                # that same interval again to the next caller, which lets the
+                # bucket sustain ~2x ``refill_rate`` under contention.
                 self._tokens = 0.0
+                self._last_refill = time.monotonic()
             else:
                 self._tokens -= 1.0
 

--- a/tests/test_channels/test_channel_rate_limiter.py
+++ b/tests/test_channels/test_channel_rate_limiter.py
@@ -1,0 +1,78 @@
+"""``RateLimiter`` token-bucket accounting at the utility boundary.
+
+The limiter guards every Discord REST call, so the contract that matters is
+the sustained rate it admits under contention — not just that a waiter sleeps.
+Time is virtualised rather than measured: a wall-clock assertion on a 0.1s
+interval is exactly the shape that turns into a Windows-only flake when the
+system clock ticks at ~15.6ms.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from agentos.channels import _util
+from agentos.channels._util import RateLimiter
+
+
+class _VirtualClock:
+    """A monotonic clock that only advances when a sleeper asks it to."""
+
+    def __init__(self) -> None:
+        self.now = 1_000.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+    async def sleep(self, delay: float) -> None:
+        self.now += delay
+
+
+@pytest.fixture
+def clock(monkeypatch: pytest.MonkeyPatch) -> _VirtualClock:
+    virtual = _VirtualClock()
+    monkeypatch.setattr(_util, "time", SimpleNamespace(monotonic=virtual.monotonic))
+    monkeypatch.setattr(_util, "asyncio", SimpleNamespace(sleep=virtual.sleep))
+    return virtual
+
+
+async def test_acquire_holds_the_configured_sustained_rate(clock: _VirtualClock) -> None:
+    """Every acquisition past the burst costs a full refill interval.
+
+    Regression: the waiter used to leave ``_last_refill`` at its pre-sleep
+    reading, so the interval it had just slept through was credited a second
+    time to the next caller and the bucket sustained ~2x ``refill_rate``.
+    """
+    limiter = RateLimiter(max_tokens=1, refill_rate=10.0)
+    start = clock.now
+
+    for _ in range(5):
+        await limiter.acquire()
+
+    # One token was in the bucket; the other four each cost 1/10s.
+    assert clock.now - start == pytest.approx(0.4)
+
+
+async def test_initial_burst_is_admitted_without_waiting(clock: _VirtualClock) -> None:
+    limiter = RateLimiter(max_tokens=3, refill_rate=10.0)
+    start = clock.now
+
+    for _ in range(3):
+        await limiter.acquire()
+
+    assert clock.now == start
+
+
+async def test_idle_refill_is_capped_at_max_tokens(clock: _VirtualClock) -> None:
+    limiter = RateLimiter(max_tokens=3, refill_rate=10.0)
+    clock.now += 100.0  # far more refill than the bucket can hold
+
+    for _ in range(3):
+        await limiter.acquire()
+    idle_end = clock.now
+
+    await limiter.acquire()
+
+    assert clock.now - idle_end == pytest.approx(0.1)


### PR DESCRIPTION
### Summary

`RateLimiter.acquire()` slept for a missing token but left `_last_refill` at its
pre-sleep reading, so the interval it had just slept through was credited again
as refill to the next caller. Every second acquisition came back for free and
the bucket sustained roughly 2x `refill_rate` under contention.

Measured on `main` with `max_tokens=1, refill_rate=10.0`: ten acquisitions in
0.556s (~18 req/s) where 10 req/s is the ceiling.

### Why it matters

`RateLimiter` throttles every Discord REST call — `DiscordChannel._rate_limiter`
is awaited at seven call sites (message send, stream edits, reactions, file
uploads) — at a default 30 req/s. The double credit lets a busy session push
~60 req/s and collect exactly the 429s the limiter exists to avoid, which then
accumulate in `FloodStrikeBackoff` and latch streaming into fallback mode.

### Changes

- `src/agentos/channels/_util.py`: the waiter now moves the refill clock past
  the wait it paid for, so that interval is accounted once.
- `tests/test_channels/test_channel_rate_limiter.py`: first coverage for
  `RateLimiter` — sustained rate under contention (the regression), the initial
  burst, and the idle-refill cap.

The regression test virtualises the monotonic clock instead of measuring wall
time. An assertion on a 0.1s interval is exactly the shape that turns into a
Windows-only flake at a ~15.6ms clock tick — the failure mode fixed in 9d969a5e
— so the clock only advances when the limiter sleeps and the arithmetic is
exact. It reports 0.2s against the previous implementation where 0.4s is
correct.

### Verification

```
uv run pytest tests/test_channels -q          # 532 passed
uv run ruff check src tests                   # All checks passed
uv run mypy src/agentos --show-error-codes    # Success: no issues found in 625 source files
```

Fixes #1876
