### PR TITLE
fix(security): recognize signing, encryption and account as key qualifiers

### DIFF
--- a/src/agentos/redact.py
+++ b/src/agentos/redact.py
@@ -173,6 +173,13 @@ _QUALIFIED_NAME_PAIRS: frozenset[tuple[str, str]] = frozenset(
         ("secret", "key"),
         ("session", "token"),
         ("service", "key"),
+        # Qualifiers that can only mean key material. ``key`` alone stays out
+        # for the reason above — ``sort_key`` and ``partition_key`` are field
+        # names — but nothing signs, encrypts or authenticates a storage
+        # account with a value the model is meant to read.
+        ("signing", "key"),
+        ("encryption", "key"),
+        ("account", "key"),
     }
 )
 

--- a/tests/test_security/test_redact.py
+++ b/tests/test_security/test_redact.py
@@ -136,14 +136,58 @@ class TestNameSegments:
 
     @pytest.mark.parametrize(
         "name",
-        ["api_key", "CAP_API_KEY", "x-cap-api-key", "capApiKey", "access_token", "client_secret"],
+        [
+            "api_key",
+            "CAP_API_KEY",
+            "x-cap-api-key",
+            "capApiKey",
+            "access_token",
+            "client_secret",
+            # A qualifier that can only mean key material, in each of the
+            # three casings ``_name_segments`` normalises.
+            "signing_key",
+            "SIGNING_KEY",
+            "signingKey",
+            "x-signing-key",
+            "encryption_key",
+            "ENCRYPTION_KEY",
+            "encryptionKey",
+            "AccountKey",
+            "account_key",
+            "STORAGE_ACCOUNT_KEY",
+        ],
     )
     def test_credential_names(self, name: str) -> None:
         assert redact._is_credential_name(name)
 
     @pytest.mark.parametrize(
         "name",
-        ["sellToken", "buyToken", "tokenAddress", "tokenId", "token_count", "session_id", "amount"],
+        [
+            "sellToken",
+            "buyToken",
+            "tokenAddress",
+            "tokenId",
+            "token_count",
+            "session_id",
+            "amount",
+            # ``key`` stays out of the strong segments precisely so these
+            # survive: masking a field name is a diff the agent cannot apply.
+            "sort_key",
+            "sortKey",
+            "cache_key",
+            "partition_key",
+            "primary_key",
+            "foreign_key",
+            "group_key",
+            "key_count",
+            # The qualifiers added for key material do not carry over to the
+            # other nouns they pair with in ordinary code.
+            "signing_algorithm",
+            "encryption_algorithm",
+            "account_id",
+            "accountName",
+            "account_balance",
+        ],
     )
     def test_ordinary_names(self, name: str) -> None:
         assert not redact._is_credential_name(name)
@@ -184,6 +228,88 @@ class TestRedaction:
         code = 'DEFAULT_API_KEY = "test-value-for-fixtures"'
         assert redact.redact_sensitive_text(code, code_file=True) == code
         assert redact.redact_sensitive_text(code, code_file=False) != code
