### PR TITLE
fix(channels): treat already_reacted and no_reaction as successful no-ops

### DIFF
--- a/src/agentos/channels/_reactions.py
+++ b/src/agentos/channels/_reactions.py
@@ -11,6 +11,11 @@ from agentos.channels.types import IncomingMessage
 
 SLACK_STATUS_EMOJI = {"received": "white_check_mark", "running": "eyes", "failed": "x"}
 
+#: Slack errors that report the reaction is already in the state we asked for.
+#: Deliberately narrow: an error meaning the call did not happen (``ratelimited``)
+#: must still surface, so it is not in here.
+_BENIGN_SLACK_REACTION_ERRORS = frozenset({"already_reacted", "no_reaction"})
+
 class StatusReactor(Protocol):
     async def received(self, message: IncomingMessage) -> None: ...
     async def running(self, message: IncomingMessage) -> None: ...
@@ -90,7 +95,15 @@ class SlackStatusReactor(_BaseStatusReactor):
         if resp.status_code == 403: self._disable("missing_oauth_scope"); return False
         resp.raise_for_status(); data = resp.json()
         if data.get("ok"): return True
-        if data.get("error") in {"missing_scope", "not_allowed_token_type"}: self._disable("missing_oauth_scope"); return False
-        raise RuntimeError(f"Slack API error: {data.get('error')}")
+        error = data.get("error")
+        # The desired end state was already true: the emoji is on the message
+        # (Slack retries an event on timeout, so ``received`` runs twice) or it
+        # is already gone (a human removed it). Neither says anything about the
+        # bot's permissions, and treating them as fatal disabled reactions for
+        # the rest of the adapter's life -- ``_disabled`` is only ever cleared
+        # in ``__init__``.
+        if error in _BENIGN_SLACK_REACTION_ERRORS: return True
+        if error in {"missing_scope", "not_allowed_token_type"}: self._disable("missing_oauth_scope"); return False
+        raise RuntimeError(f"Slack API error: {error}")
 
 NULL_STATUS_REACTOR = NullStatusReactor()

