### PR TITLE
fix(gateway): reject non-string message in sessions.send

### DIFF
--- a/src/agentos/gateway/rpc_sessions.py
+++ b/src/agentos/gateway/rpc_sessions.py
@@ -935,7 +935,9 @@ async def _handle_sessions_send(params: dict | None, ctx: RpcContext) -> dict:
     if not isinstance(params, dict) or "message" not in params:
         raise ValueError("params.message is required")
 
-    message_text: str = params["message"]
+    message_text = params["message"]
+    if not isinstance(message_text, str):
+        raise ValueError("params.message must be a string")
     source_hint = _normalize_session_send_source_hint(params)
     incoming_attachments = params.get("attachments", [])
     normalized_input = normalize_incoming_text(

--- a/tests/test_gateway/test_rpc_sessions.py
+++ b/tests/test_gateway/test_rpc_sessions.py
@@ -1139,6 +1139,49 @@ class TestSessionsSend:
         assert res.error.code == "INVALID_REQUEST"
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "bad_message",
+        [
+            0,  # falsy: previously silently coerced to "" via `message_text or ""`
+            False,
+            None,  # explicit null: same silent-coercion path
+            [],
+            {},
+            12345,  # truthy non-string: previously crashed with a raw
+            # AttributeError ('int' object has no attribute 'lower') deep in
+            # normalize_incoming_text, leaking as INTERNAL_ERROR
+            ["hello"],
+            {"a": 1},
+        ],
+    )
+    async def test_send_rejects_non_string_message(
+        self, dispatcher, ctx_with_sessions, session, bad_message
+    ):
+        res = await dispatcher.dispatch(
+            "r1",
+            "sessions.send",
+            {"key": session.session_key, "message": bad_message},
+            ctx_with_sessions,
+        )
+        assert res.ok is False
+        assert res.error.code == "INVALID_REQUEST"
+        assert res.error.message == "params.message must be a string"
+
+    @pytest.mark.asyncio
+    async def test_send_accepts_empty_string_message(
+        self, dispatcher, ctx_with_sessions, session
+    ):
+        # An empty string is a legitimate message (e.g. attachment-only
+        # sends) and must not be rejected by the type check above.
+        res = await dispatcher.dispatch(
+            "r1",
+            "sessions.send",
+            {"key": session.session_key, "message": ""},
+            ctx_with_sessions,
+        )
+        assert res.ok is True
+
+    @pytest.mark.asyncio
     async def test_send_missing_key(self, dispatcher, ctx_with_sessions):
         res = await dispatcher.dispatch("r1", "sessions.send", {"message": "hi"}, ctx_with_sessions)
         assert res.ok is False


### PR DESCRIPTION
## Linked issue
Fixes #1885 

## Summary
`_handle_sessions_send` only validated that `message` was present in
params, not that it was a string:

    message_text: str = params["message"]

The `: str` is a type hint, not a runtime check. This reaches
normalize_incoming_text()'s `text = message_text or ""`:

- A falsy non-string (0, false, null, [], {}) is falsy, so `text`
  silently becomes "" and the send proceeds with a message the caller
  never sent — no error, no indication anything was wrong.
- A truthy non-string (an int, a non-empty list/dict) reaches a
  `.lower()` call downstream and raises an unhandled AttributeError,
  leaking as a raw INTERNAL_ERROR instead of a clean validation error.

sessions.create's optional seed message already validates this
correctly (`if message is not None and not isinstance(message, str):
raise ValueError(...)`) — sessions.send's required message had no
equivalent check.

## Fix
Added the same isinstance check already used for sessions.create's
message param, adapted for a required (not optional) field. Placed
immediately after extraction so no downstream normalization logic runs
on bad input.

Alternatives considered:
- Fixing inside the shared normalize_incoming_text() helper instead of
  the call site — checked first via grep for every caller; there is
  exactly one (sessions.send), so a shared-helper fix would defend
  against a caller that doesn't exist yet. Rejected as broader than
  the bug requires.
- Coercing (str(message_text)) instead of rejecting — rejected:
  sessions.send triggers a real agent turn, a consequential write, not
  a read; silently sending a client's malformed 0 or {} as a literal
  "0"/"{}" the user never intended is worse than a clear error.
- Confirmed no internal caller (cli/gateway_client.py, mcp_server/bridge.py)
  ever constructs a non-string message — both already type their own
  `message: str` parameter at their boundary and pass it straight
  through. This fix cannot regress a legitimate use case.

## Tests
Parametrized test matrix (not a single case) covering both failure
modes: 0, False, None, [], {} (previously silent), 12345, ["hello"],
{"a": 1} (previously crashed) — all now assert INVALID_REQUEST with
the exact message "params.message must be a string". A separate test
confirms an empty string ("") is still accepted, since it's the
legitimate attachment-only-send case.

Confirmed as a real regression guard: reverted the fix locally and
reran — falsy cases returned ok:true with an empty message actually
sent; truthy cases returned INTERNAL_ERROR with the raw AttributeError
text. Restored the fix, full file passes.

Commands run (matching .github/workflows/ci.yml's ubuntu-quality job
exactly):
  uv sync --extra dev --extra recommended --frozen
  uv run ruff check src tests
  uv run mypy src/agentos --show-error-codes
  uv run pytest tests -q
  uv run python -m pytest tests/test_gateway/test_task_runtime_terminal_cleanup.py::test_no_leak_under_load -v
  npm run check (frontend)
  python scripts/build_control_ui.py build
  uv build --wheel && python scripts/build_control_ui.py verify-archive dist/*.whl

Results: ruff/mypy clean across the full repo, not just touched files.
Full suite: 31 pre-existing failures, byte-for-byte identical (diffed
directly) to a clean-main baseline run with this change stashed out —
all attributable to this sandbox running as root and lacking hydrated
Git LFS objects for the bundled ONNX model, not to this change. Frontend
check: 2063 tests passed. Control UI build, bundle budget, and wheel
build/verify all passed.

Third-party origin: none.