### PR TITLE
fix(skills): refuse a pdf-toolkit form_fill data file that is not an object

### DIFF
--- a/src/agentos/skills/bundled/pdf-toolkit/scripts/form_fill.py
+++ b/src/agentos/skills/bundled/pdf-toolkit/scripts/form_fill.py
@@ -69,8 +69,22 @@ def main() -> int:
     if not args.data.is_file():
         print(f"error: data {args.data} not found", file=sys.stderr)
         return 2
-    raw = json.loads(args.data.read_text(encoding="utf-8"))
-    data = {str(k): str(v) for k, v in (raw.items() if isinstance(raw, dict) else [])}
+    try:
+        raw = json.loads(args.data.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        print(f"error: data {args.data} is not valid JSON: {exc}", file=sys.stderr)
+        return 2
+    # A data file this script cannot use is refused like every other bad
+    # input. Coercing a non-object to {} filled nothing and still wrote the
+    # output PDF, so a blank form left here reported as a successful fill.
+    if not isinstance(raw, dict):
+        print(
+            f"error: data {args.data} must be a JSON object of field -> value, "
+            f"got {type(raw).__name__}",
+            file=sys.stderr,
+        )
+        return 2
+    data = {str(k): str(v) for k, v in raw.items()}
     pages = fill(args.input, data, args.out)
     print(json.dumps({"pages_processed": pages, "fields": len(data)}, ensure_ascii=False))
     return 0

--- a/tests/test_skill_pdf_toolkit.py
+++ b/tests/test_skill_pdf_toolkit.py
@@ -199,3 +199,136 @@ def test_tables_strategy_explicit_is_rejected_with_a_clear_message(
         extract.main()
     assert exc_info.value.code == 2
     assert "invalid choice: 'explicit'" in capsys.readouterr().err
+
+
+def _form_fill_module():
+    sys.path.insert(0, str(SCRIPTS))
+    try:
+        import form_fill  # type: ignore[import-not-found]
+    finally:
+        sys.path.pop(0)
+    return form_fill
+
+
+def _make_two_field_form(path: Path) -> None:
+    """An AcroForm with two empty `/Tx` fields — what form_fill.py is pointed at."""
+    from reportlab.pdfgen import canvas
+
+    c = canvas.Canvas(str(path))
+    c.drawString(72, 760, "Application")
+    c.acroForm.textfield(name="full_name", x=72, y=700, width=200, height=20)
+    c.acroForm.textfield(name="city", x=72, y=660, width=200, height=20)
+    c.showPage()
+    c.save()
+
+
+def _field_values(path: Path) -> dict[str, str]:
+    from pypdf import PdfReader
+
+    fields = PdfReader(str(path)).get_fields() or {}
+    return {name: (field.get("/V") or "") for name, field in fields.items()}
+
+
+def test_form_fill_fills_every_field_from_a_json_object(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The path that must keep working — the guard below must not narrow it."""
+    form_fill = _form_fill_module()
+    form = tmp_path / "form.pdf"
+    _make_two_field_form(form)
+    data = tmp_path / "data.json"
+    data.write_text('{"full_name": "Ada", "city": "Jakarta"}', encoding="utf-8")
+    out = tmp_path / "filled.pdf"
+
+    monkeypatch.setattr(
+        "sys.argv", ["form_fill.py", str(form), str(data), "--out", str(out)]
+    )
+    assert form_fill.main() == 0
+    assert _field_values(out) == {"full_name": "Ada", "city": "Jakarta"}
+    assert '"fields": 2' in capsys.readouterr().out
+
+
+def test_form_fill_accepts_an_empty_object_as_nothing_to_fill(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`{}` is a usable mapping that happens to be empty, not a bad data file."""
+    form_fill = _form_fill_module()
+    form = tmp_path / "form.pdf"
+    _make_two_field_form(form)
+    data = tmp_path / "data.json"
+    data.write_text("{}", encoding="utf-8")
+    out = tmp_path / "filled.pdf"
+
+    monkeypatch.setattr(
+        "sys.argv", ["form_fill.py", str(form), str(data), "--out", str(out)]
+    )
+    assert form_fill.main() == 0
+    assert out.is_file()
+
+
+@pytest.mark.parametrize(
+    ("payload", "kind"),
+    [
+        ('["full_name", "Ada"]', "list"),
+        ('[{"full_name": "Ada"}]', "list"),
+        ('"full_name=Ada"', "str"),
+        ("42", "int"),
+        ("null", "NoneType"),
+        ("true", "bool"),
+    ],
+)
+def test_form_fill_refuses_a_data_file_that_is_not_an_object(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    payload: str,
+    kind: str,
+) -> None:
+    """Coercing these to {} wrote a blank form and exited 0."""
+    form_fill = _form_fill_module()
+    form = tmp_path / "form.pdf"
+    _make_two_field_form(form)
+    data = tmp_path / "data.json"
+    data.write_text(payload, encoding="utf-8")
+    out = tmp_path / "filled.pdf"
+
+    monkeypatch.setattr(
+        "sys.argv", ["form_fill.py", str(form), str(data), "--out", str(out)]
+    )
+    assert form_fill.main() == 2
+    assert not out.exists(), "a refused fill must not leave an output PDF behind"
+    err = capsys.readouterr().err
+    assert "must be a JSON object" in err
+    assert kind in err
+
+
+def test_form_fill_refuses_a_data_file_that_is_not_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The same unusable-data-file path, reached one step earlier."""
+    form_fill = _form_fill_module()
+    form = tmp_path / "form.pdf"
+    _make_two_field_form(form)
+    data = tmp_path / "data.json"
+    data.write_text("full_name: Ada\n", encoding="utf-8")
+    out = tmp_path / "filled.pdf"
+
+    monkeypatch.setattr(
+        "sys.argv", ["form_fill.py", str(form), str(data), "--out", str(out)]
+    )
+    assert form_fill.main() == 2
+    assert not out.exists()
+    assert "not valid JSON" in capsys.readouterr().err
+
+
+def test_form_fill_list_fields_still_needs_no_data_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """--list-fields returns before the data file is read at all."""
+    form_fill = _form_fill_module()
+    form = tmp_path / "form.pdf"
+    _make_two_field_form(form)
+
+    monkeypatch.setattr("sys.argv", ["form_fill.py", str(form), "--list-fields"])
+    assert form_fill.main() == 0
+    assert "full_name" in capsys.readouterr().out


### PR DESCRIPTION
Fixes #1903

## The bug

`form_fill.py` coerced the data file into a field mapping with a conditional that swallowed every shape but `dict`:

```python
raw = json.loads(args.data.read_text(encoding="utf-8"))
data = {str(k): str(v) for k, v in (raw.items() if isinstance(raw, dict) else [])}
```

A JSON list — `[{"full_name": "Ada"}]`, the obvious model slip when the contract is an object — produced `data == {}`. The script then ran the full fill path over an empty mapping, wrote the output PDF, printed a success summary and exited 0.

Measured on `main` @ `8db605f3`, against a two-field AcroForm:

| data file | stdout | exit | `out.pdf` field values |
|---|---|---|---|
| `{"full_name": "Ada", "city": "Jakarta"}` | `{"pages_processed": 1, "fields": 2}` | 0 | `{'full_name': 'Ada', 'city': 'Jakarta'}` |
| `["full_name", "Ada"]` | `{"pages_processed": 1, "fields": 0}` | 0 | `{'full_name': '', 'city': ''}` |

The second row is a complete, valid, entirely blank form produced by a command that exited 0. Every signal the caller has says the fill worked: exit 0, a file at the requested path, `pages_processed: 1`. The only trace is `"fields": 0` — which `SKILL.md` never tells the caller to check, and which a legitimately empty `{}` produces too, so it cannot separate "you passed the wrong shape" from "there was nothing to fill".

The script already refuses every other bad input loudly: missing input, missing data file, missing `--out`, each `error: …` on stderr with exit 2. A data file it could not use was the one case that passed silently. `SKILL.md` already documents the contract correctly — "`data.json` maps field name → string value", with an object in the example — so this is the code catching up to the document, not a doc change.

## The fix

Refuse the unusable data file instead of coercing it:

```python
if not isinstance(raw, dict):
    print(
        f"error: data {args.data} must be a JSON object of field -> value, "
        f"got {type(raw).__name__}",
        file=sys.stderr,
    )
    return 2
data = {str(k): str(v) for k, v in raw.items()}
```

The type name is in the message because the caller here is an agent that just wrote the file and has to fix it.

`json.loads` on a file that is not JSON at all escaped as a bare `JSONDecodeError` traceback on the same path; it now returns 2 with a message. I called this out in the issue as the same "unusable data file" case — say the word if you would rather see it split out and I will drop it from this branch.

Deliberately unchanged: `fill()`, `list_fields()`, the `--list-fields` early return, the `str(k): str(v)` coercion of a valid object's values, and `SKILL.md`.

## Tests

`tests/test_skill_pdf_toolkit.py`, offline and deterministic, no network and no credentials. PDFs are built in-test with `reportlab` and read back with `pypdf`, matching the `_make_one_page_pdf` helper already in the file. No new test file, so no basename collision.

- `test_form_fill_refuses_a_data_file_that_is_not_an_object` — 6 payloads (`list` of strings, `list` of objects, `str`, `int`, `null`, `bool`), each asserting exit 2, the message naming the type, **and that no output PDF is left behind**.
- `test_form_fill_refuses_a_data_file_that_is_not_json` — the decode path, exit 2, no output file.
- `test_form_fill_fills_every_field_from_a_json_object` — the working path, asserting the field values read back out of the PDF and `"fields": 2`, so the guard cannot narrow what used to succeed.
- `test_form_fill_accepts_an_empty_object_as_nothing_to_fill` — `{}` is a usable mapping that happens to be empty, and must stay exit 0.
- `test_form_fill_list_fields_still_needs_no_data_file` — `--list-fields` returns before the data file is read.

**7 of these fail on unmodified `form_fill.py`**: the 6 non-object payloads and the invalid-JSON case.

The remaining 3 — the working fill, the empty object, and `--list-fields` — **pass either way by design**. They pin the behaviour this change must not narrow; the empty-object case in particular is the boundary the guard could easily have swallowed.

## Verification

```
$ uv run pytest tests/test_skill_pdf_toolkit.py -q
19 passed in 0.69s

$ git show upstream/main:src/agentos/skills/bundled/pdf-toolkit/scripts/form_fill.py > …/form_fill.py
$ uv run pytest tests/test_skill_pdf_toolkit.py -q
7 failed, 12 passed in 0.59s

$ uv run ruff check src tests
All checks passed!

$ uv run mypy --show-error-codes src
Success: no issues found in 627 source files

$ uv run pytest -q
6 failed, 10729 passed, 34 skipped, 4 warnings, 3 errors in 259.25s
```

The 6 failures and 3 errors are pre-existing on `upstream/main` @ `8db605f3` in this environment and untouched by this change: `test_pilot_encoder`, `test_build_wheelhouse_zip` and `test_pilot_benchmark` need a hydrated MiniLM ONNX asset that is not present locally, and `test_tracked_public_files_do_not_carry_this_machines_timezone` is a machine-timezone guard. CI should be green.

## One adjacent case, deliberately left alone

`SKILL.md` tells the reader to "strip signatures explicitly with `--clear-signatures` if that is intended", and `form_fill.py` implements no such flag — passing it is an `argparse` exit 2. Fixing that means either implementing signature stripping or correcting the document, which is a scope call rather than something to fold into input validation. Not filed yet; happy to take it if you want it as its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