--- a/tests/test_channels/test_slack_reaction_benign_errors.py
+++ b/tests/test_channels/test_slack_reaction_benign_errors.py
@@ -1,0 +1,318 @@
+"""Benign Slack reaction errors must not switch status reactions off for good.
+
+``_post`` raised ``RuntimeError`` for every non-``ok`` response except the two
+auth-shaped ones, and ``_add_state``/``_clear_active`` turn any exception into
+``_disable(...)`` -- which is permanent, since ``_disabled`` is only ever set
+back to ``False`` in ``__init__``. Slack retries an event on timeout, so
+``already_reacted`` is a routine response to ``received()``; ``no_reaction``
+is what a human removing the emoji produces. Either one silenced ✅/👀/❌ for
+every later message the adapter handled.
+
+These tests drive the real ``SlackStatusReactor._post`` through a scripted
+HTTP client rather than a hand-rolled fake, and cover the part the reactor is
+actually judged on: that a *subsequent* message still gets its reaction, that
+``_active`` is left in the right state, and that every error which genuinely
+means "the call did not happen" still disables.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agentos.channels._reactions import SlackStatusReactor
+from agentos.channels.types import IncomingMessage
+
+
+class _SilentLog:
+    def warning(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+
+def _message(ts: str = "1700000000.000100", channel: str = "C1") -> IncomingMessage:
+    return IncomingMessage(
+        sender_id="U1", channel_id=channel, content="hi", metadata={"ts": ts}
+    )
+
+
+def _response(body: dict[str, Any], status_code: int = 200) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = body
+    return resp
+
+
+def _reactor(responder: Any) -> tuple[SlackStatusReactor, MagicMock]:
+    """Build a reactor whose Slack client answers through *responder*.
+
+    *responder* takes ``(path, payload)`` and returns the JSON body.
+    """
+    client = MagicMock()
+
+    async def _post(path: str, json: dict[str, str]) -> MagicMock:
+        body = responder(path, json)
+        return _response(body) if isinstance(body, dict) else body
+
+    client.post = AsyncMock(side_effect=_post)
+    channel = MagicMock()
+    channel._get_client.return_value = client
+    return SlackStatusReactor(channel, _SilentLog()), client
+
+
+def _always(body: dict[str, Any]) -> Any:
+    return lambda path, payload: body
+
+
+def _added_emoji(client: MagicMock) -> list[str]:
+    return [
+        call.kwargs["json"]["name"]
+        for call in client.post.await_args_list
+        if call.args[0] == "/reactions.add"
+    ]
+
+
+def _removed_emoji(client: MagicMock) -> list[str]:
+    return [
+        call.kwargs["json"]["name"]
+        for call in client.post.await_args_list
+        if call.args[0] == "/reactions.remove"
+    ]
+
+
+# ── The reported symptom: reactions keep working afterwards ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_later_message_still_gets_its_reaction_after_already_reacted() -> None:
+    """The headline of #1756 -- not just ``_disabled``, but the next message.
+
+    Slack redelivering one event must not cost every *other* conversation its
+    status reactions.
+    """
+    seen: list[str] = []
+
+    def responder(path: str, payload: dict[str, str]) -> dict[str, Any]:
+        seen.append(payload["timestamp"])
+        # Only the retried first message is already reacted to.
+        if payload["timestamp"] == "111.000":
+            return {"ok": False, "error": "already_reacted"}
+        return {"ok": True}
+
+    reactor, client = _reactor(responder)
+
+    await reactor.received(_message(ts="111.000"))
+    await reactor.received(_message(ts="222.000"))
+
+    assert reactor._disabled is False
+    assert _added_emoji(client) == ["white_check_mark", "white_check_mark"]
+    assert seen == ["111.000", "222.000"]
+
+
+@pytest.mark.asyncio
+async def test_a_later_message_still_gets_its_reaction_after_no_reaction() -> None:
+    """Same, through the remove path: a human un-reacting must cost nothing."""
+
+    def responder(path: str, payload: dict[str, str]) -> dict[str, Any]:
+        if path == "/reactions.remove":
+            return {"ok": False, "error": "no_reaction"}
+        return {"ok": True}
+
+    reactor, client = _reactor(responder)
+
+    first = _message(ts="111.000")
+    await reactor.received(first)
+    await reactor.completed(first)
+    await reactor.received(_message(ts="222.000"))
+
+    assert reactor._disabled is False
+    assert _added_emoji(client) == ["white_check_mark", "white_check_mark"]
+    assert _removed_emoji(client) == ["white_check_mark"]
+
+
+# ── Tracked state after a benign no-op ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_already_reacted_still_tracks_the_mark_for_later_removal() -> None:
+    """The emoji *is* on the message, so the reactor still owes a removal."""
+    reactor, client = _reactor(_always({"ok": False, "error": "already_reacted"}))
+    message = _message()
+
+    await reactor.received(message)
+
+    key = reactor._message_key(message)
+    assert reactor._active[key] == [
+        {"channel": "C1", "timestamp": "1700000000.000100", "name": "white_check_mark"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_no_reaction_on_completion_leaves_no_tracked_entry_behind() -> None:
+    """A stale ``_active`` key would leak once per message for the adapter's life."""
+
+    def responder(path: str, payload: dict[str, str]) -> dict[str, Any]:
+        if path == "/reactions.remove":
+            return {"ok": False, "error": "no_reaction"}
+        return {"ok": True}
+
+    reactor, _client = _reactor(responder)
+    message = _message()
+
+    await reactor.received(message)
+    await reactor.completed(message)
+
+    assert reactor._active.get(reactor._message_key(message), []) == []
+    assert reactor._disabled is False
+
+
+@pytest.mark.asyncio
+async def test_one_message_hitting_a_benign_error_does_not_touch_another() -> None:
+    """Cross-message isolation: the buckets are per-``ts`` and stay that way."""
+
+    def responder(path: str, payload: dict[str, str]) -> dict[str, Any]:
+        if payload["timestamp"] == "111.000":
+            return {"ok": False, "error": "already_reacted"}
+        return {"ok": True}
+
+    reactor, _client = _reactor(responder)
+    benign = _message(ts="111.000")
+    ordinary = _message(ts="222.000")
+
+    await reactor.received(benign)
+    await reactor.received(ordinary)
+    await reactor.completed(benign)
+
+    assert reactor._active.get("111.000", []) == []
+    assert len(reactor._active["222.000"]) == 1
+    assert reactor._disabled is False
+
+
+# ── Whole lifecycles under benign errors ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_the_full_success_lifecycle_survives_benign_errors_throughout() -> None:
+    """received → running → completed with every call answering "already so"."""
+
+    def responder(path: str, payload: dict[str, str]) -> dict[str, Any]:
+        if path == "/reactions.add":
+            return {"ok": False, "error": "already_reacted"}
+        return {"ok": False, "error": "no_reaction"}
+
+    reactor, client = _reactor(responder)
+    message = _message()
+
+    await reactor.received(message)
+    await reactor.running(message)
+    await reactor.completed(message)
+
+    assert reactor._disabled is False
+    assert _added_emoji(client) == ["white_check_mark", "eyes"]
+    assert _removed_emoji(client) == ["white_check_mark", "eyes"]
+    assert reactor._active.get(reactor._message_key(message), []) == []
+
+
+@pytest.mark.asyncio
+async def test_failed_still_posts_the_outcome_mark_after_a_benign_clear() -> None:
+    """``failed()`` clears progress marks first; that must not cost the ❌."""
+
+    def responder(path: str, payload: dict[str, str]) -> dict[str, Any]:
+        if path == "/reactions.remove":
+            return {"ok": False, "error": "no_reaction"}
+        return {"ok": True}
+
+    reactor, client = _reactor(responder)
+    message = _message()
+
+    await reactor.received(message)
+    await reactor.failed(message)
+
+    assert reactor._disabled is False
+    assert _added_emoji(client) == ["white_check_mark", "x"]
+
+
+# ── Errors that mean the call did not happen still disable ───────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error",
+    ["ratelimited", "channel_not_found", "message_not_found", "invalid_name", "fatal_error"],
+)
+async def test_an_error_meaning_the_call_failed_still_disables(error: str) -> None:
+    """The benign set must stay exactly two entries wide.
+
+    ``ratelimited`` in particular means the reaction was *not* applied, so
+    reporting success would leave the message unmarked with nothing to notice.
+    """
+    reactor, _client = _reactor(_always({"ok": False, "error": error}))
+
+    await reactor.received(_message())
+
+    assert reactor._disabled is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error", ["missing_scope", "not_allowed_token_type"])
+async def test_auth_shaped_errors_still_disable(error: str) -> None:
+    reactor, _client = _reactor(_always({"ok": False, "error": error}))
+
+    await reactor.received(_message())
+
+    assert reactor._disabled is True
+
+
+@pytest.mark.asyncio
+async def test_a_403_still_disables() -> None:
+    client = MagicMock()
+    client.post = AsyncMock(return_value=_response({}, status_code=403))
+    channel = MagicMock()
+    channel._get_client.return_value = client
+    reactor = SlackStatusReactor(channel, _SilentLog())
+
+    await reactor.received(_message())
+
+    assert reactor._disabled is True
+
+
+@pytest.mark.asyncio
+async def test_an_http_error_still_disables() -> None:
+    """``raise_for_status`` fires before the body is ever inspected."""
+    resp = _response({"ok": False, "error": "already_reacted"})
+    resp.raise_for_status.side_effect = RuntimeError("500 Server Error")
+    client = MagicMock()
+    client.post = AsyncMock(return_value=resp)
+    channel = MagicMock()
+    channel._get_client.return_value = client
+    reactor = SlackStatusReactor(channel, _SilentLog())
+
+    await reactor.received(_message())
+
+    assert reactor._disabled is True
+
+
+@pytest.mark.asyncio
+async def test_a_benign_error_does_not_rescue_a_reactor_already_disabled() -> None:
+    """Once off, the reactor stays off -- this change adds no recovery path."""
+    responses = iter(
+        [
+            _response({"ok": False, "error": "ratelimited"}),
+            _response({"ok": False, "error": "already_reacted"}),
+        ]
+    )
+    client = MagicMock()
+    client.post = AsyncMock(side_effect=lambda path, json: next(responses))
+    channel = MagicMock()
+    channel._get_client.return_value = client
+    reactor = SlackStatusReactor(channel, _SilentLog())
+
+    await reactor.received(_message(ts="111.000"))
+    assert reactor._disabled is True
+
+    await reactor.received(_message(ts="222.000"))
+
+    assert reactor._disabled is True
+    assert client.post.await_count == 1, "a disabled reactor must not call Slack again"


