### PR TITLE
fix(channels): support target channel and composite id in Discord edit and delete (Closes #1883)

### DIFF
--- a/src/agentos/channels/discord.py
+++ b/src/agentos/channels/discord.py
@@ -506,7 +506,6 @@ class DiscordChannel:
             elif op == 11:  # Heartbeat ACK
                 self._state.last_heartbeat_ack = True
 
-
     async def _handle_dispatch(self, event_type: str | None, data: dict[str, Any]) -> None:
         if event_type == "READY":
             self._state.session_id = data["session_id"]
@@ -926,9 +925,7 @@ class DiscordChannel:
 
     def is_connected(self) -> bool:
         return (
-            self._connected
-            and self._dispatch_task is not None
-            and not self._dispatch_task.done()
+            self._connected and self._dispatch_task is not None and not self._dispatch_task.done()
         )
 
     async def health_check(self) -> ChannelHealth:
@@ -941,7 +938,6 @@ class DiscordChannel:
                 "sequence": self._state.sequence,
             },
         )
-
 
     # ------------------------------------------------------------------
     # Inbound
@@ -1244,40 +1240,53 @@ class DiscordChannel:
             provider_message_id=message_id,
         )
 
+    def _split_message_ref(self, message_id: str) -> tuple[str, str]:
+        channel_id, sep, raw_message_id = message_id.partition("|")
+        if sep:
+            return channel_id, raw_message_id
+        resolved_channel = self._sent_messages.get(message_id, self.config.default_channel_id)
+        if not resolved_channel:
+            raise ValueError(
+                "discord edit/delete requires '<channel_id>|<message_id>' "
+                "when default_channel_id is not configured"
+            )
+        return resolved_channel, message_id
+
     async def edit(self, message_id: str, content: str) -> ChannelSendResult:
         await self._rate_limiter.acquire()
         client = self._get_client()
-        channel_id = self._sent_messages.get(message_id, self.config.default_channel_id)
+        channel_id, raw_message_id = self._split_message_ref(message_id)
         resp = await retry_request(
             client.patch,
-            f"/channels/{channel_id}/messages/{message_id}",
+            f"/channels/{channel_id}/messages/{raw_message_id}",
             json={"content": content},
             headers=self._auth_headers(),
         )
         resp.raise_for_status()
-        log.debug("discord.edit", message_id=message_id)
+        log.debug("discord.edit", message_id=raw_message_id)
         return ChannelSendResult.sent(
             capability=ChannelCapabilities.EDIT,
             target_id=channel_id,
-            provider_message_id=message_id,
+            provider_message_id=raw_message_id,
         )
 
     async def delete(self, message_id: str) -> ChannelSendResult:
         await self._rate_limiter.acquire()
         client = self._get_client()
-        channel_id = self._sent_messages.get(message_id, self.config.default_channel_id)
+        channel_id, raw_message_id = self._split_message_ref(message_id)
         resp = await retry_request(
             client.delete,
-            f"/channels/{channel_id}/messages/{message_id}",
+            f"/channels/{channel_id}/messages/{raw_message_id}",
             headers=self._auth_headers(),
         )
         resp.raise_for_status()
+        self._sent_messages.pop(raw_message_id, None)
         self._sent_messages.pop(message_id, None)
-        log.debug("discord.delete", message_id=message_id)
+        log.debug("discord.delete", message_id=raw_message_id)
         return ChannelSendResult.sent(
             capability=ChannelCapabilities.DELETE,
             target_id=channel_id,
-            provider_message_id=message_id,
+            provider_message_id=raw_message_id,
         )
 
     # ------------------------------------------------------------------

--- a/src/agentos/tools/builtin/messaging.py
+++ b/src/agentos/tools/builtin/messaging.py
@@ -41,7 +41,7 @@ def _outgoing_metadata(channel: str, target: str, thread_id: str | None) -> dict
 
 
 def _delete_message_id(channel: str, target: str, message_id: str) -> str:
-    if channel == "telegram" and "|" not in message_id:
+    if channel in ("telegram", "discord") and "|" not in message_id and target:
         return f"{target}|{message_id}"
     return message_id
 

