### PR TITLE
fix(gateway): accept max_messages alias in sessions.truncate

### DIFF
--- a/src/agentos/gateway/rpc_sessions.py
+++ b/src/agentos/gateway/rpc_sessions.py
@@ -430,7 +430,8 @@ def _require_max_messages(params: dict | None, default: int = 20) -> int:
     checkpoint/force safety check in the handler.
     """
 
-    value = (params or {}).get("maxMessages", default)
+    params_dict = params or {}
+    value = params_dict.get("maxMessages", params_dict.get("max_messages", default))
     if isinstance(value, bool):
         raise ValueError(_MAX_MESSAGES_ERROR)
     if not isinstance(value, int):

--- a/tests/test_gateway/test_rpc_sessions_truncate_validation.py
+++ b/tests/test_gateway/test_rpc_sessions_truncate_validation.py
@@ -134,3 +134,52 @@ async def test_default_is_used_when_max_messages_is_absent(dispatcher, ctx, mana
 
     assert res.ok is True
     assert manager.truncate_calls == [(SESSION_KEY, 20)]
+
+
+@pytest.mark.parametrize("value", [0, 1, 5, 50])
+def test_snake_case_max_messages_accepted(value: int) -> None:
+    assert _require_max_messages({"max_messages": value}) == value
+
+
+@pytest.mark.parametrize("value", [False, True, "20", 20.0, None, -1, [], {"a": 1}])
+def test_snake_case_max_messages_rejected(value: Any) -> None:
+    with pytest.raises(ValueError, match="params.maxMessages must be a non-negative integer"):
+        _require_max_messages({"max_messages": value})
+
+
+def test_camel_case_precedence_over_snake_case() -> None:
+    assert _require_max_messages({"maxMessages": 5, "max_messages": 10}) == 5
+
+
+@pytest.mark.asyncio
+async def test_snake_case_max_messages_truncates_correctly(dispatcher, ctx, manager) -> None:
+    res = await dispatcher.dispatch(
+        "r1",
+        "sessions.truncate",
+        {"key": SESSION_KEY, "max_messages": 5},
+        ctx,
+    )
+
+    assert res.ok is True
+    assert manager.truncate_calls == [(SESSION_KEY, 5)]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", [False, True, "5", -1])
+async def test_snake_case_bad_max_messages_rejects_and_truncates_nothing(
+    dispatcher, ctx, manager, value: Any
+) -> None:
+    manager.transcript = [object(), object(), object()]
+
+    res = await dispatcher.dispatch(
+        "r1",
+        "sessions.truncate",
+        {"key": SESSION_KEY, "max_messages": value},
+        ctx,
+    )
+
+    assert res.ok is False
+    assert res.error.code == "INVALID_REQUEST"
+    assert res.error.message == "params.maxMessages must be a non-negative integer"
+    assert manager.truncate_calls == []
+


### PR DESCRIPTION
Closes #1886

### Description
In `src/agentos/gateway/rpc_sessions.py`, `_require_max_messages` previously only checked for camelCase `maxMessages`. When a caller invoked `sessions.truncate` with snake_case `{"max_messages": 5}`, the parameter was ignored and silently defaulted to `20`, truncating the session to 20 messages instead of 5. Furthermore, invalid values passed under `max_messages` bypassed validation checks and defaulted to 20.

This PR updates `_require_max_messages` to accept `max_messages` when `maxMessages` is not provided (while preserving camelCase precedence if both are passed), ensuring consistent behavior with other Gateway RPC methods.

### Changes
- Updated `_require_max_messages` in `src/agentos/gateway/rpc_sessions.py` to read `params.get("maxMessages", params.get("max_messages", default))`.
- Added unit and handler tests in `tests/test_gateway/test_rpc_sessions_truncate_validation.py` asserting snake_case acceptance, precedence, and validation rejection.

### Validation
- `uv run pytest tests/test_gateway/test_rpc_sessions_truncate_validation.py -v` (38/38 passed)
- `uv run ruff check src/agentos/gateway/rpc_sessions.py tests/test_gateway/test_rpc_sessions_truncate_validation.py`