### PR DESCRIPTION
Fixes #1756

## The bug

`SlackStatusReactor._post` treats every non-`ok` response but the two auth-shaped ones as fatal:

```python
if data.get("ok"): return True
if data.get("error") in {"missing_scope", "not_allowed_token_type"}: self._disable("missing_oauth_scope"); return False
raise RuntimeError(f"Slack API error: {data.get('error')}")
```

and both callers turn any exception into a `_disable(...)`:

```python
except Exception as exc:
    self._warn_failure(f"add:{state}", exc)
    self._disable(f"add_failed:{type(exc).__name__}")
```

`_disable` is permanent — `_disabled` is only ever set back to `False` in `__init__`, so there is no recovery path short of restarting the adapter.

Two routine Slack answers land in that fatal branch:

- **`already_reacted`** — Slack retries an event when the app does not ack in time, so `received()` runs twice on the same `ts` and the second `reactions.add` reports the emoji is already there.
- **`no_reaction`** — a human removed the emoji before `completed()` got to reclaim it.

Neither says anything about the bot's permissions or setup. Both mean **the desired end state was already true**. The cost was one redelivered event silencing ✅/👀/❌ for every message the adapter handled afterwards, across every channel it serves.

## The fix

```python
#: Slack errors that report the reaction is already in the state we asked for.
#: Deliberately narrow: an error meaning the call did not happen (``ratelimited``)
#: must still surface, so it is not in here.
_BENIGN_SLACK_REACTION_ERRORS = frozenset({"already_reacted", "no_reaction"})
```