+
+
+class TestQualifiedKeyMaterial:
+    """``<qualifier>_key`` names that only the pair list can recognise.
+
+    The value in every case is opaque: no vendor prefix, no JWT shape, no
+    userinfo. Nothing but :func:`_is_credential_name` can decide it, which is
+    what makes these the cases the pair list exists for.
+    """
+
+    OPAQUE = "9f2b7c41ae55d0e3bb84aa11"
+
+    @pytest.mark.parametrize(
+        "assignment",
+        [
+            "SIGNING_KEY={value}",
+            "ENCRYPTION_KEY={value}",
+            "AccountKey={value}",
+            '"signingKey": "{value}"',
+            "encryption-key={value}",
+        ],
+    )
+    def test_an_env_dump_masks_key_material(self, assignment: str) -> None:
+        line = assignment.format(value=self.OPAQUE)
+        out = redact.redact_terminal_output(f"{line}\nPATH=/usr/bin\n", "printenv")
+        assert self.OPAQUE not in out
+        assert "PATH=/usr/bin" in out
+
+    @pytest.mark.parametrize(
+        "assignment",
+        [
+            "SIGNING_KEY={value}",
+            "ENCRYPTION_KEY={value}",
+            "AccountKey={value}",
+        ],
+    )
+    def test_a_dotenv_read_masks_key_material(self, assignment: str) -> None:
+        """The other surface the same pair list gates: ``read_file`` on ``.env``."""
+        line = assignment.format(value=self.OPAQUE)
+        out = redact.redact_file_output(f"{line}\n", path=".env")
+        assert self.OPAQUE not in out
+
+    def test_a_signing_key_masks_like_the_secret_key_beside_it(self) -> None:
+        """The asymmetry this closes: one dump, two names of the same shape."""
+        dump = f"SECRET_KEY={self.OPAQUE}\nSIGNING_KEY={self.OPAQUE}\n"
+        out = redact.redact_terminal_output(dump, "printenv")
+        assert self.OPAQUE not in out
+        assert out.count(redact._MASK) == 2
+
+    def test_an_azure_account_key_does_not_survive_its_connection_string(self) -> None:
+        account_key = "2b8Hs9KpLmQwErTyUiOpAsDfGhJkZxCvBnM1234567890abcdefgh=="
+        out = redact.redact_terminal_output(f"AccountKey={account_key}\n", "printenv")
+        assert account_key not in out
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "sort_key=created_at_descending",
+            "partition_key=tenant_4418_shard_0007",
+            "cache_key=user_profile_v3_20260913",
+            "account_id=acct_00000000000000000000",
+        ],
+    )
+    def test_ordinary_key_fields_are_left_alone(self, line: str) -> None:
+        """Masking these breaks the edit the agent makes next."""
+        assert redact.redact_terminal_output(f"{line}\n", "printenv") == f"{line}\n"
+
+    def test_a_reference_value_is_still_a_location_not_a_secret(self) -> None:
+        """Recognising the name must not override the reference-value guard."""
+        line = "SIGNING_KEY=$SIGNING_KEY\n"
+        assert redact.redact_terminal_output(line, "printenv") == line
+
+    def test_source_code_still_skips_the_assignment_pass(self) -> None:
+        """A masked identifier is code the agent can no longer match on."""
+        code = f'DEFAULT_SIGNING_KEY = "{self.OPAQUE}"'
+        assert redact.redact_sensitive_text(code, code_file=True) == code
+        assert redact.redact_sensitive_text(code, code_file=False) != code
+
+    def test_ordinary_output_is_not_put_through_the_assignment_pass(self) -> None:
+        """Only an env dump or a credential-file read reaches this pass."""
+        line = f"SIGNING_KEY={self.OPAQUE}\n"
+        assert redact.redact_terminal_output(line, "cat settings.py") == line
 
 
 class TestTerminalOutput:


### PR DESCRIPTION
Fixes #1901

## The bug

`redact.py` judges an assignment's name in `_is_credential_name`: one segment in `_STRONG_NAME_SEGMENTS`, or two adjacent segments in `_QUALIFIED_NAME_PAIRS`. The pair list is the mechanism that makes a bare `key` count, and the comment above it says why `key` is not a strong segment on its own:

> `token` and `key` are pointedly absent: a token is an asset in web3 payloads and a key is a map entry everywhere else. They only count in the qualified pairs below.

Three qualifiers that can mean nothing but key material were missing from that list. The result is an asymmetry inside a single `printenv` dump — value `9f2b7c41ae55d0e3bb84aa11` in every row, measured on `main` @ `8db605f3`:

| assignment | `redact_terminal_output` | `redact_file_output` (`.env`) |
|---|---|---|
| `SECRET_KEY=…` | masked | masked |
| `PRIVATE_KEY=…` | masked | masked |
| `API_KEY=…` | masked | masked |
| `SIGNING_KEY=…` | **leaked** | **leaked** |
| `ENCRYPTION_KEY=…` | **leaked** | **leaked** |
| `AccountKey=…` | **leaked** | **leaked** |
| `"signingKey": "…"` | **leaked** | **leaked** |

All three casings behave alike, which places the gap in the pair list rather than in `_name_segments`: `signingKey`, `x-signing-key` and `SIGNING_KEY` all reduce to `signing` + `key`, and none was recognised.

These are not display-only names. A signing key forges the tokens it signs; an Azure `AccountKey` is full read/write on the storage account. `redact_terminal_output` is the policy for every terminal surface and `redact_file_output` for `read_file` / `grep_search`, and `.env` files carrying `ENCRYPTION_KEY` or `SIGNING_KEY` are ordinary Django, Rails and Laravel layout.

