### PR TITLE
fix(skills): report the pages a pdf-toolkit split could not honour

### DIFF
--- a/src/agentos/skills/bundled/pdf-toolkit/SKILL.md
+++ b/src/agentos/skills/bundled/pdf-toolkit/SKILL.md
@@ -119,6 +119,18 @@ python {baseDir}/scripts/split.py input.pdf --pages "1-3,7,10-12" --out output_d
 Each range writes one output file: `output_dir/input_001.pdf`,
 `output_dir/input_002.pdf`, …
 
+Pages past the end of the document are dropped, so a range that overruns still
+writes its valid pages. The summary says which pages each file actually holds
+and which were out of range, because the file list alone cannot show it:
+
+```json
+{"files": ["output_dir/input_001.pdf"], "count": 1, "pages": [[3, 4, 5]],
+ "total_pages": 5, "pages_out_of_range": [6, 7]}
+```
+
+If no requested page exists in the document, nothing is written and the script
+exits 2.
+
 ---
 
 ## Path C: Form fill

--- a/src/agentos/skills/bundled/pdf-toolkit/scripts/split.py
+++ b/src/agentos/skills/bundled/pdf-toolkit/scripts/split.py
@@ -11,9 +11,20 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from pypdf import PdfReader, PdfWriter
+
+
+@dataclass
+class SplitResult:
+    """What a split produced, including the pages it could not honour."""
+
+    files: list[Path] = field(default_factory=list)
+    pages: list[list[int]] = field(default_factory=list)
+    total_pages: int = 0
+    pages_out_of_range: list[int] = field(default_factory=list)
 
 
 def split_ranges(spec: str) -> list[list[int]]:
@@ -33,13 +44,23 @@ def split_ranges(spec: str) -> list[list[int]]:
     return groups
 
 
-def split(input_path: Path, pages_spec: str, out_dir: Path) -> list[Path]:
+def split(input_path: Path, pages_spec: str, out_dir: Path) -> SplitResult:
+    """Write one file per range, and report what each one actually holds.
+
+    Pages past the end of the document are dropped rather than refused, so a
+    range that overruns still yields its valid pages — but the caller cannot
+    see that from the file list alone, which is why the dropped pages and the
+    per-file page lists are part of the result.
+    """
     reader = PdfReader(str(input_path))
     total = len(reader.pages)
     out_dir.mkdir(parents=True, exist_ok=True)
     written: list[Path] = []
+    pages_written: list[list[int]] = []
+    dropped: list[int] = []
     for idx, group in enumerate(split_ranges(pages_spec), start=1):
         valid_pages = [p for p in group if 1 <= p <= total]
+        dropped.extend(p for p in group if not 1 <= p <= total)
         if not valid_pages:
             continue
         writer = PdfWriter()
@@ -49,7 +70,13 @@ def split(input_path: Path, pages_spec: str, out_dir: Path) -> list[Path]:
         with out_path.open("wb") as fh:
             writer.write(fh)
         written.append(out_path)
-    return written
+        pages_written.append(valid_pages)
+    return SplitResult(
+        files=written,
+        pages=pages_written,
+        total_pages=total,
+        pages_out_of_range=dropped,
+    )
 
 
 def _parse_args() -> argparse.Namespace:
@@ -65,13 +92,26 @@ def main() -> int:
     if not args.input.is_file():
         print(f"error: input {args.input} not found", file=sys.stderr)
         return 2
-    written = split(args.input, args.pages, args.out)
+    result = split(args.input, args.pages, args.out)
     print(
         json.dumps(
-            {"files": [str(p) for p in written], "count": len(written)},
+            {
+                "files": [str(p) for p in result.files],
+                "count": len(result.files),
+                "pages": result.pages,
+                "total_pages": result.total_pages,
+                "pages_out_of_range": result.pages_out_of_range,
+            },
             ensure_ascii=False,
         )
     )
+    if not result.files:
+        print(
+            f"error: no requested page is within {args.input} "
+            f"(1-{result.total_pages}); nothing was written",
+            file=sys.stderr,
+        )
+        return 2
     return 0
 
 

