### PR TITLE
fix(skills): recursively extract text from nested group shapes in pptx (Closes #1894)

### DIFF
--- a/src/agentos/skills/bundled/pptx/scripts/extract_text.py
+++ b/src/agentos/skills/bundled/pptx/scripts/extract_text.py
@@ -75,20 +75,25 @@ def _table_text(shape) -> list[str]:
     return out
 
 
+def _collect_shape_text(shape) -> list[str]:
+    """Recursively collect non-empty text strings from a shape or group shape."""
+    out: list[str] = []
+    out.extend(_shape_text(shape))
+    out.extend(_table_text(shape))
+    if getattr(shape, "shapes", None):
+        try:
+            for inner in shape.shapes:
+                out.extend(_collect_shape_text(inner))
+        except (AttributeError, TypeError):
+            pass
+    return out
+
+
 def _slide_text(slide) -> list[str]:
-    """Walk shapes (and one level of grouped shapes) collecting text."""
+    """Walk shapes (and recursively grouped shapes) collecting text."""
     out: list[str] = []
     for shape in slide.shapes:
-        out.extend(_shape_text(shape))
-        out.extend(_table_text(shape))
-        # one level of group expansion (sufficient for most decks)
-        if getattr(shape, "shape_type", None) and getattr(shape, "shapes", None):
-            try:
-                for inner in shape.shapes:
-                    out.extend(_shape_text(inner))
-                    out.extend(_table_text(inner))
-            except (AttributeError, TypeError):
-                pass
+        out.extend(_collect_shape_text(shape))
     return out
 
 

--- a/tests/test_skills/test_pptx_extract_text.py
+++ b/tests/test_skills/test_pptx_extract_text.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure the pptx skill script is importable
+pptx_script_dir = Path(__file__).resolve().parents[2] / "src/agentos/skills/bundled/pptx/scripts"
+if str(pptx_script_dir) not in sys.path:
+    sys.path.insert(0, str(pptx_script_dir))
+
+import extract_text  # noqa: E402
+
+
+def test_pptx_extract_nested_group_shapes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pptx = pytest.importorskip("pptx")
+    from pptx.util import Inches
+
+    prs = pptx.Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+
+    # Top-level textbox
+    tb0 = slide.shapes.add_textbox(Inches(1), Inches(1), Inches(2), Inches(1))
+    tb0.text_frame.text = "Top Level Text"
+
+    # Top-level table
+    table_shape = slide.shapes.add_table(1, 2, Inches(1), Inches(5), Inches(2), Inches(1))
+    table_shape.table.cell(0, 0).text = "Cell A"
+    table_shape.table.cell(0, 1).text = "Cell B"
+
+    # Group 1 (depth 1)
+    g1 = slide.shapes.add_group_shape()
+    tb1 = g1.shapes.add_textbox(Inches(1), Inches(2), Inches(2), Inches(1))
+    tb1.text_frame.text = "Depth 1 Text"
+
+    # Group 2 nested inside Group 1 (depth 2)
+    g2 = g1.shapes.add_group_shape()
+    tb2 = g2.shapes.add_textbox(Inches(1), Inches(3), Inches(2), Inches(1))
+    tb2.text_frame.text = "Depth 2 Text"
+
+    # Group 3 nested inside Group 2 (depth 3)
+    g3 = g2.shapes.add_group_shape()
+    tb3 = g3.shapes.add_textbox(Inches(1), Inches(4), Inches(2), Inches(1))
+    tb3.text_frame.text = "Depth 3 Text"
+
+    # Verify _slide_text extracts all nested levels
+    extracted = extract_text._slide_text(slide)
+    assert "Top Level Text" in extracted
+    assert "Depth 1 Text" in extracted
+    assert "Depth 2 Text" in extracted
+    assert "Depth 3 Text" in extracted
+    assert "Cell A | Cell B" in extracted
+
+    # Save to file and verify CLI main() with --json
+    deck_path = tmp_path / "nested_groups.pptx"
+    prs.save(str(deck_path))
+
+    stdout_capture = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", stdout_capture)
+
+    rc = extract_text.main([str(deck_path), "--json"])
+    assert rc == 0
+
+    records = json.loads(stdout_capture.getvalue())
+    assert len(records) == 1
+    slide_record = records[0]
+    assert slide_record["slide"] == 1
+    assert "Top Level Text" in slide_record["text"]
+    assert "Depth 1 Text" in slide_record["text"]
+    assert "Depth 2 Text" in slide_record["text"]
+    assert "Depth 3 Text" in slide_record["text"]
+    assert "Cell A | Cell B" in slide_record["text"]


### PR DESCRIPTION
Closes #1894

## SUMMARY
Enables recursive text and table extraction from arbitrarily nested group shapes in PowerPoint presentations.

## PROBLEM
In `src/agentos/skills/bundled/pptx/scripts/extract_text.py`, `_slide_text` only checked top-level shapes and a single hardcoded level of group shape children. In complex decks with multi-level grouped shapes (e.g. diagrams, flowcharts, cards, infographics), child group shapes are `GroupShape` objects lacking direct text frames or tables. Because the code did not recurse into nested group shapes, all text and tables inside nested groups (depth >= 2) were silently skipped.

## FIX
1. Added recursive helper `_collect_shape_text(shape)` that extracts text from the shape, its table (if present), and recursively inspects `shape.shapes`.
2. Updated `_slide_text` to utilize `_collect_shape_text(shape)`.

## TESTING
Added unit tests in `tests/test_skills/test_pptx_extract_text.py`:
- Verified extraction across 3 levels of nested group shapes, top-level textboxes, and tables.
- Verified CLI `--json` output records.
- Ran test suite: `pytest tests/test_skills/test_pptx_extract_text.py` (1 passed).
- Lint check: `ruff check` passed cleanly.