checked after `ok` and before the auth branch, so the auth-shaped errors keep disabling exactly as they did. No retry layer, no change to `_disable`, no change to the auth branch or the 403 branch, no recovery path added.

**On `ratelimited`.** The triage note mentions it alongside the two benign errors when describing the blast radius, but the Scope line names only `already_reacted` / `no_reaction`, and it ends with "Do not add a general retry layer" — and rate limiting is precisely the case that would need one. So I read `ratelimited` as out of scope and left it disabling, with a test pinning that. Treating it as success would be actively worse than today: the reaction genuinely was not applied, and reporting success leaves the message unmarked with nothing anywhere to notice. Say the word if you want it handled and I will take it as a follow-up.

## Tests

`tests/test_channels/test_slack_reaction_benign_errors.py` — new file, offline, deterministic, no network and no credentials. Basename checked against the tree (`find tests -name "test_*.py" -exec basename {} \; | sort | uniq -d` is empty). Every case drives the real `SlackStatusReactor._post` through a scripted HTTP client keyed on path and payload, not a hand-rolled reactor subclass, so the branch under test is the one that ships.

**The reported symptom — reactions still work afterwards (2 cases):**

- `test_a_later_message_still_gets_its_reaction_after_already_reacted` — the headline of the issue. Not just `_disabled is False`: message `111.000` is redelivered and answers `already_reacted`, then message `222.000` must still produce its own `/reactions.add`. Asserted on the emoji actually posted per call.
- `test_a_later_message_still_gets_its_reaction_after_no_reaction` — same through the remove path.