This is the same class as #1517 (`reset_token` vs `reset-token`), accepted at `priority: p2` / `type: security`, where the closing note observed that "`api_key` survives only because `agentos.redact`'s qualified-pair list happens to name it". This adds three names to that list.

## The fix

Three entries in `_QUALIFIED_NAME_PAIRS`:

```python
("signing", "key"),
("encryption", "key"),
("account", "key"),
```

Deliberately untouched: `_STRONG_NAME_SEGMENTS` (adding `key` there would mask `sort_key` and `partition_key`), `_name_segments`, `_is_secret_literal_value`, and every regex. The pair mechanism already normalises casing, so no new spelling logic is needed.

## Tests

`tests/test_security/test_redact.py`, offline and deterministic, no credentials and no network.

Added to the existing `TestNameSegments` matrix:

- 10 positive names — `signing_key`, `SIGNING_KEY`, `signingKey`, `x-signing-key`, `encryption_key`, `ENCRYPTION_KEY`, `encryptionKey`, `AccountKey`, `account_key`, `STORAGE_ACCOUNT_KEY`.
- 12 negative names — `sort_key`, `sortKey`, `cache_key`, `partition_key`, `primary_key`, `foreign_key`, `group_key`, `key_count`, `signing_algorithm`, `encryption_algorithm`, `account_id`, `accountName`, `account_balance`.

New `TestQualifiedKeyMaterial` class, covering both surfaces the pair list gates and the guards that must survive:

- `test_an_env_dump_masks_key_material` — 5 assignment spellings through `redact_terminal_output`, each also asserting `PATH=/usr/bin` on the same dump is untouched.
- `test_a_dotenv_read_masks_key_material` — the same names through `redact_file_output(path=".env")`, the `read_file` surface.
- `test_a_signing_key_masks_like_the_secret_key_beside_it` — the asymmetry itself: one dump, two names, `_MASK` must appear twice.
- `test_an_azure_account_key_does_not_survive_its_connection_string`.
- `test_ordinary_key_fields_are_left_alone` — 4 field names that must stay readable.
- `test_a_reference_value_is_still_a_location_not_a_secret` — `SIGNING_KEY=$SIGNING_KEY` names where the value lives; recognising the name must not override `_is_reference_value`.
- `test_source_code_still_skips_the_assignment_pass` — `code_file=True` untouched, `code_file=False` masked.
- `test_ordinary_output_is_not_put_through_the_assignment_pass` — `cat settings.py` output is not an env dump.

**21 of the new cases fail on unmodified `redact.py`** (the 10 name positives, 5 env-dump spellings, 3 `.env` spellings, the side-by-side asymmetry, the Azure key, and the source-code case — whose second assertion needs the name recognised).

The remaining new cases — the 12 negative names, the 4 ordinary key fields, the reference-value guard and the ordinary-output guard — **pass either way by design**. They are there to pin the false-positive surface the pair list exists to avoid, and would only fail if this change reached too far.

## Verification

```
$ uv run pytest tests/test_security/test_redact.py -q
105 passed in 0.15s

$ git show upstream/main:src/agentos/redact.py > src/agentos/redact.py   # fix reverted, tests kept
$ uv run pytest tests/test_security/test_redact.py -q
21 failed, 84 passed in 0.28s

$ uv run ruff check src tests
All checks passed!

$ uv run mypy --show-error-codes src
Success: no issues found in 627 source files

$ uv run pytest -q
6 failed, 10759 passed, 34 skipped, 4 warnings, 3 errors in 260.57s
```

The 6 failures and 3 errors are pre-existing on `upstream/main` @ `8db605f3` in this environment and unrelated to this change: `test_pilot_encoder` / `test_build_wheelhouse_zip` / `test_pilot_benchmark` need a hydrated MiniLM ONNX asset that is not present locally, and `test_tracked_public_files_do_not_carry_this_machines_timezone` is a machine-timezone guard. Neither set touches `redact.py`; CI should be green.

## One adjacent case, deliberately left alone

`LICENSE_KEY`, `DEPLOY_KEY` and `CONSUMER_KEY` also leak by name, and I left all three alone. A license key is not host credential material; `consumer_key` is the public half of an OAuth1 pair whose secret half already masks on the `secret` segment. Widening to every `<word>_key` would start masking `sort_key`, `cache_key` and `partition_key` — exactly the false-positive surface the comment above the list is written to avoid. Happy to revisit if you would rather draw that line elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
