### PR TITLE
fix(persistence): close the lock-window race in apply_pending's migration check

### DIFF
--- a/src/agentos/persistence/migrator.py
+++ b/src/agentos/persistence/migrator.py
@@ -86,12 +86,22 @@ def apply_pending(db_url: str, migrations_dir: Path) -> list[str]:
     try:
         with _yoyo_utf8_open():
             migrations = read_migrations(str(path))
-            pending = backend.to_apply(migrations)
-            ids = [m.id for m in pending]
-            if not ids:
-                return []
-
+            # to_apply() and apply_migrations() must run under the same lock
+            # acquisition: backend.lock() only serializes what happens inside
+            # it, and if to_apply() ran before the lock was even requested, a
+            # sibling process that fully completed its own apply_pending()
+            # call while we were waiting for the lock is invisible to us --
+            # we would still be holding a stale "pending" list and attempt to
+            # re-apply migrations that already landed. yoyo's apply_one()
+            # does not re-check whether a migration is already applied before
+            # running it, so that isn't caught downstream either; it's this
+            # caller's job to keep the read and the apply inside one critical
+            # section.
             with backend.lock():
+                pending = backend.to_apply(migrations)
+                ids = [m.id for m in pending]
+                if not ids:
+                    return []
                 backend.apply_migrations(pending)
         log.info("migrator.applied", extra={"count": len(ids), "ids": ids})
         return ids

--- a/tests/test_persistence/test_migrator.py
+++ b/tests/test_persistence/test_migrator.py
@@ -27,6 +27,76 @@ def test_apply_pending_registers_python312_datetime_adapter(tmp_path: Path) -> N
     assert applied == ["V001__demo"]
 
 
+def test_apply_pending_does_not_reapply_a_migration_a_sibling_process_just_landed(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Regression test: to_apply() and apply_migrations() must run under the
+    same lock acquisition.
+
+    backend.lock() only serializes what happens *inside* it -- it does not
+    retroactively invalidate a ``pending`` list computed before the lock was
+    even requested. If two processes boot concurrently against the same
+    database (multiple workers, a rolling restart sharing a volume), both
+    can compute the same stale ``pending`` list before either acquires the
+    lock; the second one to get the lock would then blindly try to
+    re-apply what the first already committed, since yoyo's apply_one()
+    does not re-check applied state before running. This simulates that:
+    the fake lock() applies a "sibling's" migration as a side effect of
+    being entered, standing in for a sibling process that finished its own
+    full apply_pending() cycle while we were blocked waiting for the lock.
+    """
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    (migrations_dir / "V001__demo.py").write_text(
+        "from yoyo import step\n"
+        "__depends__ = set()\n"
+        "steps = [step('CREATE TABLE demo (id INTEGER PRIMARY KEY)')]\n",
+        encoding="utf-8",
+    )
+
+    class RacingBackend:
+        def __init__(self) -> None:
+            self.applied_ids: set[str] = set()
+            self.to_apply_calls = 0
+            self.apply_migrations_calls: list[list[str]] = []
+
+        def to_apply(self, migrations):
+            self.to_apply_calls += 1
+            return [m for m in migrations if m.id not in self.applied_ids]
+
+        @contextlib.contextmanager
+        def lock(self):
+            # Stand-in for: a sibling process fully completed its own
+            # apply_pending() -- read, apply, mark-applied -- while we were
+            # blocked waiting to acquire this same lock.
+            self.applied_ids.add("V001__demo")
+            yield
+
+        def apply_migrations(self, pending):
+            ids = [m.id for m in pending]
+            self.apply_migrations_calls.append(ids)
+            for m in pending:
+                if m.id in self.applied_ids:
+                    raise RuntimeError(
+                        f"attempted to re-apply {m.id!r}, already applied by a concurrent process"
+                    )
+            self.applied_ids.update(ids)
+
+        def close(self) -> None:
+            pass
+
+    backend = RacingBackend()
+    monkeypatch.setattr(migrator, "get_backend", lambda _url: backend)
+
+    applied = apply_pending(str(tmp_path / "demo.sqlite"), migrations_dir)
+
+    # to_apply() must see the sibling's already-applied migration and
+    # correctly exclude it -- not attempt to re-apply it and raise.
+    assert applied == []
+    assert backend.apply_migrations_calls == []
+    assert backend.to_apply_calls == 1
+
+
 def test_apply_pending_forces_utf8_when_yoyo_loads_python_migrations(
     tmp_path: Path, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Linked issue
Fixes #1881 
- [x] This pull request fully resolves the linked issue

## Summary
`apply_pending` computed `pending = backend.to_apply(migrations)` before
entering `with backend.lock():`. yoyo's DB-row-based advisory lock only
serializes what happens *inside* it -- it does not retroactively
invalidate a `pending` list computed before the lock was even requested.
Confirmed by reading yoyo's own source (`apply_one()` has no internal
`is_applied()` re-check before running a migration's steps and marking it
applied), so nothing downstream catches this either.

Concretely: two processes booting concurrently against the same SQLite
file -- a multi-worker deployment, or a rolling restart briefly sharing a
persistent volume -- can both compute the same stale `pending` list
before either acquires the lock. The second process to get the lock then
blindly attempts to re-apply what the first already committed: a hard
crash for a DDL migration ("duplicate column"), or silent data
duplication for a non-idempotent data migration.

## Alternatives considered
- Catching the resulting DDL error and treating it as already-applied:
  rejected -- papers over one specific symptom (DDL errors) while leaving
  non-idempotent data migrations vulnerable to silent duplication.
- Adding a separate OS-level file lock (fcntl) around the whole function:
  rejected -- redundant given yoyo already provides a DB-level lock for
  exactly this purpose ("Create a lock to prevent concurrent
  migrations"), and running two independent lock mechanisms in parallel
  risks them drifting out of sync for no benefit.

The chosen fix instead uses yoyo's own existing lock correctly: moving
`to_apply()` inside the same `with backend.lock():` block as
`apply_migrations()` closes the gap with the smallest possible change --
two lines reordered, no new locking primitive introduced.

## Fix
`to_apply()` and `apply_migrations()` now run inside the same lock
acquisition, so by the time `to_apply()` computes what's pending, it's
guaranteed to see the result of anything a sibling process already
committed and released the lock on.

## Tests
Added `test_apply_pending_does_not_reapply_a_migration_a_sibling_process_just_landed`:
a fake backend whose `lock()` applies a "sibling's" migration as a side
effect of being entered (standing in for a sibling process completing
its own full cycle while we were blocked waiting for the lock), then
asserts `to_apply()` correctly excludes it and `apply_migrations()` is
never even called. Verified this is a genuine regression test, not a
tautology, by reverting just the source fix and confirming the test
fails with exactly the predicted error (`RuntimeError: attempted to
re-apply 'V001__demo', already applied by a concurrent process`) against
the unfixed code, then passes again with the fix restored.

Ran: 
uv run ruff check src/agentos/persistence/migrator.py tests/test_persistence/test_migrator.py
uv run ruff format --check src/agentos/persistence/migrator.py tests/test_persistence/test_migrator.py
uv run mypy src/agentos/persistence/migrator.py --show-error-codes
uv run pytest tests/test_persistence/test_migrator.py -v

All clean: `ruff check` pass, `ruff format --check` pass, `mypy` 0
issues, pytest 3/3 (2 pre-existing tests unchanged + 1 new).

Third-party origin: none.