--- a/tests/test_skill_pdf_toolkit.py
+++ b/tests/test_skill_pdf_toolkit.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -71,7 +72,9 @@ def test_merge_split_extract_round_trip(tmp_path: Path) -> None:
 
     out_dir = tmp_path / "split_out"
     parts = split.split(combined, "1,2", out_dir)
-    assert len(parts) == 2
+    assert len(parts.files) == 2
+    assert parts.pages == [[1], [2]]
+    assert parts.pages_out_of_range == []
 
     payload = extract.extract(combined, tables_strategy=None)
     assert payload["pages"] == 2
@@ -199,3 +202,144 @@ def test_tables_strategy_explicit_is_rejected_with_a_clear_message(
         extract.main()
     assert exc_info.value.code == 2
     assert "invalid choice: 'explicit'" in capsys.readouterr().err
+
+
+def _split_module():
+    sys.path.insert(0, str(SCRIPTS))
+    try:
+        import split  # type: ignore[import-not-found]
+    finally:
+        sys.path.pop(0)
+    return split
+
+
+def _make_n_page_pdf(path: Path, pages: int) -> None:
+    from reportlab.lib.pagesizes import LETTER
+    from reportlab.pdfgen import canvas
+
+    c = canvas.Canvas(str(path), pagesize=LETTER)
+    for page in range(1, pages + 1):
+        c.setFont("Helvetica", 14)
+        c.drawString(72, 720, f"PAGE {page}")
+        c.showPage()
+    c.save()
+
+
+def _page_count(path: Path) -> int:
+    from pypdf import PdfReader
+
+    return len(PdfReader(str(path)).pages)
+
+
+def test_split_reports_the_pages_each_output_actually_holds(tmp_path: Path) -> None:
+    """A range inside the document is unchanged, and now says what it wrote."""
+    split = _split_module()
+    src = tmp_path / "five.pdf"
+    _make_n_page_pdf(src, 5)
+
+    result = split.split(src, "1-3,5", tmp_path / "out")
+    assert [p.name for p in result.files] == ["five_001.pdf", "five_002.pdf"]
+    assert result.pages == [[1, 2, 3], [5]]
+    assert result.total_pages == 5
+    assert result.pages_out_of_range == []
+    assert [_page_count(p) for p in result.files] == [3, 1]
+
+
+def test_split_names_the_pages_an_overrunning_range_could_not_honour(
+    tmp_path: Path,
+) -> None:
+    """`3-7` on a 5-page document wrote a 3-page file and said nothing."""
+    split = _split_module()
+    src = tmp_path / "five.pdf"
+    _make_n_page_pdf(src, 5)
+
+    result = split.split(src, "3-7", tmp_path / "out")
+    assert len(result.files) == 1
+    assert _page_count(result.files[0]) == 3
+    assert result.pages == [[3, 4, 5]]
+    assert result.pages_out_of_range == [6, 7]
+
+
+def test_split_collects_out_of_range_pages_across_every_group(tmp_path: Path) -> None:
+    """Each range contributes its own rejects, in the order they were asked for."""
+    split = _split_module()
+    src = tmp_path / "five.pdf"
+    _make_n_page_pdf(src, 5)
+
+    result = split.split(src, "4-6,1-2,9", tmp_path / "out")
+    assert result.pages == [[4, 5], [1, 2]]
+    assert result.pages_out_of_range == [6, 9]
+
+
+def test_split_reports_a_page_below_the_first_as_out_of_range(tmp_path: Path) -> None:
+    """The other end of the clamp: page 0 is not a page either."""
+    split = _split_module()
+    src = tmp_path / "five.pdf"
+    _make_n_page_pdf(src, 5)
+
+    result = split.split(src, "0-2", tmp_path / "out")
+    assert result.pages == [[1, 2]]
+    assert result.pages_out_of_range == [0]
+
+
+def test_split_exits_non_zero_when_no_requested_page_exists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`7-9` on a 5-page document wrote nothing and exited 0."""
+    split = _split_module()
+    src = tmp_path / "five.pdf"
+    _make_n_page_pdf(src, 5)
+    out_dir = tmp_path / "out"
+
+    monkeypatch.setattr(
+        "sys.argv", ["split.py", str(src), "--pages", "7-9", "--out", str(out_dir)]
+    )
+    assert split.main() == 2
+    captured = capsys.readouterr()
+    assert "nothing was written" in captured.err
+    assert "1-5" in captured.err
+    payload = json.loads(captured.out)
+    assert payload["files"] == []
+    assert payload["pages_out_of_range"] == [7, 8, 9]
+    assert payload["total_pages"] == 5
+
+
+def test_split_exits_zero_when_a_partial_range_still_produced_a_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A short file is a result, not a failure — the report is what carries it."""
+    split = _split_module()
+    src = tmp_path / "five.pdf"
+    _make_n_page_pdf(src, 5)
+    out_dir = tmp_path / "out"
+
+    monkeypatch.setattr(
+        "sys.argv", ["split.py", str(src), "--pages", "3-7", "--out", str(out_dir)]
+    )
+    assert split.main() == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["count"] == 1
+    assert payload["pages"] == [[3, 4, 5]]
+    assert payload["pages_out_of_range"] == [6, 7]
+
+
+def test_split_keeps_its_existing_summary_keys(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`files` and `count` keep their shape; the new keys are additive."""
+    split = _split_module()
+    src = tmp_path / "five.pdf"
+    _make_n_page_pdf(src, 5)
+    out_dir = tmp_path / "out"
+
+    monkeypatch.setattr(
+        "sys.argv", ["split.py", str(src), "--pages", "1-2,4", "--out", str(out_dir)]
+    )
+    assert split.main() == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["count"] == 2
+    assert all(isinstance(name, str) for name in payload["files"])
+    assert [Path(name).name for name in payload["files"]] == [
+        "five_001.pdf",
+        "five_002.pdf",
+    ]


### PR DESCRIPTION
Fixes #1902

## The bug

`split.py` clamped every requested page to the document and threw the rejects away without a word:

```python
for idx, group in enumerate(split_ranges(pages_spec), start=1):
    valid_pages = [p for p in group if 1 <= p <= total]
    if not valid_pages:
        continue
```

A range that overruns the last page produced a **shorter PDF than the caller asked for**; a range entirely past the end produced nothing. Both reported success. Measured on `main` @ `8db605f3` against a 5-page document:

| `--pages` | stdout | exit | what the caller got |
|---|---|---|---|
| `1-3` | `{"files": ["…_001.pdf"], "count": 1}` | 0 | correct |
| `3-7` | `{"files": ["…_001.pdf"], "count": 1}` | 0 | a **3-page** file presented as pages 3–7 |
| `7-9` | `{"files": [], "count": 0}` | 0 | nothing, reported as success |

`split.py` has no way to learn the page count before it runs — `--pages` is written by the agent from the user's request, and "split out pages 7 to 9" on a document that turns out to be 5 pages long is an ordinary thing to ask. The agent reads exit 0 and reports the split as done. Nothing in `{"files": [...], "count": N}` distinguishes "wrote what you asked for" from "wrote part of it".

Same shape as #1674, where the watchers marked every item seen while reporting only `--limit` of them: the operation half-succeeds and the report cannot tell you.

## The fix

The clamp stays — a range that overruns should still yield its valid pages, and refusing the whole call would be a worse trade. What changes is that the result now carries what the file list cannot show:

```json
{"files": ["out/five_001.pdf"], "count": 1, "pages": [[3, 4, 5]],
 "total_pages": 5, "pages_out_of_range": [6, 7]}
```

and a split where no requested page exists writes nothing, says so on stderr, and exits 2 — the same convention `split.py` already uses for `error: input … not found`.

`files` and `count` keep their exact shape, so anything reading them today is unaffected; the three new keys are additive.

`split()` now returns a `SplitResult` dataclass rather than a bare `list[Path]`, because the page lists and the document length have to reach `main()` and the reader that knows them lives inside `split()`. That updates its one in-repo caller, the assertion in `test_merge_split_extract_round_trip`, which now also pins the new fields. The alternative — a back-compat wrapper around a second function — left a vestigial shim in an 80-line script, so I took the rename-free contract change instead. Happy to swap it if you would rather `split()` keep its old signature.

`SKILL.md` documents the summary and the exit-2 case in the same change.

## Tests

`tests/test_skill_pdf_toolkit.py`, offline and deterministic, no network and no credentials. PDFs are built in-test with `reportlab` and read back with `pypdf`, matching the `_make_one_page_pdf` helper already in the file. No new test file, so no basename collision.

- `test_split_reports_the_pages_each_output_actually_holds` — the in-range path, asserting file names, per-file page lists **and the real page count of each written PDF**, so the report cannot drift from the bytes.
- `test_split_names_the_pages_an_overrunning_range_could_not_honour` — `3-7` on 5 pages: one file, 3 pages in it, `pages_out_of_range == [6, 7]`.
- `test_split_collects_out_of_range_pages_across_every_group` — `4-6,1-2,9`, so rejects from more than one group accumulate in request order.
- `test_split_reports_a_page_below_the_first_as_out_of_range` — **the direction the issue did not report**: the clamp has a lower bound too, and `0-2` must name page 0 as dropped.
- `test_split_exits_non_zero_when_no_requested_page_exists` — exit 2, `nothing was written` and the `1-5` bound on stderr, and the JSON still emitted.
- `test_split_exits_zero_when_a_partial_range_still_produced_a_file` — a short file stays a success; only a completely empty split fails.
- `test_split_keeps_its_existing_summary_keys` — `count`, and `files` still a list of strings in order.
- `test_merge_split_extract_round_trip` (existing) — updated for the new return type and now pins `pages`/`pages_out_of_range` on the happy path.

**7 of these fail on unmodified `split.py`** — every one above except `test_split_keeps_its_existing_summary_keys`.

That one **passes either way by design**: it exists to prove the change is additive rather than to catch the bug, and it would only fail if `files`/`count` were reshaped.

## Verification

```
$ uv run pytest tests/test_skill_pdf_toolkit.py -q
16 passed in 0.58s

$ git show upstream/main:src/agentos/skills/bundled/pdf-toolkit/scripts/split.py > …/split.py
$ uv run pytest tests/test_skill_pdf_toolkit.py -q
7 failed, 9 passed in 0.55s

$ uv run ruff check src tests
All checks passed!

$ uv run mypy --show-error-codes src
Success: no issues found in 627 source files

$ uv run pytest -q
6 failed, 10726 passed, 34 skipped, 4 warnings, 3 errors in 254.83s
```

The 6 failures and 3 errors are pre-existing on `upstream/main` @ `8db605f3` in this environment and untouched by this change: `test_pilot_encoder`, `test_build_wheelhouse_zip` and `test_pilot_benchmark` need a hydrated MiniLM ONNX asset that is not present locally, and `test_tracked_public_files_do_not_carry_this_machines_timezone` is a machine-timezone guard. CI should be green.

## Two adjacent cases, deliberately left alone

**Output numbering.** The `enumerate` index counts skipped groups, so `--pages "7-9,1-2"` writes `…_002.pdf` with no `…_001.pdf` beside it. Renumbering would change output filenames for callers that map the index back to the requested range, which is a breaking change for a cosmetic gap — and now that `pages` and `pages_out_of_range` are reported, the hole is explainable rather than mysterious. I would rather you decide that one than have it arrive inside a reporting fix.

**Malformed specs.** `split_ranges` raises a bare `ValueError` traceback on `--pages "1-3,abc"` — or on an en-dash `1–3`, which a model writes more often than one would like — instead of the clean `error: …` + exit 2 used everywhere else. Separate defect, separate fix; I flagged it in #1902 and will file it on its own if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
