### PR TITLE
fix(tools): report a missing base path from glob_search and grep_search

### DIFF
--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -1035,6 +1035,12 @@ async def glob_search(pattern: str, path: str | None = None) -> str:
     if blocked is not None:
         return json.dumps(blocked)
     _gate_workspace_strict_read("glob_search", base, path or str(base))
+    # After the access gates, never before: a blocked path must report as
+    # blocked rather than leak its existence through this error. "No matches"
+    # for a path that is not there is not self-correcting -- the model reads
+    # it as "the symbol does not exist" and stops looking.
+    if not base.exists():
+        raise FileNotFoundError(f"Path not found: {path or base}")
 
     loop = asyncio.get_running_loop()
     strict_roots = _strict_read_roots()
@@ -1117,6 +1123,12 @@ async def grep_search(
     if blocked is not None:
         return json.dumps(blocked)
     _gate_workspace_strict_read("grep_search", base, path or str(base))
+    # After the access gates, never before: a blocked path must report as
+    # blocked rather than leak its existence through this error. "No matches"
+    # for a path that is not there is not self-correcting -- the model reads
+    # it as "the symbol does not exist" and stops looking.
+    if not base.exists():
+        raise FileNotFoundError(f"Path not found: {path or base}")
 
     loop = asyncio.get_running_loop()
     strict_roots = _strict_read_roots()

--- a/tests/test_tools/test_search_missing_base_path.py
+++ b/tests/test_tools/test_search_missing_base_path.py
@@ -1,0 +1,214 @@
+"""``glob_search``/``grep_search`` report a missing base path instead of "no matches".
+
+Both tools resolved the base and searched it without checking that it exists,
+so a typo'd directory answered ``No matches`` -- which is not self-correcting:
+the model reads it as "the symbol is not in this codebase" and stops looking,
+rather than as "you named a directory that is not there". Every other
+filesystem tool raises ``FileNotFoundError`` for the same input.
+
+These tests pin the new contract, the error's agreement with ``list_dir``, and
+-- the part that is easy to get wrong -- that the check sits *after* the
+workspace-strict gate, so strict mode does not become an existence oracle for
+paths outside the workspace.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from agentos.tools.builtin import filesystem as fs
+from agentos.tools.types import (
+    CallerKind,
+    ToolContext,
+    WorkspaceAccessError,
+    current_tool_context,
+)
+
+
+@contextmanager
+def _tool_context(workspace: Path, *, strict: bool = True) -> Iterator[None]:
+    token = current_tool_context.set(
+        ToolContext(
+            caller_kind=CallerKind.CLI,
+            channel_kind="cli",
+            channel_id="cli:test",
+            workspace_dir=str(workspace),
+            workspace_strict=strict,
+        )
+    )
+    try:
+        yield
+    finally:
+        current_tool_context.reset(token)
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    ws = tmp_path / "workspace"
+    (ws / "src").mkdir(parents=True)
+    (ws / "src" / "app.py").write_text("needle = 1\n", encoding="utf-8")
+    return ws
+
+
+# ── The base does not exist ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_glob_search_names_the_missing_directory(workspace: Path) -> None:
+    with _tool_context(workspace):
+        with pytest.raises(FileNotFoundError) as excinfo:
+            await fs.glob_search("*.py", path=str(workspace / "scr"))
+    assert "scr" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_grep_search_names_the_missing_directory(workspace: Path) -> None:
+    with _tool_context(workspace):
+        with pytest.raises(FileNotFoundError) as excinfo:
+            await fs.grep_search("needle", path=str(workspace / "scr"))
+    assert "scr" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_the_error_reports_the_path_the_caller_typed(workspace: Path) -> None:
+    """A resolved absolute path the caller never wrote is not a usable hint."""
+    with _tool_context(workspace):
+        with pytest.raises(FileNotFoundError) as excinfo:
+            await fs.grep_search("needle", path="src/nope")
+    assert "src/nope" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_grep_search_checks_the_base_before_applying_include(
+    workspace: Path,
+) -> None:
+    """The include filter must not turn a missing directory back into no-matches."""
+    with _tool_context(workspace):
+        with pytest.raises(FileNotFoundError):
+            await fs.grep_search("needle", path=str(workspace / "gone"), include="*.py")
+
+
+@pytest.mark.asyncio
+async def test_a_missing_file_base_is_reported_too(workspace: Path) -> None:
+    """``grep_search`` accepts a file as its base, so a missing file counts."""
+    with _tool_context(workspace):
+        with pytest.raises(FileNotFoundError):
+            await fs.grep_search("needle", path=str(workspace / "src" / "gone.py"))
+
+
+@pytest.mark.asyncio
+async def test_a_deeply_nested_missing_path_is_reported(workspace: Path) -> None:
+    with _tool_context(workspace):
+        with pytest.raises(FileNotFoundError):
+            await fs.glob_search("*.py", path=str(workspace / "a" / "b" / "c"))
+
+
+@pytest.mark.asyncio
+async def test_a_symlink_to_a_removed_target_is_reported(workspace: Path) -> None:
+    """``exists()`` follows the link, so a dangling link is a missing path."""
+    target = workspace / "real"
+    target.mkdir()
+    link = workspace / "link"
+    link.symlink_to(target, target_is_directory=True)
+    target.rmdir()
+    with _tool_context(workspace):
+        with pytest.raises(FileNotFoundError):
+            await fs.grep_search("needle", path=str(link))
+
+
+@pytest.mark.asyncio
+async def test_the_error_agrees_with_list_dir_on_the_same_input(
+    workspace: Path,
+) -> None:
+    """"The same error the other tools raise" -- pinned, not assumed."""
+    missing = str(workspace / "scr")
+    with _tool_context(workspace):
+        with pytest.raises(FileNotFoundError) as from_list_dir:
+            await fs.list_dir(missing)
+        with pytest.raises(FileNotFoundError) as from_grep:
+            await fs.grep_search("needle", path=missing)
+        with pytest.raises(FileNotFoundError) as from_glob:
+            await fs.glob_search("*.py", path=missing)
+    prefix = "Path not found:"
+    assert str(from_list_dir.value).startswith(prefix)
+    assert str(from_grep.value).startswith(prefix)
+    assert str(from_glob.value).startswith(prefix)
+
+
+# ── Ordering: the gate wins, so this is not an existence oracle ──────────────
+
+
+@pytest.mark.asyncio
+async def test_a_missing_path_outside_the_workspace_is_refused_not_reported(
+    workspace: Path, tmp_path: Path
+) -> None:
+    """Strict mode must not learn to answer "does this outside path exist?".
+
+    ``_gate_workspace_strict_read``'s own docstring requires existence checks
+    to sit behind it. If this check ran first, the two outside paths below
+    would return different errors and that difference is the oracle.
+    """
+    outside_missing = str(tmp_path / "elsewhere" / "gone")
+    with _tool_context(workspace):
+        with pytest.raises(WorkspaceAccessError):
+            await fs.grep_search("needle", path=outside_missing)
+        with pytest.raises(WorkspaceAccessError):
+            await fs.glob_search("*.py", path=outside_missing)
+
+
+@pytest.mark.asyncio
+async def test_outside_paths_are_indistinguishable_whether_they_exist_or_not(
+    workspace: Path, tmp_path: Path
+) -> None:
+    """The existing and the missing outside path must fail the same way."""
+    present = tmp_path / "elsewhere"
+    present.mkdir()
+    missing = tmp_path / "elsewhere-gone"
+    with _tool_context(workspace):
+        with pytest.raises(WorkspaceAccessError) as for_present:
+            await fs.grep_search("needle", path=str(present))
+        with pytest.raises(WorkspaceAccessError) as for_missing:
+            await fs.grep_search("needle", path=str(missing))
+    assert type(for_present.value) is type(for_missing.value)
+
+
+# ── The direction the issue did not ask about: no over-correction ────────────
+
+
+@pytest.mark.asyncio
+async def test_an_existing_directory_with_no_matches_is_still_not_an_error(
+    workspace: Path,
+) -> None:
+    """"No matches" stays the answer when the path is real and empty of hits."""
+    with _tool_context(workspace):
+        out = await fs.grep_search("definitely-absent-symbol", path=str(workspace))
+    assert "No matches" in out
+
+
+@pytest.mark.asyncio
+async def test_glob_search_with_no_hits_in_a_real_directory_still_returns_text(
+    workspace: Path,
+) -> None:
+    with _tool_context(workspace):
+        out = await fs.glob_search("*.rs", path=str(workspace / "src"))
+    assert "No files matched" in out
+
+
+@pytest.mark.asyncio
+async def test_the_default_base_is_never_reported_missing(workspace: Path) -> None:
+    """``path=None`` resolves to the workspace root, which exists."""
+    with _tool_context(workspace):
+        assert "app.py" in await fs.glob_search("**/*.py")
+        assert "needle" in await fs.grep_search("needle")
+
+
+@pytest.mark.asyncio
+async def test_an_existing_file_base_still_searches_that_file(workspace: Path) -> None:
+    """A file base is legitimate for grep_search and must not become an error."""
+    with _tool_context(workspace):
+        out = await fs.grep_search("needle", path=str(workspace / "src" / "app.py"))
+    assert "app.py:1:" in out


### PR DESCRIPTION
Fixes #1802

## The bug

`glob_search` and `grep_search` resolve their base and search it, with no check that the base is there:

```python
base = _resolve_base(path)
blocked = _sensitive_access_block("grep_search", base, path or str(base))
...
_gate_workspace_strict_read("grep_search", base, path or str(base))
# straight into the walk
```

`Path.rglob`/`Path.glob` on a directory that does not exist yields nothing, so a typo'd path returns `No matches for '<pattern>'`. As the triage note puts it, that answer is not self-correcting: the model concludes the symbol does not exist and stops looking, instead of re-reading the path it just typed. Every other filesystem tool in this module raises for the same input — `read_file` and friends with `File not found:`, `list_dir` with `Path not found:`.

Measured on `main` @ `8db605f3`, workspace containing `src/app.py`:

| call | before | after |
|---|---|---|
| `grep_search("needle", path="src/nope")` | `No matches for 'needle'` | `FileNotFoundError: Path not found: src/nope` |
| `glob_search("*.py", path=".../scr")` | `No files matched pattern '*.py' in …` | `FileNotFoundError: Path not found: …/scr` |
| `list_dir(".../scr")` | `FileNotFoundError: Path not found: …` | unchanged |

## The fix

One existence check per tool, and nothing else:

```python
if not base.exists():
    raise FileNotFoundError(f"Path not found: {path or base}")
```

Message and exception type are taken from `list_dir`, the tool the triage note points at, rather than invented.

**Placement is the part worth reviewing.** The check goes *after* `_sensitive_access_block` and `_gate_workspace_strict_read`, because that gate's own docstring requires it:

> Call this after sensitive-path checks so sensitive hard-blocks keep higher priority, and **before existence/metadata checks so strict mode does not become an existence oracle for outside paths.**

Put the existence check first and a caller in strict mode could tell an existing outside directory (`WorkspaceAccessError`) from a missing one (`FileNotFoundError`), which is exactly the oracle that docstring forbids. Two of the tests below pin that.

Deliberately not changed, per "No other behaviour changes": no `NotADirectoryError` for a file base (`grep_search` legitimately searches a single file, and `glob_search` on a file is a no-match, not an error), no change to the no-match strings, no docs change — `docs/tools-and-sandbox.md` only lists the tool names and never documented the missing-path behaviour.

## Tests

`tests/test_tools/test_search_missing_base_path.py` — new file, offline, deterministic, no network and no credentials. Basename checked against the tree (`find tests -name "test_*.py" -exec basename {} \; | sort | uniq -d` is empty), so no pytest collection collision.

**The bug, both tools (8 cases, all failing without the fix):**

- `test_glob_search_names_the_missing_directory`, `test_grep_search_names_the_missing_directory`
- `test_the_error_reports_the_path_the_caller_typed` — a resolved absolute path the caller never wrote is not a usable hint
- `test_grep_search_checks_the_base_before_applying_include` — the `include` filter must not turn a missing directory back into a no-match
- `test_a_missing_file_base_is_reported_too` — `grep_search` accepts a file base, so a missing file counts
- `test_a_deeply_nested_missing_path_is_reported`
- `test_a_symlink_to_a_removed_target_is_reported` — `exists()` follows the link, so a dangling link is a missing path
- `test_the_error_agrees_with_list_dir_on_the_same_input` — "the same error the other tools raise", pinned rather than assumed: `list_dir`, `grep_search` and `glob_search` on one missing path all raise `FileNotFoundError` with the same `Path not found:` prefix

**Ordering — that this did not become an existence oracle (2 cases):**

- `test_a_missing_path_outside_the_workspace_is_refused_not_reported` — a missing outside path still raises `WorkspaceAccessError`, not `FileNotFoundError`
- `test_outside_paths_are_indistinguishable_whether_they_exist_or_not` — an existing and a missing outside path fail identically

**The direction the issue did not ask about — no over-correction (4 cases):**

- `test_an_existing_directory_with_no_matches_is_still_not_an_error`
- `test_glob_search_with_no_hits_in_a_real_directory_still_returns_text`
- `test_the_default_base_is_never_reported_missing` — `path=None` resolves to the workspace root
- `test_an_existing_file_base_still_searches_that_file`

**8 of the 14 fail on unmodified `filesystem.py`** — every case in the first group.

The other 6 **pass either way by design**: the two ordering cases would only fail if the check were placed ahead of the gates, and the four no-over-correction cases would only fail if the check reached past a missing base. They are the guardrails on this change, not detectors of the original bug, and I would rather say so than pad the count.

## Verification

```
$ uv run pytest tests/test_tools/test_search_missing_base_path.py -q
14 passed in 1.23s

$ git show upstream/main:src/agentos/tools/builtin/filesystem.py > …/filesystem.py
$ uv run pytest tests/test_tools/test_search_missing_base_path.py -q
8 failed, 6 passed in 1.25s

$ uv run ruff check src tests
All checks passed!

$ uv run mypy --show-error-codes src
Success: no issues found in 627 source files

$ uv run pytest -q
6 failed, 10733 passed, 34 skipped, 4 warnings, 3 errors in 257.48s
```

The 6 failures and 3 errors are pre-existing on `upstream/main` @ `8db605f3` in this environment and untouched by this change: `test_pilot_encoder`, `test_build_wheelhouse_zip` and `test_pilot_benchmark` need a hydrated MiniLM ONNX asset that is not present locally, and `test_tracked_public_files_do_not_carry_this_machines_timezone` is a machine-timezone guard. CI should be green.

## One adjacent case, deliberately left alone

`glob_search` on a base that exists but is a *file* returns `No files matched …` rather than `NotADirectoryError`, which is what `list_dir` would raise. Making the two agree there is a behaviour change beyond the existence check this issue scopes, and `grep_search` deliberately accepts a file base, so the two tools would need different answers. Left as-is; happy to take it as its own issue if you want the symmetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