--- a/tests/test_channels/test_discord_edit_delete.py
+++ b/tests/test_channels/test_discord_edit_delete.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agentos.channels.discord import DiscordChannel, DiscordChannelConfig
+from agentos.tools.builtin.messaging import _channels, _delete_message_id, message
+
+
+def test_delete_message_id_encodes_target_for_discord() -> None:
+    res = _delete_message_id("discord", "111222333", "999888")
+    assert res == "111222333|999888"
+
+    # Preserves existing channel|msg
+    res_existing = _delete_message_id("discord", "111222333", "444555|999888")
+    assert res_existing == "444555|999888"
+
+    # Preserves bare id when target is empty
+    res_empty_target = _delete_message_id("discord", "", "999888")
+    assert res_empty_target == "999888"
+
+
+def test_discord_split_message_ref() -> None:
+    cfg = DiscordChannelConfig(token="fake_token", default_channel_id="chan_def")
+    channel = DiscordChannel(cfg)
+
+    # 1. Composite channel_id|message_id
+    assert channel._split_message_ref("chan_custom|msg_1") == ("chan_custom", "msg_1")
+
+    # 2. Tracked sent message
+    channel._sent_messages["msg_tracked"] = "chan_sent"
+    assert channel._split_message_ref("msg_tracked") == ("chan_sent", "msg_tracked")
+
+    # 3. Fallback to default_channel_id
+    assert channel._split_message_ref("msg_unknown") == ("chan_def", "msg_unknown")
+
+    # 4. Error when neither is available
+    channel_no_default = DiscordChannel(DiscordChannelConfig(token="fake_token"))
+    with pytest.raises(
+        ValueError, match="discord edit/delete requires '<channel_id>\\|<message_id>'"
+    ):
+        channel_no_default._split_message_ref("msg_untracked")
+
+
+@pytest.mark.asyncio
+async def test_discord_edit_with_composite_channel_ref() -> None:
+    channel = DiscordChannel(DiscordChannelConfig(token="fake_token"))
+
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+
+    mock_client = MagicMock()
+    mock_client.patch = AsyncMock(return_value=mock_resp)
+    channel._client = mock_client
+
+    # Edit using composite channel_id|message_id
+    result = await channel.edit("target_chan|msg_42", "updated content")
+
+    mock_client.patch.assert_awaited_with(
+        "/channels/target_chan/messages/msg_42",
+        json={"content": "updated content"},
+        headers=channel._auth_headers(),
+    )
+    assert result.target_id == "target_chan"
+    assert result.provider_message_id == "msg_42"
+
+
+@pytest.mark.asyncio
+async def test_discord_delete_with_composite_channel_ref() -> None:
+    channel = DiscordChannel(DiscordChannelConfig(token="fake_token"))
+
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+
+    mock_client = MagicMock()
+    mock_client.delete = AsyncMock(return_value=mock_resp)
+    channel._client = mock_client
+
+    channel._sent_messages["msg_42"] = "target_chan"
+
+    # Delete using composite channel_id|message_id
+    result = await channel.delete("target_chan|msg_42")
+
+    mock_client.delete.assert_awaited_with(
+        "/channels/target_chan/messages/msg_42",
+        headers=channel._auth_headers(),
+    )
+    assert result.target_id == "target_chan"
+    assert result.provider_message_id == "msg_42"
+    assert "msg_42" not in channel._sent_messages
+
+
+@pytest.mark.asyncio
+async def test_messaging_tool_delete_discord_honors_target() -> None:
+    channel = DiscordChannel(DiscordChannelConfig(token="fake_token"))
+
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+
+    mock_client = MagicMock()
+    mock_client.delete = AsyncMock(return_value=mock_resp)
+    channel._client = mock_client
+
+    _channels["discord"] = channel
+    try:
+        await message(
+            channel="discord",
+            target="target_guild_channel",
+            action="delete",
+            message_id="msg_999",
+        )
+        mock_client.delete.assert_awaited_with(
+            "/channels/target_guild_channel/messages/msg_999",
+            headers=channel._auth_headers(),
+        )
+    finally:
+        _channels.pop("discord", None)


### PR DESCRIPTION
### Summary
Fixes #1883

### Problem
1. When calling `DiscordChannel.edit` or `DiscordChannel.delete` for messages not currently present in the in-memory `_sent_messages` cache (e.g. across gateway restarts, or for incoming user messages), `channel_id` was resolved via `self._sent_messages.get(message_id, self.config.default_channel_id)`. Because `default_channel_id` defaults to `""`, the HTTP request was sent to `/channels//messages/{message_id}` (a malformed path with a double slash), failing with 404/400. Even when `default_channel_id` was set, untracked messages in any other channel would attempt to delete/edit from `default_channel_id`.
2. `DiscordChannel` had no support for composite message references like `<channel_id>|<message_id>` (unlike `TelegramChannel`).
3. In `src/agentos/tools/builtin/messaging.py`, `_delete_message_id` only encoded `target` for Telegram, discarding the `target` parameter when deleting Discord messages.

### Fix
- In `src/agentos/channels/discord.py`, added `_split_message_ref(message_id)` to partition composite `<channel_id>|<message_id>` references, falling back to `_sent_messages` or `default_channel_id`, or raising a clear `ValueError` when the channel cannot be resolved.
- Used `_split_message_ref` in `DiscordChannel.edit` and `DiscordChannel.delete`.
- In `src/agentos/tools/builtin/messaging.py`, updated `_delete_message_id` to include `"discord"`, encoding `f"{target}|{message_id}"` when a target is provided.
- Added comprehensive unit tests in `tests/test_channels/test_discord_edit_delete.py`.
