### PR TITLE
fix(skills): validate sheet title in edit_xlsx rename_sheet

### DIFF
--- a/src/agentos/skills/bundled/xlsx/scripts/edit_xlsx.py
+++ b/src/agentos/skills/bundled/xlsx/scripts/edit_xlsx.py
@@ -102,15 +102,27 @@ def apply_ops(wb: Any, ops: list[dict[str, Any]]) -> int:
         elif kind == "rename_sheet":
             old = op.get("old")
             new = op.get("new")
-            if old in wb.sheetnames and isinstance(new, str):
-                wb[old].title = new
-                applied += 1
+            if (
+                old in wb.sheetnames
+                and isinstance(new, str)
+                and new.strip()
+                and not any(ch in new for ch in (":", "\\", "/", "?", "*", "[", "]"))
+                and new.strip() not in (s for s in wb.sheetnames if s != old)
+            ):
+                try:
+                    wb[old].title = new.strip()
+                    applied += 1
+                except (ValueError, KeyError):
+                    pass
         elif kind == "merge_cells":
             sheet_name = op.get("sheet")
             rng = op.get("range")
             if sheet_name in wb.sheetnames and isinstance(rng, str):
-                wb[sheet_name].merge_cells(rng)
-                applied += 1
+                try:
+                    wb[sheet_name].merge_cells(rng)
+                    applied += 1
+                except ValueError:
+                    pass
     return applied
 
 

--- a/tests/test_skill_xlsx.py
+++ b/tests/test_skill_xlsx.py
@@ -571,3 +571,109 @@ def test_clearing_a_cell_keeps_its_style(
     cell = load_workbook(str(out))["S"].cell(row=1, column=1)
     assert cell.value is None
     assert cell.number_format == "0.00%"
+
+
+@pytest.mark.parametrize(
+    "invalid_name",
+    [
+        "",
+        "   ",
+        "Invalid*Name",
+        "Invalid:Name",
+        "Invalid?Name",
+        "Invalid/Name",
+        "Invalid\\Name",
+        "Invalid[Name",
+        "Invalid]Name",
+    ],
+)
+def test_rename_sheet_skips_invalid_titles(
+    invalid_name: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    create_xlsx, edit_xlsx, _ = _import_scripts()
+    src = tmp_path / "book.xlsx"
+    create_xlsx.build({"sheets": [{"name": "Sales", "rows": [["ok"]]}]}).save(str(src))
+
+    out = tmp_path / "out.xlsx"
+    report = _run_cli(
+        edit_xlsx,
+        monkeypatch,
+        capsys,
+        src,
+        out,
+        [
+            {"op": "rename_sheet", "old": "Sales", "new": invalid_name},
+            {"op": "set_cell", "sheet": "Sales", "row": 1, "col": 2, "value": "added"},
+        ],
+        tmp_path,
+    )
+
+    assert report == {"applied": 1}
+    from openpyxl import load_workbook
+
+    wb = load_workbook(str(out))
+    assert "Sales" in wb.sheetnames
+    assert wb["Sales"].cell(row=1, column=2).value == "added"
+
+
+def test_rename_sheet_skips_existing_name_collision(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    create_xlsx, edit_xlsx, _ = _import_scripts()
+    src = tmp_path / "book.xlsx"
+    create_xlsx.build(
+        {"sheets": [{"name": "Sheet1", "rows": [["1"]]}, {"name": "Sheet2", "rows": [["2"]]}]}
+    ).save(str(src))
+
+    out = tmp_path / "out.xlsx"
+    report = _run_cli(
+        edit_xlsx,
+        monkeypatch,
+        capsys,
+        src,
+        out,
+        [
+            {"op": "rename_sheet", "old": "Sheet1", "new": "Sheet2"},
+            {"op": "set_cell", "sheet": "Sheet1", "row": 1, "col": 1, "value": "updated"},
+        ],
+        tmp_path,
+    )
+
+    assert report == {"applied": 1}
+    from openpyxl import load_workbook
+
+    wb = load_workbook(str(out))
+    assert wb.sheetnames == ["Sheet1", "Sheet2"]
+    assert wb["Sheet1"].cell(row=1, column=1).value == "updated"
+
+
+def test_merge_cells_skips_invalid_range(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    create_xlsx, edit_xlsx, _ = _import_scripts()
+    src = tmp_path / "book.xlsx"
+    create_xlsx.build({"sheets": [{"name": "S", "rows": [["a", "b"]]}]}).save(str(src))
+
+    out = tmp_path / "out.xlsx"
+    report = _run_cli(
+        edit_xlsx,
+        monkeypatch,
+        capsys,
+        src,
+        out,
+        [
+            {"op": "merge_cells", "sheet": "S", "range": "not-a-range"},
+            {"op": "set_cell", "sheet": "S", "row": 1, "col": 1, "value": "survives"},
+        ],
+        tmp_path,
+    )
+
+    assert report == {"applied": 1}
+    from openpyxl import load_workbook
+
+    wb = load_workbook(str(out))
+    assert wb["S"].cell(row=1, column=1).value == "survives"
+


### PR DESCRIPTION
Closes #1887

### Description
In `src/agentos/skills/bundled/xlsx/scripts/edit_xlsx.py`, the `rename_sheet` op previously assigned `wb[old].title = new` directly without validation or error handling. When an op supplied an empty/whitespace-only title or a title containing prohibited characters (`* : ? / \ [ ]`), openpyxl raised an unhandled `ValueError`, crashing the entire script with exit code 1 and aborting any remaining operations in the batch. Furthermore, renaming to an existing sheet name caused openpyxl to auto-append a numeric collision suffix (e.g. `Sheet21`).

This PR adds sheet title validation and error handling to `rename_sheet`:
- Strips whitespace and skips empty/whitespace-only titles.
- Skips titles containing forbidden characters (`:`, `\`, `/`, `?`, `*`, `[`, `]`).
- Prevents collisions by verifying the target title is not already present among other sheets.
- Handles openpyxl `ValueError` exceptions in `rename_sheet` and `merge_cells` so malformed ops are skipped without crashing the batch.

### Changes
- Updated `src/agentos/skills/bundled/xlsx/scripts/edit_xlsx.py` with title checks and exception handling.
- Added public regression tests in `tests/test_skill_xlsx.py` verifying invalid titles, existing sheet name collisions, and invalid merge ranges are skipped while valid operations continue to apply.

### Validation
- `uv run pytest tests/test_skill_xlsx.py -v` (40/40 passed)
- `uv run ruff check src/agentos/skills/bundled/xlsx/scripts/edit_xlsx.py tests/test_skill_xlsx.py`
