### PR TITLE
fix(skills): walk headers and footers in docx replace_text

### DIFF
--- a/src/agentos/skills/bundled/docx/scripts/edit_docx.py
+++ b/src/agentos/skills/bundled/docx/scripts/edit_docx.py
@@ -95,14 +95,38 @@ def _iter_table_paragraphs(tables: Iterable[Table]) -> Iterator[Paragraph]:
             yield from _iter_table_paragraphs(cell.tables)
 
 
+def _iter_header_footer_paragraphs(doc: Document) -> Iterator[Paragraph]:
+    """Yield paragraphs and table-cell paragraphs from all headers and footers."""
+    seen: set[Any] = set()
+    for section in getattr(doc, "sections", []):
+        containers = [section.header, section.footer]
+        if getattr(section, "different_first_page_header_footer", False):
+            containers.extend([section.first_page_header, section.first_page_footer])
+        settings = getattr(doc, "settings", None)
+        if getattr(settings, "odd_and_even_pages_header_footer", False):
+            containers.extend([section.even_page_header, section.even_page_footer])
+
+        for hf in containers:
+            if hf is None:
+                continue
+            part = getattr(hf, "part", None)
+            key = part if part is not None else id(hf)
+            if key in seen:
+                continue
+            seen.add(key)
+            yield from hf.paragraphs
+            yield from _iter_table_paragraphs(hf.tables)
+
+
 def _iter_all_paragraphs(doc: Document) -> Iterator[Paragraph]:
-    """Body paragraphs followed by every table-cell paragraph in the document.
+    """Body paragraphs, table-cell paragraphs, and header/footer paragraphs.
 
     ``doc.paragraphs`` is body-only in python-docx, yet contracts, reports and
-    invoices keep most of their placeholders inside tables.
+    invoices keep placeholders inside tables and section headers/footers.
     """
     yield from doc.paragraphs
     yield from _iter_table_paragraphs(doc.tables)
+    yield from _iter_header_footer_paragraphs(doc)
 
 
 def apply_ops(doc: Document, ops: list[dict[str, Any]]) -> int:

--- a/tests/test_skill_docx.py
+++ b/tests/test_skill_docx.py
@@ -378,3 +378,85 @@ def test_apply_ops_skips_non_dict_ops() -> None:
 
     assert applied == 1
     assert doc.paragraphs[0].text == "Hello Wei"
+
+
+def test_replace_text_reaches_headers_and_footers() -> None:
+    from docx import Document
+
+    edit_docx = _edit_docx_module()
+    doc = Document()
+    doc.add_paragraph("Body paragraph")
+    sec = doc.sections[0]
+    sec.header.paragraphs[0].text = "Header {{ORG}}"
+    sec.footer.paragraphs[0].text = "Confidential {{DOC_ID}}"
+
+    applied = edit_docx.apply_ops(
+        doc,
+        [
+            {"op": "replace_text", "find": "{{ORG}}", "with": "Acme Corp"},
+            {"op": "replace_text", "find": "{{DOC_ID}}", "with": "DOC-999"},
+        ],
+    )
+
+    assert applied == 2
+    assert sec.header.paragraphs[0].text == "Header Acme Corp"
+    assert sec.footer.paragraphs[0].text == "Confidential DOC-999"
+
+
+def test_replace_text_reaches_header_tables() -> None:
+    from docx import Document
+    from docx.shared import Inches
+
+    edit_docx = _edit_docx_module()
+    doc = Document()
+    sec = doc.sections[0]
+    tbl = sec.header.add_table(1, 1, Inches(1))
+    tbl.cell(0, 0).text = "TableInHeader: {{DATE}}"
+
+    applied = edit_docx.apply_ops(
+        doc,
+        [{"op": "replace_text", "find": "{{DATE}}", "with": "2026-09-12"}],
+    )
+
+    assert applied == 1
+    assert tbl.cell(0, 0).text == "TableInHeader: 2026-09-12"
+
+
+def test_replace_text_visits_shared_section_headers_once() -> None:
+    from docx import Document
+
+    edit_docx = _edit_docx_module()
+    doc = Document()
+    sec0 = doc.sections[0]
+    sec0.header.paragraphs[0].text = "{{TAG}}"
+    # Adding a second section links its header to sec0 by default
+    doc.add_section()
+
+    applied = edit_docx.apply_ops(
+        doc,
+        [{"op": "replace_text", "find": "{{TAG}}", "with": "{{TAG}}!"}],
+    )
+
+    assert applied == 1
+    assert sec0.header.paragraphs[0].text == "{{TAG}}!"
+
+
+def test_replace_text_different_first_page_header() -> None:
+    from docx import Document
+
+    edit_docx = _edit_docx_module()
+    doc = Document()
+    sec = doc.sections[0]
+    sec.different_first_page_header_footer = True
+    sec.first_page_header.paragraphs[0].text = "First: {{TITLE}}"
+    sec.header.paragraphs[0].text = "Other: {{TITLE}}"
+
+    applied = edit_docx.apply_ops(
+        doc,
+        [{"op": "replace_text", "find": "{{TITLE}}", "with": "Quarterly Report"}],
+    )
+
+    assert applied == 2
+    assert sec.first_page_header.paragraphs[0].text == "First: Quarterly Report"
+    assert sec.header.paragraphs[0].text == "Other: Quarterly Report"
+


### PR DESCRIPTION
Closes #1888

### Description
In `src/agentos/skills/bundled/docx/scripts/edit_docx.py`, `_iter_all_paragraphs` previously iterated only over `doc.paragraphs` (body) and `_iter_table_paragraphs(doc.tables)` (body tables). Document section headers and footers (`section.header`, `section.footer`, first page, and even page variants) were completely omitted.

In Word documents and templates, headers and footers frequently contain metadata placeholders such as `{{CONFIDENTIAL}}`, `{{TITLE}}`, `{{ORG}}`, or `{{VERSION}}`. When running `replace_text` on such documents, these placeholders were never touched, leaving them un-replaced with `applied: 0`.

This PR updates `edit_docx.py` to traverse all section headers and footers (including nested tables):
- Added `_iter_header_footer_paragraphs(doc: Document)` traversing `section.header`, `section.footer`, `section.first_page_header`, `section.first_page_footer`, and even page variants.
- Traverses both paragraph items and table-cell paragraphs within headers and footers.
- De-duplicates shared header/footer parts across sections to prevent duplicate substitutions.

### Changes
- Updated `src/agentos/skills/bundled/docx/scripts/edit_docx.py` to yield header and footer paragraphs in `_iter_all_paragraphs`.
- Added public regression tests in `tests/test_skill_docx.py` testing header/footer paragraph replacement, header table replacement, shared header de-duplication, and different first-page headers.

### Validation
- `uv run pytest tests/test_skill_docx.py -v` (29/29 passed)
- `uv run ruff check src/agentos/skills/bundled/docx/scripts/edit_docx.py tests/test_skill_docx.py`
