### PR TITLE
fix(session): match on session_key in search_transcript and session_search (#1801)

### DIFF
--- a/src/agentos/session/storage.py
+++ b/src/agentos/session/storage.py
@@ -32,9 +32,7 @@ def _serialized_write[**P, R](
     """Hold transaction ownership for a complete mutating storage call."""
 
     @wraps(method)
-    async def wrapped(
-        self: SessionStorage, /, *args: P.args, **kwargs: P.kwargs
-    ) -> R:
+    async def wrapped(self: SessionStorage, /, *args: P.args, **kwargs: P.kwargs) -> R:
         async with self._write_lock:
             try:
                 return await method(self, *args, **kwargs)
@@ -132,15 +130,12 @@ CREATE TABLE IF NOT EXISTS projects (
 )
 """
 
-_CREATE_IDX_PROJECTS_AGENT = (
-    "CREATE INDEX IF NOT EXISTS idx_projects_agent ON projects(agent_id)"
-)
+_CREATE_IDX_PROJECTS_AGENT = "CREATE INDEX IF NOT EXISTS idx_projects_agent ON projects(agent_id)"
 
 # Backstop for the advisory Python-side name check (closes the concurrent
 # create race). NOCASE folds ASCII only; the casefold check stays primary.
 _CREATE_UNIQUE_IDX_PROJECTS_NAME = (
-    "CREATE UNIQUE INDEX IF NOT EXISTS idx_projects_name_nocase "
-    "ON projects(name COLLATE NOCASE)"
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_projects_name_nocase ON projects(name COLLATE NOCASE)"
 )
 
 _CREATE_IDX_SESSIONS_PROJECT = (
@@ -517,15 +512,11 @@ class SessionStorage:
             )
             await self._conn.commit()
         # Defensive: zero-out any NULL epoch rows left by a partial migration.
-        async with self._conn.execute(
-            "SELECT COUNT(*) FROM sessions WHERE epoch IS NULL"
-        ) as cur:
+        async with self._conn.execute("SELECT COUNT(*) FROM sessions WHERE epoch IS NULL") as cur:
             row = await cur.fetchone()
         null_count = row[0] if row else 0
         if null_count > 0:
-            await self._conn.execute(
-                "UPDATE sessions SET epoch = 0 WHERE epoch IS NULL"
-            )
+            await self._conn.execute("UPDATE sessions SET epoch = 0 WHERE epoch IS NULL")
             await self._conn.commit()
 
     async def _migrate_transcript_reasoning_content_column(self) -> None:
@@ -545,9 +536,7 @@ class SessionStorage:
         async with self._conn.execute("PRAGMA table_info(transcript_entries)") as cur:
             columns = [row[1] for row in await cur.fetchall()]
         if "turn_usage" not in columns:
-            await self._conn.execute(
-                "ALTER TABLE transcript_entries ADD COLUMN turn_usage TEXT"
-            )
+            await self._conn.execute("ALTER TABLE transcript_entries ADD COLUMN turn_usage TEXT")
             await self._conn.commit()
 
     async def _migrate_summary_metadata_columns(self) -> None:
@@ -580,8 +569,7 @@ class SessionStorage:
             "tokens_before": "ALTER TABLE session_summaries ADD COLUMN tokens_before INTEGER",
             "tokens_after": "ALTER TABLE session_summaries ADD COLUMN tokens_after INTEGER",
             "removed_count": (
-                "ALTER TABLE session_summaries ADD COLUMN "
-                "removed_count INTEGER NOT NULL DEFAULT 0"
+                "ALTER TABLE session_summaries ADD COLUMN removed_count INTEGER NOT NULL DEFAULT 0"
             ),
             "kept_count": (
                 "ALTER TABLE session_summaries ADD COLUMN kept_count INTEGER NOT NULL DEFAULT 0"
@@ -611,9 +599,7 @@ class SessionStorage:
             "coverage_turn_id": (
                 "ALTER TABLE memory_durable_receipts ADD COLUMN coverage_turn_id TEXT"
             ),
-            "coverage_hash": (
-                "ALTER TABLE memory_durable_receipts ADD COLUMN coverage_hash TEXT"
-            ),
+            "coverage_hash": ("ALTER TABLE memory_durable_receipts ADD COLUMN coverage_hash TEXT"),
             "coverage_entry_count": (
                 "ALTER TABLE memory_durable_receipts ADD COLUMN coverage_entry_count INTEGER"
             ),
@@ -918,9 +904,7 @@ class SessionStorage:
                 "UPDATE sessions SET project_id = NULL WHERE project_id = ?",
                 (project_id,),
             )
-            await self.conn.execute(
-                "DELETE FROM projects WHERE project_id = ?", (project_id,)
-            )
+            await self.conn.execute("DELETE FROM projects WHERE project_id = ?", (project_id,))
             await self.conn.commit()
         except Exception:
             await self.conn.rollback()
@@ -1012,8 +996,7 @@ class SessionStorage:
         where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
         params += [limit, offset]
         sql = (
-            f"SELECT * FROM agent_tasks {where} "
-            "ORDER BY created_at ASC, rowid ASC LIMIT ? OFFSET ?"
+            f"SELECT * FROM agent_tasks {where} ORDER BY created_at ASC, rowid ASC LIMIT ? OFFSET ?"
         )
         async with self.conn.execute(sql, params) as cur:
             rows = await cur.fetchall()
@@ -1112,9 +1095,7 @@ class SessionStorage:
         allowed = set(MemoryDurableReceipt.model_fields) - {"receipt_id", "created_at"}
         unknown = sorted(set(fields) - allowed)
         if unknown:
-            raise ValueError(
-                f"Unknown memory durable receipt fields: {', '.join(unknown)}"
-            )
+            raise ValueError(f"Unknown memory durable receipt fields: {', '.join(unknown)}")
         if "session_key" in fields:
             fields["session_key"] = canonicalize_session_key(fields["session_key"])
         fields.setdefault("updated_at", _now_ms())
@@ -1229,7 +1210,7 @@ class SessionStorage:
                 raise StaleEpochError(
                     f"Epoch mismatch for {entry.session_key}: "
                     f"expected {expected_epoch}, got {actual}"
-            )
+                )
             await self.conn.commit()
         else:
             sql = f"INSERT INTO transcript_entries ({', '.join(cols)}) VALUES ({placeholders})"
@@ -1306,9 +1287,7 @@ class SessionStorage:
             ORDER BY created_at ASC, id ASC
             LIMIT ? OFFSET ?
         """
-        async with self.conn.execute(
-            sql, (session_id, session_id, limit_val, offset)
-        ) as cur:
+        async with self.conn.execute(sql, (session_id, session_id, limit_val, offset)) as cur:
             rows = await cur.fetchall()
         return [TranscriptEntry(**_deserialize_row(dict(r))) for r in rows]
 
@@ -1383,9 +1362,7 @@ class SessionStorage:
             row = await cur.fetchone()
         return row[0] if row else 0
 
-    async def count_transcript_entries_batch(
-        self, session_ids: list[str]
-    ) -> dict[str, int]:
+    async def count_transcript_entries_batch(self, session_ids: list[str]) -> dict[str, int]:
         """Count transcript entries for many sessions in one round trip.
 
         Used by ``sessions.list`` (rpc_sessions.py) to avoid the N+1 pattern
@@ -1548,9 +1525,7 @@ class SessionStorage:
                 node=node,
                 entries=archived_entries or [],
                 compaction_id=summary.compaction_id if summary is not None else None,
-                compaction_index=summary.compaction_index
-                if summary is not None
-                else None,
+                compaction_index=summary.compaction_index if summary is not None else None,
             )
 
             await self.conn.execute(
@@ -1727,9 +1702,7 @@ class SessionStorage:
     # ── SessionContextState CRUD ─────────────────────────────────────────────
 
     @_serialized_write
-    async def save_context_state(
-        self, state: SessionContextState
-    ) -> SessionContextState:
+    async def save_context_state(self, state: SessionContextState) -> SessionContextState:
         """Persist portable or provider-native context state for later replay."""
         state.session_key = canonicalize_session_key(state.session_key)
         data = state.model_dump(exclude={"id"})
@@ -1737,8 +1710,7 @@ class SessionStorage:
         placeholders = ", ".join("?" for _ in cols)
         values = [_serialize(data[c]) for c in cols]
         async with self.conn.execute(
-            "INSERT INTO session_context_states "
-            f"({', '.join(cols)}) VALUES ({placeholders})",
+            f"INSERT INTO session_context_states ({', '.join(cols)}) VALUES ({placeholders})",
             values,
         ) as cur:
             state.id = cur.lastrowid
@@ -1766,8 +1738,7 @@ class SessionStorage:
             clauses.append("valid = 1")
         where = " AND ".join(clauses)
         async with self.conn.execute(
-            "SELECT * FROM session_context_states "
-            f"WHERE {where} ORDER BY created_at ASC, id ASC",
+            f"SELECT * FROM session_context_states WHERE {where} ORDER BY created_at ASC, id ASC",
             params,
         ) as cur:
             rows = await cur.fetchall()
@@ -1824,14 +1795,18 @@ class SessionStorage:
         self,
         query: str,
         session_id: str | None = None,
+        session_key: str | None = None,
         limit: int = 20,
         project_id: str | None = None,
     ) -> list[dict[str, Any]]:
         """Full-text search across transcript entries.
 
-        ``project_id`` restricts hits to transcripts of sessions in that
-        project. Returns dicts with: id, session_key, role, snippet,
-        created_at.
+        ``session_key`` restricts hits to a specific session by its
+        human-readable key (indexed on ``transcript_entries.session_key``).
+        ``session_id`` is kept for backward compatibility but ``session_key``
+        takes precedence when both are supplied.  ``project_id`` restricts
+        hits to transcripts of sessions in that project.  Returns dicts with:
+        id, session_key, role, snippet, created_at.
         """
         safe_q = self.sanitize_fts_query(query)
         if safe_q == '""':
@@ -1840,7 +1815,10 @@ class SessionStorage:
         clauses = ["f.content MATCH ?"]
         params: list[Any] = [safe_q]
         joins = ""
-        if session_id:
+        if session_key:
+            clauses.append("t.session_key = ?")
+            params.append(session_key)
+        elif session_id:
             clauses.append("t.session_id = ?")
             params.append(session_id)
         if project_id:

--- a/src/agentos/session/storage.py
+++ b/src/agentos/session/storage.py
@@ -1819,8 +1819,8 @@ class SessionStorage:
             clauses.append("t.session_key = ?")
             params.append(session_key)
         elif session_id:
-            clauses.append("t.session_id = ?")
-            params.append(session_id)
+            clauses.append("(t.session_id = ? OR t.session_key = ?)")
+            params.extend([session_id, session_id])
         if project_id:
             joins = "JOIN sessions s ON s.session_id = t.session_id "
             clauses.append("s.project_id = ?")

--- a/src/agentos/tools/builtin/session_search.py
+++ b/src/agentos/tools/builtin/session_search.py
@@ -55,6 +55,10 @@ def create_session_search_tool(
                     "(e.g. 'agent:main:webchat:abc123')."
                 ),
             },
+            "session_id": {
+                "type": "string",
+                "description": ("Optional: legacy alias for session key."),
+            },
             "scope": {
                 "type": "string",
                 "enum": ["all", "project"],
@@ -75,6 +79,8 @@ def create_session_search_tool(
     async def session_search(
         query: str,
         session: str | None = None,
+        session_id: str | None = None,
+        session_key: str | None = None,
         scope: str = "all",
         limit: int = 20,
     ) -> str:
@@ -89,9 +95,9 @@ def create_session_search_tool(
         project_id: str | None = None
         if scope == "project":
             ctx = current_tool_context.get()
-            session_key = getattr(ctx, "session_key", None) if ctx else None
-            session = await active_storage.get_session(session_key) if session_key else None
-            project_id = getattr(session, "project_id", None) if session else None
+            ctx_key = getattr(ctx, "session_key", None) if ctx else None
+            caller_session = await active_storage.get_session(ctx_key) if ctx_key else None
+            project_id = getattr(caller_session, "project_id", None) if caller_session else None
             if not project_id:
                 return json.dumps(
                     {
@@ -101,10 +107,11 @@ def create_session_search_tool(
                     }
                 )
 
+        target_session = session or session_key or session_id
         try:
             results = await active_storage.search_transcript(
                 query=query,
-                session_key=session,
+                session_key=target_session,
                 limit=limit,
                 project_id=project_id,
             )

--- a/src/agentos/tools/builtin/session_search.py
+++ b/src/agentos/tools/builtin/session_search.py
@@ -48,9 +48,12 @@ def create_session_search_tool(
                 "type": "string",
                 "description": "Search query - natural language terms to find in transcripts.",
             },
-            "session_id": {
+            "session": {
                 "type": "string",
-                "description": "Optional: restrict search to a specific session ID.",
+                "description": (
+                    "Optional: restrict search to a specific session key "
+                    "(e.g. 'agent:main:webchat:abc123')."
+                ),
             },
             "scope": {
                 "type": "string",
@@ -71,7 +74,7 @@ def create_session_search_tool(
     )
     async def session_search(
         query: str,
-        session_id: str | None = None,
+        session: str | None = None,
         scope: str = "all",
         limit: int = 20,
     ) -> str:
@@ -101,7 +104,7 @@ def create_session_search_tool(
         try:
             results = await active_storage.search_transcript(
                 query=query,
-                session_id=session_id,
+                session_key=session,
                 limit=limit,
                 project_id=project_id,
             )

--- a/tests/test_session/test_search_transcript_session_key.py
+++ b/tests/test_session/test_search_transcript_session_key.py
@@ -1,0 +1,99 @@
+"""Test that session_search / search_transcript filters by session_key (#1801)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agentos.session.manager import SessionManager
+from agentos.session.storage import SessionStorage
+from agentos.tools.builtin.session_search import create_session_search_tool
+from agentos.tools.registry import ToolRegistry
+
+
+@pytest.mark.asyncio
+async def test_search_transcript_filters_by_session_key() -> None:
+    """search_transcript must return results when filtered by session_key.
+
+    Regression test for #1801.
+    """
+    storage = SessionStorage(":memory:")
+    await storage.connect()
+    try:
+        manager = SessionManager(storage)
+        s1 = await manager.create("agent:main:chat_1")
+        s2 = await manager.create("agent:main:chat_2")
+
+        # Insert transcript entries via manager (correct API)
+        await manager.append_message(
+            s1.session_key, role="user", content="deployed to production"
+        )
+        await manager.append_message(
+            s2.session_key, role="user", content="deployed to staging"
+        )
+
+        # Search without session filter — should find both
+        all_hits = await storage.search_transcript("deployed")
+        assert len(all_hits) == 2
+
+        # Search filtered by session_key — should find only session 1
+        key_hits = await storage.search_transcript(
+            "deployed", session_key="agent:main:chat_1"
+        )
+        assert len(key_hits) == 1
+        assert key_hits[0]["session_key"] == "agent:main:chat_1"
+
+        # Search filtered by session_id (backward compat) — should also work
+        id_hits = await storage.search_transcript(
+            "deployed", session_id=s1.session_id
+        )
+        assert len(id_hits) == 1
+        assert id_hits[0]["session_key"] == "agent:main:chat_1"
+
+        # session_key takes precedence over session_id when both provided
+        both_hits = await storage.search_transcript(
+            "deployed",
+            session_id=s2.session_id,
+            session_key="agent:main:chat_1",
+        )
+        assert len(both_hits) == 1
+        assert both_hits[0]["session_key"] == "agent:main:chat_1"
+    finally:
+        await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_session_search_tool_uses_session_key_filter() -> None:
+    """session_search tool must filter by session_key (not session_id).
+
+    Regression test for #1801.
+    """
+    storage = SessionStorage(":memory:")
+    await storage.connect()
+    try:
+        manager = SessionManager(storage)
+        s1 = await manager.create("agent:main:chat_1")
+        s2 = await manager.create("agent:main:chat_2")
+
+        await manager.append_message(
+            s1.session_key, role="user", content="quantum widget blueprint"
+        )
+        await manager.append_message(
+            s2.session_key, role="user", content="quantum widget prototype"
+        )
+
+        registry = ToolRegistry()
+        create_session_search_tool(storage, registry=registry)
+        registered = registry.get("session_search")
+        assert registered is not None
+
+        # Search with session filter using session_key
+        result_json = await registered.handler(
+            query="quantum widget", session="agent:main:chat_1"
+        )
+        result = json.loads(result_json)
+        assert result["result_count"] == 1
+        assert result["results"][0]["session_key"] == "agent:main:chat_1"
+    finally:
+        await storage.close()

--- a/tests/test_session/test_search_transcript_session_key.py
+++ b/tests/test_session/test_search_transcript_session_key.py
@@ -26,28 +26,20 @@ async def test_search_transcript_filters_by_session_key() -> None:
         s2 = await manager.create("agent:main:chat_2")
 
         # Insert transcript entries via manager (correct API)
-        await manager.append_message(
-            s1.session_key, role="user", content="deployed to production"
-        )
-        await manager.append_message(
-            s2.session_key, role="user", content="deployed to staging"
-        )
+        await manager.append_message(s1.session_key, role="user", content="deployed to production")
+        await manager.append_message(s2.session_key, role="user", content="deployed to staging")
 
         # Search without session filter — should find both
         all_hits = await storage.search_transcript("deployed")
         assert len(all_hits) == 2
 
         # Search filtered by session_key — should find only session 1
-        key_hits = await storage.search_transcript(
-            "deployed", session_key="agent:main:chat_1"
-        )
+        key_hits = await storage.search_transcript("deployed", session_key="agent:main:chat_1")
         assert len(key_hits) == 1
         assert key_hits[0]["session_key"] == "agent:main:chat_1"
 
         # Search filtered by session_id (backward compat) — should also work
-        id_hits = await storage.search_transcript(
-            "deployed", session_id=s1.session_id
-        )
+        id_hits = await storage.search_transcript("deployed", session_id=s1.session_id)
         assert len(id_hits) == 1
         assert id_hits[0]["session_key"] == "agent:main:chat_1"
 
@@ -89,11 +81,17 @@ async def test_session_search_tool_uses_session_key_filter() -> None:
         assert registered is not None
 
         # Search with session filter using session_key
-        result_json = await registered.handler(
-            query="quantum widget", session="agent:main:chat_1"
-        )
+        result_json = await registered.handler(query="quantum widget", session="agent:main:chat_1")
         result = json.loads(result_json)
         assert result["result_count"] == 1
         assert result["results"][0]["session_key"] == "agent:main:chat_1"
+
+        # Search with session_id alias
+        result_alias_json = await registered.handler(
+            query="quantum widget", session_id="agent:main:chat_2"
+        )
+        result_alias = json.loads(result_alias_json)
+        assert result_alias["result_count"] == 1
+        assert result_alias["results"][0]["session_key"] == "agent:main:chat_2"
     finally:
         await storage.close()


### PR DESCRIPTION
### Summary

Fixes #1801

`search_transcript` filtered on `t.session_id` (the internal UUID), but `session_search` and all user/model-facing session tools expose `session_key`. As a result, the model or caller had no way to supply a valid `session_id`, making scoped transcript searches for a specific session return 0 matches.

### Key Changes
- **Storage:** Added `session_key: str | None = None` parameter to [search_transcript](file:///src/agentos/session/storage.py) in `src/agentos/session/storage.py` filtering on `t.session_key = ?` (indexed).
- **Tool:** Updated [session_search](file:///src/agentos/tools/builtin/session_search.py) parameter definition and docs to accept `session` (or `session_id` for backwards compatibility) and pass it as `session_key` to `search_transcript`.
- **Tests:** Added comprehensive regression tests in `tests/test_session/test_search_transcript_session_key.py`.

### Verification
- `uv run pytest tests/test_session/test_search_transcript_session_key.py -q` (all passed)
- `uv run pytest tests/test_session/test_projects.py -q` (all passed)
- `uv run ruff check` & `uv run ruff format --check` passed
