### PR TITLE
fix(skills): validate run and paragraph bounds in docx replace_run (Closes #1896)

### DIFF
--- a/src/agentos/skills/bundled/docx/scripts/edit_docx.py
+++ b/src/agentos/skills/bundled/docx/scripts/edit_docx.py
@@ -28,9 +28,11 @@ from docx.table import Table, _Cell
 from docx.text.paragraph import Paragraph
 
 
-def _replace_run(para: Paragraph, run_idx: int, text: str) -> None:
+def _replace_run(para: Paragraph, run_idx: int, text: str) -> bool:
     if 0 <= run_idx < len(para.runs):
         para.runs[run_idx].text = text
+        return True
+    return False
 
 
 def _replace_text_in_paragraph(para: Paragraph, find: str, replacement: str) -> bool:
@@ -113,11 +115,16 @@ def apply_ops(doc: Document, ops: list[dict[str, Any]]) -> int:
         kind = op.get("op")
         if kind == "replace_run":
             try:
-                para = doc.paragraphs[int(op["para"])]
-            except (KeyError, IndexError, ValueError):
+                para_idx = int(op["para"])
+                if para_idx < 0 or para_idx >= len(doc.paragraphs):
+                    continue
+                para = doc.paragraphs[para_idx]
+                run_idx = int(op.get("run", 0))
+                text = str(op.get("text", ""))
+                if _replace_run(para, run_idx, text):
+                    applied += 1
+            except (KeyError, IndexError, ValueError, TypeError):
                 continue
-            _replace_run(para, int(op.get("run", 0)), str(op.get("text", "")))
-            applied += 1
         elif kind == "replace_text":
             find = str(op.get("find", ""))
             replacement = str(op.get("with", ""))

--- a/tests/test_skill_docx.py
+++ b/tests/test_skill_docx.py
@@ -378,3 +378,47 @@ def test_apply_ops_skips_non_dict_ops() -> None:
 
     assert applied == 1
     assert doc.paragraphs[0].text == "Hello Wei"
+
+
+def test_replace_run_returns_bool() -> None:
+    edit_docx = _edit_docx_module()
+    paragraph = _paragraph([("Run 0", False)])
+
+    assert edit_docx._replace_run(paragraph, 0, "Updated") is True
+    assert paragraph.runs[0].text == "Updated"
+    assert edit_docx._replace_run(paragraph, 5, "OutOfBounds") is False
+    assert edit_docx._replace_run(paragraph, -1, "Negative") is False
+    assert paragraph.runs[0].text == "Updated"
+
+
+def test_apply_ops_replace_run_counts_only_valid_modifications() -> None:
+    from docx import Document
+
+    edit_docx = _edit_docx_module()
+    doc = Document()
+    p0 = doc.add_paragraph()
+    p0.add_run("Original 0")
+    p1 = doc.add_paragraph()
+    p1.add_run("Original 1")
+
+    ops = [
+        # Out-of-bounds run index: should be ignored and not increment applied
+        {"op": "replace_run", "para": 0, "run": 99, "text": "Out of bounds"},
+        # Negative run index: should be ignored
+        {"op": "replace_run", "para": 0, "run": -1, "text": "Negative run"},
+        # Out-of-bounds para index: should be ignored
+        {"op": "replace_run", "para": 10, "run": 0, "text": "Out of bounds para"},
+        # Negative para index: should be ignored
+        {"op": "replace_run", "para": -1, "run": 0, "text": "Negative para"},
+        # Invalid para type: should be ignored without raising
+        {"op": "replace_run", "para": "invalid", "run": 0, "text": "Invalid para"},
+        {"op": "replace_run", "para": None, "run": 0, "text": "None para"},
+        # Valid replace_run: should succeed and increment applied
+        {"op": "replace_run", "para": 1, "run": 0, "text": "Replaced 1"},
+    ]
+
+    applied = edit_docx.apply_ops(doc, ops)
+    assert applied == 1
+    assert doc.paragraphs[0].runs[0].text == "Original 0"
+    assert doc.paragraphs[1].runs[0].text == "Replaced 1"
+


### PR DESCRIPTION
Closes #1896

## SUMMARY
Validates paragraph and run index boundaries in docx `replace_run` operations and ensures `applied` count is only incremented when an edit is actually performed.

## PROBLEM
In `src/agentos/skills/bundled/docx/scripts/edit_docx.py`, `_replace_run` returned `None` and performed no modifications when given an out-of-bounds or negative `run` index. However, `apply_ops` unconditionally executed `applied += 1`, falsely reporting successful modifications when no changes occurred. Additionally, negative paragraph indices silently wrapped from the end of the document via `doc.paragraphs[-1]`, and non-integer types could cause unhandled `TypeError` exceptions.

## FIX
1. Updated `_replace_run(para, run_idx, text) -> bool` to return `True` on successful replacement and `False` otherwise.
2. Guarded paragraph index bounds (`0 <= para_idx < len(doc.paragraphs)`), preventing silent negative index wrapping.
3. Added `TypeError` handling alongside `(KeyError, IndexError, ValueError)` when parsing operation parameters.
4. Only incremented `applied` when `_replace_run` returns `True`.

## TESTING
Added unit tests in `tests/test_skill_docx.py`:
- Verified `_replace_run` returns `True` for valid run indices and `False` for out-of-bounds / negative indices.
- Verified `apply_ops` ignores out-of-bounds run indices, negative run indices, out-of-bounds paragraph indices, negative paragraph indices, and malformed parameter types without falsely incrementing `applied`.
- Ran test suite: `pytest tests/test_skill_docx.py` (27 passed).
- Lint check: `ruff check` passed cleanly.