**Tracked state after a benign no-op (3 cases):**

- `test_already_reacted_still_tracks_the_mark_for_later_removal` — asserts the exact `_active` payload: the emoji *is* on the message, so the reactor still owes a removal and must not silently drop the token.
- `test_no_reaction_on_completion_leaves_no_tracked_entry_behind` — a stale `_active` key would leak once per message for the adapter's lifetime, the same leak #1560 fixed on the other path.
- `test_one_message_hitting_a_benign_error_does_not_touch_another` — cross-message isolation: one `ts` bucket emptied, the other still holding its mark.

**Whole lifecycles (2 cases):**

- `test_the_full_success_lifecycle_survives_benign_errors_throughout` — received → running → completed with every add answering `already_reacted` and every remove answering `no_reaction`; asserts the four calls, the order, and that `_active` ends empty.
- `test_failed_still_posts_the_outcome_mark_after_a_benign_clear` — `failed()` clears progress marks before adding ❌, so a benign clear must not cost the outcome marker.

**The set must not widen (10 cases):**

- `test_an_error_meaning_the_call_failed_still_disables` — `ratelimited`, `channel_not_found`, `message_not_found`, `invalid_name`, `fatal_error`.
- `test_auth_shaped_errors_still_disable` — `missing_scope`, `not_allowed_token_type`.
- `test_a_403_still_disables`, `test_an_http_error_still_disables` — the status-code branch and the `raise_for_status` branch, which sit before the body is ever inspected.
- `test_a_benign_error_does_not_rescue_a_reactor_already_disabled` — once off, stays off, and the disabled reactor makes no further Slack call at all (`await_count == 1`).

**7 of the 17 fail on unmodified `_reactions.py`** — every case in the first three groups.

The 10 in the last group **pass either way by design**. They are the fence around the two-entry set rather than detectors of the original bug, and they are the reason I am comfortable that this does not reach past its scope.

## Verification

```
$ uv run pytest tests/test_channels/test_slack_reaction_benign_errors.py -q
17 passed in 1.26s

$ git show upstream/main:src/agentos/channels/_reactions.py > …/_reactions.py
$ uv run pytest tests/test_channels/test_slack_reaction_benign_errors.py -q
7 failed, 10 passed in 1.20s

$ uv run pytest tests/test_channels/ -q
560 passed in 11.92s

$ uv run ruff check src tests
All checks passed!

$ uv run mypy --show-error-codes src
Success: no issues found in 627 source files

$ uv run pytest -q
6 failed, 10736 passed, 34 skipped, 4 warnings, 3 errors in 255.34s
```

The 6 failures and 3 errors are pre-existing on `upstream/main` @ `8db605f3` in this environment and untouched by this change: `test_pilot_encoder`, `test_build_wheelhouse_zip` and `test_pilot_benchmark` need a hydrated MiniLM ONNX asset that is not present locally, and `test_tracked_public_files_do_not_carry_this_machines_timezone` is a machine-timezone guard. CI should be green.

## Two adjacent cases, deliberately left alone

**No recovery path.** `_disabled` is still one-way. A transient failure that *should* disable still costs the adapter its reactions until restart, which is arguably worth revisiting — but it is a lifecycle change, not the two-error classification this issue scopes, and it is the thing most likely to turn into the retry layer the triage note rules out.

**The Telegram reactor.** `_BaseStatusReactor`'s disable-on-any-exception behaviour is shared, but the benign-error vocabulary is Slack's; nothing was changed in the base class, so no other adapter's behaviour moves.

I am aware #1767 and #1880 are open on this issue and reached the same two-error classification independently — that part of the fix is simply what the API documents. This PR's difference is in what is pinned around it: the subsequent-message recovery that is the issue's actual title, the `_active` bookkeeping after a no-op, cross-message isolation, and the full received/running/failed/completed lifecycles. Happy to fold anything useful from either of those into this one, or to stand down if you would rather take theirs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
