### PR TITLE
fix(tools): delegate spawned_by filter to list_sessions to avoid truncation (#1799)

### DIFF
--- a/src/agentos/tools/builtin/agents.py
+++ b/src/agentos/tools/builtin/agents.py
@@ -126,12 +126,7 @@ async def subagents(
             if current_key is None:
                 log.warning("subagents.list_no_session_context")
                 return json.dumps({"action": "list", "subagents": []})
-            all_sessions = await mgr.list_sessions()
-            subs = [
-                s
-                for s in all_sessions
-                if isinstance(s, dict) and s.get("spawned_by") == current_key
-            ]
+            subs = await mgr.list_sessions(spawned_by=current_key)
             return json.dumps({"action": "list", "subagents": subs})
         except (ImportError, AttributeError, NotImplementedError) as exc:
             raise _manager_unavailable() from exc

--- a/tests/test_tools/test_subagents_list_truncation.py
+++ b/tests/test_tools/test_subagents_list_truncation.py
@@ -1,0 +1,113 @@
+"""Test that subagents(action='list') delegates spawned_by filter to SQL (#1799)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agentos.tools.builtin import agents as agents_tool
+from agentos.tools.builtin import sessions as sessions_tool
+from agentos.tools.types import CallerKind, ToolContext, current_tool_context
+
+
+class _StubManager:
+    """Session manager with >100 sessions to demonstrate truncation fix."""
+
+    def __init__(self, n_extra: int = 120) -> None:
+        self._sessions: list[dict] = []
+        # Create n_extra filler sessions (no spawned_by)
+        for i in range(n_extra):
+            self._sessions.append(
+                {
+                    "session_key": f"agent:main:filler:{i:04d}",
+                    "spawned_by": None,
+                    "status": "completed",
+                }
+            )
+        # The subagent we care about — placed AFTER the filler
+        self._sessions.append(
+            {
+                "session_key": "agent:main:child_session",
+                "spawned_by": "agent:main:parent_session",
+                "status": "running",
+            }
+        )
+
+    async def get_current_session(self):
+        return None
+
+    async def list_sessions(self, **kwargs):
+        sb = kwargs.get("spawned_by")
+        if sb is not None:
+            return [s for s in self._sessions if s.get("spawned_by") == sb]
+        # Simulate the old default limit=100 truncation
+        limit = kwargs.get("limit", 100)
+        return self._sessions[:limit]
+
+    async def get_session(self, session_key: str):
+        for s in self._sessions:
+            if s["session_key"] == session_key:
+                return s
+        return None
+
+    async def kill_session(self, session_key: str) -> None:
+        pass
+
+    async def inject_message(self, session_key: str, message: str, provenance: str) -> None:
+        pass
+
+
+def _ctx(session_key: str) -> ToolContext:
+    return ToolContext(
+        caller_kind=CallerKind.AGENT,
+        session_key=session_key,
+        agent_id="main",
+    )
+
+
+@pytest.fixture
+def stub_manager():
+    mgr = _StubManager(n_extra=120)
+    sessions_tool.set_session_manager(mgr)
+    sessions_tool.set_task_runtime(None)
+    yield mgr
+    sessions_tool.set_session_manager(None)
+    sessions_tool.set_task_runtime(None)
+
+
+@pytest.mark.asyncio
+async def test_subagents_list_finds_child_beyond_100_sessions(
+    stub_manager: _StubManager,
+) -> None:
+    """subagents(action='list') must find spawned subagents even when
+    >100 total sessions exist.
+
+    Before the fix, list_sessions() was called without spawned_by, defaulting
+    to limit=100 and filtering in Python — silently dropping the child.
+
+    Regression test for #1799.
+    """
+    token = current_tool_context.set(_ctx("agent:main:parent_session"))
+    try:
+        payload = json.loads(await agents_tool.subagents("list"))
+    finally:
+        current_tool_context.reset(token)
+
+    assert payload["action"] == "list"
+    keys = [s["session_key"] for s in payload["subagents"]]
+    assert "agent:main:child_session" in keys
+
+
+@pytest.mark.asyncio
+async def test_subagents_list_empty_when_no_children(
+    stub_manager: _StubManager,
+) -> None:
+    """A parent with no spawned children returns an empty list."""
+    token = current_tool_context.set(_ctx("agent:main:no_children_here"))
+    try:
+        payload = json.loads(await agents_tool.subagents("list"))
+    finally:
+        current_tool_context.reset(token)
+
+    assert payload == {"action": "list", "subagents": []}

--- a/tests/test_tools/test_subagents_ownership.py
+++ b/tests/test_tools/test_subagents_ownership.py
@@ -19,11 +19,15 @@ class _StubSessionManager:
     async def get_current_session(self):
         return None
 
-    async def list_sessions(self):
-        return [
+    async def list_sessions(self, **kwargs):
+        all_sessions = [
             {"session_key": "sub-legacy", "spawned_by": None, "status": "running"},
             {"session_key": "sub-owned", "spawned_by": "agent:main:parent", "status": "running"},
         ]
+        sb = kwargs.get("spawned_by")
+        if sb is not None:
+            return [s for s in all_sessions if s.get("spawned_by") == sb]
+        return all_sessions
 
     async def get_session(self, session_key: str):
         self.get_session_calls.append(session_key)
@@ -38,7 +42,7 @@ class _StubSessionManager:
 
 def _ctx(session_key: str | None) -> ToolContext:
     return ToolContext(
-                caller_kind=CallerKind.AGENT,
+        caller_kind=CallerKind.AGENT,
         session_key=session_key,
         agent_id="main",
     )


### PR DESCRIPTION
### Summary

Fixes #1799

In `subagents(action="list")`, `mgr.list_sessions()` was previously invoked without parameters. It fetched the default limit of 100 sessions and then filtered by `spawned_by == current_key` in Python. On gateways with >100 total sessions, child subagents that fell beyond the first 100 records were silently excluded from the listing.

### Key Changes
- **Tools:** In [agents.py](file:///src/agentos/tools/builtin/agents.py), delegated the `spawned_by` filter directly to the database query: `await mgr.list_sessions(spawned_by=current_key)` rather than post-filtering in Python.
- **Tests:**
  - Updated `_StubSessionManager` in `tests/test_tools/test_subagents_ownership.py` to accept and filter on `spawned_by`.
  - Added dedicated regression test `tests/test_tools/test_subagents_list_truncation.py` simulating 120 filler sessions to ensure subagents beyond 100 entries are returned.

### Verification
- `uv run pytest tests/test_tools/test_subagents_ownership.py tests/test_tools/test_subagents_list_truncation.py -q` (all passed)
- `uv run pytest tests/test_tools/ -q` (1178 passed)
- `uv run mypy src/agentos/tools/builtin/agents.py --show-error-codes` (no issues found)
- `uv run ruff check` & `uv run ruff format --check` passed
